### PR TITLE
fix start pop up saying the host is the target if host becomes traitor

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/GameSession/GameModes/TraitorManager.cs
+++ b/Barotrauma/BarotraumaShared/Source/GameSession/GameModes/TraitorManager.cs
@@ -60,7 +60,7 @@ namespace Barotrauma
             }
             else if (server.Character == traitorCharacter)
             {
-                CreateStartPopUp(traitorCharacter.Name);
+                CreateStartPopUp(targetCharacter.Name);
                 return;
             }
 #endif


### PR DESCRIPTION
Right now, if you're hosting and you toggled "play yourself", if you become the traitor the target on the pop-up will be you instead of your actual target, though the server logs will correctly tell you your actual target.