### PR TITLE
 DebugMac and ReleaseMac for Launcher.csproj use the right pre-processor constant.

### DIFF
--- a/Barotrauma/Launcher/Launcher.csproj
+++ b/Barotrauma/Launcher/Launcher.csproj
@@ -60,7 +60,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseMac|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\bin\ReleaseMac\</OutputPath>
-    <DefineConstants>TRACE;LINUX;CLIENT</DefineConstants>
+    <DefineConstants>TRACE;OSX;CLIENT</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -70,7 +70,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugMac|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\bin\DebugMac\</OutputPath>
-    <DefineConstants>TRACE;LINUX;CLIENT;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;OSX;CLIENT;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
Broke in https://github.com/Regalis11/Barotrauma/pull/348/commits/96e1d5cba46109da3f913e91021604ff78ebc69a.