### PR TITLE
Job preferences are now saved in config.xml.

### DIFF
--- a/Barotrauma/Content/Jobs.xml
+++ b/Barotrauma/Content/Jobs.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Jobs>
-  <Job name="Captain" description="The Commanding Officer with authority over the entire crew. The captain is responsible for commanding the rest of the crew and trying to keep everything running smoothly." minnumber="1" maxnumber="1">
+  <Job name="Captain" description="The Commanding Officer is responsible for commanding the entirety of the crew and ensuring that everything is running smoothly." minnumber="1" maxnumber="1">
     <Skills>
       <Skill name="Weapons" level="50,60"/>
       <Skill name="Construction" level="20,30"/>
@@ -18,7 +18,7 @@
     </Items>
   </Job>
   
-  <Job name="Engineer" description="Engineers have above-average construction and mechanic skills, but fixing complex mechanical devices is still usually out of their skill set. They are competent at fixing electrical devices however, and are the ones to turn to when the power grid starts failing." minnumber="1">
+  <Job name="Engineer" description="Engineers are the backbone of a submarine's crew, complementing a mechanic's construction skill with their knowledge of electrical engineering. They are capable of performing maintenance on the various electrical pieces of the submarine." minnumber="1">
     <Skills>
       <Skill name="Weapons" level="10,30"/>
       <Skill name="Construction" level="20,30"/>
@@ -36,7 +36,7 @@
     </Items>
   </Job>
 
-  <Job name="Mechanic" description="Mechanics have high construction and mechanic skills. They are skilled at using tools such as plasma cutters and welders, and are usually the only ones who can fix broken mechanical devices." minnumber="1">
+  <Job name="Mechanic" description="Mechanics are capable of fixing various mechanical devices with their high construction skill. Together with engineers they ensure a submarine is working to its fullest." minnumber="1">
     <Skills>
       <Skill name="Weapons" level="10,30"/>
       <Skill name="Construction" level="50,60"/>
@@ -54,7 +54,7 @@
     </Items>
   </Job>
 
-  <Job name="Security Officer" description="Security officers are responsible for keeping the submarine safe from potential attackers. The creatures inhabiting the ocean aren't the only threat they need to worry about, as several of the renegade groups opposing the Europa Coalition are known to have sent infiltrators on board the vessels." maxnumber="2">
+  <Job name="Security Officer" description="Security Officers are responsible for keeping the submarine safe from threats, both external and internal. The creatures inhabiting the ocean aren't the only threat they need to worry about, as several of the renegade groups opposing the Europa Coalition are known to have sent infiltrators on board the vessels." maxnumber="2">
     <Skills>
       <Skill name="Weapons" level="50,60"/>
       <Skill name="Medical" level="30,40"/>
@@ -74,7 +74,7 @@
     </Items>
   </Job>
 
-  <Job name="Medical Doctor" description="The primary duty of the doctors is too help injured crew members, but their knowledge of chemistry and pharmaceutics can also be useful for creating various non-medicinal chemicals." maxnumber="2">
+  <Job name="Medical Doctor" description="Although usually taken for granted, Doctors play an important role on the submarine, possessing the required skill to treat injured or unconscious crew members. Their skills can also be useful for creating various non-medicinal chemicals." maxnumber="2">
     <Skills>
       <Skill name="Weapons" level="10,20"/>
       <Skill name="Construction" level="10,20"/>

--- a/Barotrauma/Content/Jobs.xml
+++ b/Barotrauma/Content/Jobs.xml
@@ -32,7 +32,7 @@
       <Item name="Orange Jumpsuit" equip="true"/>
       <Item name="Headset" equip="true">
         <Item name="Battery Cell"/>
-      </Item>      
+      </Item>
     </Items>
   </Job>
 
@@ -50,11 +50,11 @@
       <Item name="Blue Jumpsuit" equip="true"/>
       <Item name="Headset" equip="true">
         <Item name="Battery Cell"/>
-      </Item>      
+      </Item>
     </Items>
   </Job>
 
-  <Job name="Security Officer" description="Security officers are are responsible for keeping the submarine safe from potential attackers. The creatures inhabiting the ocean aren't the only threat they need to worry about, as several of the renegade groups opposing the Europa Coalition are known to have sent infiltrators on board the vessels." maxnumber="2">
+  <Job name="Security Officer" description="Security officers are responsible for keeping the submarine safe from potential attackers. The creatures inhabiting the ocean aren't the only threat they need to worry about, as several of the renegade groups opposing the Europa Coalition are known to have sent infiltrators on board the vessels." maxnumber="2">
     <Skills>
       <Skill name="Weapons" level="50,60"/>
       <Skill name="Medical" level="30,40"/>

--- a/Barotrauma/Source/GameMain.cs
+++ b/Barotrauma/Source/GameMain.cs
@@ -217,6 +217,11 @@ namespace Barotrauma
         yield return CoroutineStatus.Running;
 
             JobPrefab.LoadAll(SelectedPackage.GetFilesOfType(ContentType.Jobs));
+            // Add any missing jobs from the prefab into Config.JobNamePreferences.
+            foreach (JobPrefab job in JobPrefab.List)
+            {
+                if (!Config.JobNamePreferences.Contains(job.Name)) { Config.JobNamePreferences.Add(job.Name); }
+            }
             StructurePrefab.LoadAll(SelectedPackage.GetFilesOfType(ContentType.Structure));
             TitleScreen.LoadState = 20.0f;
         yield return CoroutineStatus.Running;

--- a/Barotrauma/Source/GameSettings.cs
+++ b/Barotrauma/Source/GameSettings.cs
@@ -61,7 +61,14 @@ namespace Barotrauma
         public List<string> JobNamePreferences
         {
             get { return jobNamePreferences; }
-            set { UnsavedSettings = true; jobNamePreferences = value; }
+            set
+            {
+                // Begin saving coroutine. Remove any existing save coroutines if one is running.
+                if (CoroutineManager.IsCoroutineRunning("saveCoroutine")) { CoroutineManager.StopCoroutines("saveCoroutine"); }
+                CoroutineManager.StartCoroutine(ApplyUnsavedChanges(), "saveCoroutine");
+
+                jobNamePreferences = value;
+            }
         }
 
         public string   MasterServerUrl { get; set; }
@@ -81,12 +88,6 @@ namespace Barotrauma
             private set
             {
                 unsavedSettings = value;
-                // Beging saving coroutine. Remove any existing save coroutines if one is running.
-                if (CoroutineManager.IsCoroutineRunning("saveCoroutine")) { CoroutineManager.StopCoroutines("saveCoroutine"); }
-                if (unsavedSettings == true)
-                {
-                    CoroutineManager.StartCoroutine(ApplyUnsavedChanges(), "saveCoroutine");
-                }
 
                 if (applyButton != null)
                 {

--- a/Barotrauma/Source/GameSettings.cs
+++ b/Barotrauma/Source/GameSettings.cs
@@ -23,6 +23,8 @@ namespace Barotrauma
 
         private WindowMode windowMode;
 
+        public List<string> jobNamePreferences;
+
         private KeyOrMouse[] keyMapping;
 
         private bool unsavedSettings;
@@ -56,6 +58,12 @@ namespace Barotrauma
 
         public ContentPackage SelectedContentPackage { get; set; }
 
+        public List<string> JobNamePreferences
+        {
+            get { return jobNamePreferences; }
+            set { UnsavedSettings = true; jobNamePreferences = value; }
+        }
+
         public string   MasterServerUrl { get; set; }
         public bool     AutoCheckUpdates { get; set; }
         public bool     WasGameUpdated { get; set; }
@@ -73,6 +81,13 @@ namespace Barotrauma
             private set
             {
                 unsavedSettings = value;
+                // Beging saving coroutine. Remove any existing save coroutines if one is running.
+                if (CoroutineManager.IsCoroutineRunning("saveCoroutine")) { CoroutineManager.StopCoroutines("saveCoroutine"); }
+                if (unsavedSettings == true)
+                {
+                    CoroutineManager.StartCoroutine(ApplyUnsavedChanges(), "saveCoroutine");
+                }
+
                 if (applyButton != null)
                 {
                     //applyButton.Selected = unsavedSettings;
@@ -123,6 +138,12 @@ namespace Barotrauma
                 MasterServerUrl = "";
                 
                 SelectedContentPackage = ContentPackage.list.Any() ? ContentPackage.list[0] : new ContentPackage("");
+
+                JobNamePreferences = new List<string>();
+                foreach (JobPrefab job in JobPrefab.List)
+                {
+                    JobNamePreferences.Add(job.Name);
+                }
 
                 return;
             }
@@ -208,6 +229,13 @@ namespace Barotrauma
                             }
                         }
                         break;
+                    case "gameplay":
+                        JobNamePreferences = new List<string>();
+                        foreach (XElement ele in subElement.Element("jobpreferences").Elements("job"))
+                        {
+                            JobNamePreferences.Add(ToolBox.GetAttributeString(ele, "name", ""));
+                        }
+                        break;
                 }
             }
 
@@ -290,6 +318,17 @@ namespace Barotrauma
 
 
             }
+
+            var gameplay = new XElement("gameplay");
+
+            var jobPreferences = new XElement("jobpreferences");
+            foreach (string jobName in JobNamePreferences)
+            {
+                jobPreferences.Add(new XElement("job", new XAttribute("name", jobName)));
+            }
+
+            gameplay.Add(jobPreferences);
+            doc.Root.Add(gameplay);
 
             doc.Save(filePath);
         }
@@ -498,6 +537,13 @@ namespace Barotrauma
             keyBox.Deselect();
 
             yield return CoroutineStatus.Success;
+        }
+
+        private IEnumerable<object> ApplyUnsavedChanges()
+        {
+            yield return new WaitForSeconds(10.0f);
+
+            Save("config.xml");
         }
 
         private bool ApplyClicked(GUIButton button, object userData)

--- a/Barotrauma/Source/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/Source/Screens/NetLobbyScreen.cs
@@ -540,9 +540,12 @@ namespace Barotrauma
 
 
                 int i = 1;
-                foreach (JobPrefab job in JobPrefab.List)
+                foreach (string jobName in GameMain.Config.JobNamePreferences)
                 {
-                    GUITextBlock jobText = new GUITextBlock(new Rectangle(0, 0, 0, 20),  i + ". " + job.Name+"    ", 
+                    JobPrefab job = JobPrefab.List.First(x => x.Name == jobName); 
+                    if (job == null) { continue; }
+
+                    GUITextBlock jobText = new GUITextBlock(new Rectangle(0, 0, 0, 20),  i + ". " + job.Name + "    ", 
                         "",Alignment.Left, Alignment.Right, jobList, false,
                         GameMain.GraphicsWidth<1000 ? GUI.SmallFont : GUI.Font);
                     jobText.UserData = job;
@@ -1199,6 +1202,8 @@ namespace Barotrauma
         private void UpdateJobPreferences(GUIListBox listBox)
         {
             listBox.Deselect();
+            List<string> jobNamePreferences = new List<string>();
+
             for (int i = 0; i < listBox.children.Count; i++)
             {
                 float a = (float)(i - 1) / 3.0f;
@@ -1210,8 +1215,11 @@ namespace Barotrauma
                 listBox.children[i].SelectedColor = color;
 
                 (listBox.children[i] as GUITextBlock).Text = (i+1) + ". " + (listBox.children[i].UserData as JobPrefab).Name;
+
+                jobNamePreferences.Add((listBox.children[i].UserData as JobPrefab).Name);
             }
-            
+
+            GameMain.Config.JobNamePreferences = jobNamePreferences;
         }
 
         public bool TrySelectSub(string subName, string md5Hash, GUIListBox subList)

--- a/Barotrauma/Source/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/Source/Screens/NetLobbyScreen.cs
@@ -546,7 +546,7 @@ namespace Barotrauma
                     if (job == null) { continue; }
 
                     GUITextBlock jobText = new GUITextBlock(new Rectangle(0, 0, 0, 20),  i + ". " + job.Name + "    ", 
-                        "",Alignment.Left, Alignment.Right, jobList, false,
+                        "", Alignment.Left, Alignment.Right, jobList, false,
                         GameMain.GraphicsWidth<1000 ? GUI.SmallFont : GUI.Font);
                     jobText.UserData = job;
 

--- a/Barotrauma/config.xml
+++ b/Barotrauma/config.xml
@@ -3,4 +3,14 @@
   <graphicsmode width="1280" height="720" fullscreen="false" vsync="false" />
   <contentpackage path="Data/ContentPackages/Vanilla 0.3.xml" />
   <keymapping Select="E" Use="0" Aim="1" Up="W" Down="S" Left="A" Right="D" Attack="R" Run="LeftShift" Crouch="LeftControl" Chat="Tab" CrewOrders="C" />
+  <gameplay>
+    <jobpreferences>
+      <job name="Engineer" />
+      <job name="Mechanic" />
+      <job name="Captain" />
+      <job name="Security Officer" />
+      <job name="Medical Doctor" />
+      <job name="Assistant" />
+    </jobpreferences>
+  </gameplay>
 </config>


### PR DESCRIPTION
Making this PR in response to #5.

- Added a string list to GameMain.Config which stores the names of jobs based on the order they are specified in inside the config.xml. The default looks like this:
```xml
<gameplay>
  <jobpreferences>
    <job name="Mechanic" />
    <job name="Engineer" />
    <job name="Captain" />
    <job name="Security Officer" />
    <job name="Medical Doctor" />
    <job name="Assistant" />
  </jobpreferences>
</gameplay>
```

This order is updated every time you modify the job preferences on the lobby screen. The above setup being default also means the captain is no longer the first choice.

- Added a save coroutine which will update the config.xml with the latest settings so long as no further changes to the job preferences are made after 10 seconds. Could probably be used for other things but at the moment it's only used for saving the jobs.

- Rewrote some of the job descriptions.