### PR TITLE
Chat tweaks and fixes

### DIFF
--- a/Barotrauma/BarotraumaClient/Source/Networking/NetworkMember.cs
+++ b/Barotrauma/BarotraumaClient/Source/Networking/NetworkMember.cs
@@ -69,7 +69,10 @@ namespace Barotrauma.Networking
                     textBox.TextColor = ChatMessage.MessageColor[(int)ChatMessageType.Dead];
                     break;
                 default:
-                    textBox.TextColor = ChatMessage.MessageColor[(int)ChatMessageType.Default];
+                    if (command != "") //PMing
+                        textBox.TextColor = ChatMessage.MessageColor[(int)ChatMessageType.Private];
+                    else
+                        textBox.TextColor = ChatMessage.MessageColor[(int)ChatMessageType.Default];
                     break;
             }
 

--- a/Barotrauma/BarotraumaClient/Source/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/BarotraumaClient/Source/Screens/NetLobbyScreen.cs
@@ -1099,7 +1099,7 @@ namespace Barotrauma
             }
 
             GUITextBlock msg = new GUITextBlock(new Rectangle(0, 0, chatBox.Rect.Width - 20, 0),
-                message.TextWithSender,
+                (message.Type == ChatMessageType.Private ? "[PM] " : "") + message.TextWithSender,
                 ((chatBox.CountChildren % 2) == 0) ? Color.Transparent : Color.Black * 0.1f, message.Color,
                 Alignment.Left, Alignment.TopLeft, "", null, true, GUI.SmallFont);
             msg.UserData = message;

--- a/Barotrauma/BarotraumaClient/Source/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/BarotraumaClient/Source/Screens/NetLobbyScreen.cs
@@ -33,6 +33,13 @@ namespace Barotrauma
         private GUIListBox jobList;
 
         private GUITextBox textBox, seedBox;
+        public GUITextBox TextBox
+        {
+            get
+            {
+                return textBox;
+            }
+        }
 
         private GUIFrame defaultModeContainer, campaignContainer;
 

--- a/Barotrauma/BarotraumaShared/Source/Networking/ChatMessage.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/ChatMessage.cs
@@ -25,7 +25,7 @@ namespace Barotrauma.Networking
             new Color(63, 72, 204),     //dead
             new Color(157, 225, 160),   //server
             new Color(238, 208, 0),     //radio
-            new Color(228, 199, 27)     //private
+            new Color(64, 240, 89)     //private
         };
         
         public readonly string Text;

--- a/Barotrauma/BarotraumaShared/Source/Networking/ChatMessage.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/ChatMessage.cs
@@ -185,7 +185,7 @@ namespace Barotrauma.Networking
                 GameMain.Server.SendChatMessage(denyMsg, c);
                 return;
             }
-
+            if (c.Character != null && !c.Character.CanSpeak) return;
             GameMain.Server.SendChatMessage(txt, null, c);
         }
 

--- a/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
@@ -167,7 +167,7 @@ namespace Barotrauma.Networking
 
             if (!string.IsNullOrWhiteSpace(message.SenderName))
             {
-                displayedText = message.SenderName + ": " + displayedText;
+                displayedText = (message.Type == ChatMessageType.Private ? "[PM] " : "" ) + message.SenderName + ": " + displayedText;
             }
             
             GUITextBlock msg = new GUITextBlock(new Rectangle(0, 0, chatBox.Rect.Width - 40, 0), displayedText,

--- a/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
@@ -224,7 +224,7 @@ namespace Barotrauma.Networking
             //tab doesn't autoselect the chatbox when debug console is open, 
             //because tab is used for autocompleting console commands
             if ((PlayerInput.KeyHit(InputType.Chat) || PlayerInput.KeyHit(InputType.RadioChat)) &&
-                (Screen.Selected == GameMain.GameScreen && msgBox.Visible || (!DebugConsole.IsOpen && GUIComponent.KeyboardDispatcher.Subscriber == null)))
+                (!DebugConsole.IsOpen && GUIComponent.KeyboardDispatcher.Subscriber == null) && (Screen.Selected != GameMain.GameScreen || msgBox.Visible))
             {
                 if (msgBox.Selected)
                 {
@@ -234,7 +234,7 @@ namespace Barotrauma.Networking
                 else
                 {
                     msgBox.Select();
-                    if (PlayerInput.KeyHit(InputType.RadioChat))
+                    if (Screen.Selected == GameMain.GameScreen && PlayerInput.KeyHit(InputType.RadioChat))
                     {
                         msgBox.Text = "r; ";
                         msgBox.OnTextChanged?.Invoke(msgBox, msgBox.Text);

--- a/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
@@ -223,7 +223,7 @@ namespace Barotrauma.Networking
             //tab doesn't autoselect the chatbox when debug console is open, 
             //because tab is used for autocompleting console commands
             if ((PlayerInput.KeyHit(InputType.Chat) || PlayerInput.KeyHit(InputType.RadioChat)) && 
-                chatMsgBox.Visible && !DebugConsole.IsOpen)
+                chatMsgBox.Visible && !DebugConsole.IsOpen && GUIComponent.KeyboardDispatcher.Subscriber == null)
             {
                 if (chatMsgBox.Selected)
                 {

--- a/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/NetworkMember.cs
@@ -205,9 +205,10 @@ namespace Barotrauma.Networking
         public virtual void Update(float deltaTime) 
         {
 #if CLIENT
+            GUITextBox msgBox = (Screen.Selected == GameMain.GameScreen ? chatMsgBox : GameMain.NetLobbyScreen.TextBox);
             if (gameStarted && Screen.Selected == GameMain.GameScreen)
             {
-                chatMsgBox.Visible = Character.Controlled == null || Character.Controlled.CanSpeak;
+                msgBox.Visible = Character.Controlled == null || Character.Controlled.CanSpeak;
 
                 inGameHUD.Update(deltaTime);
 
@@ -222,22 +223,21 @@ namespace Barotrauma.Networking
 
             //tab doesn't autoselect the chatbox when debug console is open, 
             //because tab is used for autocompleting console commands
-            if ((PlayerInput.KeyHit(InputType.Chat) || PlayerInput.KeyHit(InputType.RadioChat)) && 
-                chatMsgBox.Visible && !DebugConsole.IsOpen && GUIComponent.KeyboardDispatcher.Subscriber == null)
+            if ((PlayerInput.KeyHit(InputType.Chat) || PlayerInput.KeyHit(InputType.RadioChat)) &&
+                (Screen.Selected == GameMain.GameScreen && msgBox.Visible || (!DebugConsole.IsOpen && GUIComponent.KeyboardDispatcher.Subscriber == null)))
             {
-                if (chatMsgBox.Selected)
+                if (msgBox.Selected)
                 {
-                    chatMsgBox.Text = "";
-                    chatMsgBox.Deselect();
+                    msgBox.Text = "";
+                    msgBox.Deselect();
                 }
                 else
                 {
-                    chatMsgBox.Select();
+                    msgBox.Select();
                     if (PlayerInput.KeyHit(InputType.RadioChat))
                     {
-                        chatMsgBox.Text = "r; ";
-                        chatMsgBox.OnTextChanged?.Invoke(chatMsgBox, chatMsgBox.Text);
-
+                        msgBox.Text = "r; ";
+                        msgBox.OnTextChanged?.Invoke(msgBox, msgBox.Text);
                     }
                 }
             }


### PR DESCRIPTION
* Prevents the chat keybind from deactivating the chat
* Allows the use of chat keybind during lobby
* Prevents server from receiving messages from unconscious clients. Previously it was possible to keep the chat box open and send messages while KO'd if you compiled yourself.
* Changes the private message color to be toxic green for a distinction from radio chat
* Adds a [PM] tag to private messages for an even easier distinction

![default](https://user-images.githubusercontent.com/3470436/33616240-5e643048-d9ed-11e7-9658-02c4bf7bd423.png)