### PR TITLE
Player input is updated only when game windows is active

### DIFF
--- a/Barotrauma/BarotraumaClient/Source/PlayerInput.cs
+++ b/Barotrauma/BarotraumaClient/Source/PlayerInput.cs
@@ -143,23 +143,26 @@ namespace Barotrauma
         {
             timeSinceClick += deltaTime;
 
-            oldMouseState = mouseState;
-            mouseState = latestMouseState;
-            UpdateVariable();
-
-            oldKeyboardState = keyboardState;
-            keyboardState = Keyboard.GetState();
-            
-            doubleClicked = false;
-            if (LeftButtonClicked())
+            if (GameMain.Instance.IsActive)
             {
-                if (timeSinceClick < DoubleClickDelay &&
-                    (mouseState.Position - lastClickPosition).ToVector2().Length() < MaxDoubleClickDistance)
+                oldMouseState = mouseState;
+                mouseState = latestMouseState;
+                UpdateVariable();
+
+                oldKeyboardState = keyboardState;
+                keyboardState = Keyboard.GetState();
+
+                doubleClicked = false;
+                if (LeftButtonClicked())
                 {
-                    doubleClicked = true;
+                    if (timeSinceClick < DoubleClickDelay &&
+                        (mouseState.Position - lastClickPosition).ToVector2().Length() < MaxDoubleClickDistance)
+                    {
+                        doubleClicked = true;
+                    }
+                    lastClickPosition = mouseState.Position;
+                    timeSinceClick = 0.0;
                 }
-                lastClickPosition = mouseState.Position;
-                timeSinceClick = 0.0;
             }
         }
 


### PR DESCRIPTION
I added only if inside PlayerInput.Update method.
It's easier after this change to debug server code when you have 2 windows active on 1 computer. It was nuisance when client interactions changed things on server client.

[IsActive documentation](https://msdn.microsoft.com/en-us/library/microsoft.xna.framework.game.isactive.aspx)