### PR TITLE
Rear Railgun Controller/Additional Railgun Loaders

### DIFF
--- a/Barotrauma/BarotraumaShared/Content/Items/Weapons/railgun.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Weapons/railgun.xml
@@ -55,6 +55,31 @@
     </ConnectionPanel>
   </Item>
 
+  	    <Item
+    name="Rear Railgun Controller"
+    category="Machine"
+    type="Controller"
+    linkable="true"
+    disableitemusagewhenselected="true"
+    >
+
+    <Sprite texture ="railgunetc2.png" depth="0.8" sourcerect="188,0,57,96"/>
+    
+    <Controller UserPos="35, -50.0" direction ="Left" canbeselected = "true">
+      <limbposition limb="Head" position="-5,-62"/>
+      <limbposition limb="Torso" position="-5,-108"/>
+      <limbposition limb="LeftHand" position="43,-85"/>
+      <limbposition limb="RightHand" position="43,-85"/>
+    </Controller>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="power_in"/>
+      <output name="position_out"/>
+      <output name="trigger_out"/>
+    </ConnectionPanel>
+  </Item>
+
   <Item
     name="Railgun Loader"
     category="Machine"
@@ -64,6 +89,51 @@
     <Sprite texture ="railgunetc.png" depth="0.8" sourcerect="0,0,177,128"/>
 
     <ItemContainer hideitems="false" drawinventory="true" capacity="6" slotsperrow="6" itempos="24,-75" iteminterval="26,0" itemrotation="90" canbeselected = "true">
+      <Containable name="Railgun Shell"/>
+      <Containable name="Nuclear Shell"/>
+      <Containable name="Ancient Weapon"/>
+    </ItemContainer>      
+  </Item>
+
+<Item
+    name="Railgun Single Loader"
+    category="Machine"
+    linkable="true"
+    >
+
+    <Sprite texture ="railgunetc2.png" depth="0.8" sourcerect="131,2,46,128"/>
+
+    <ItemContainer hideitems="false" drawinventory="true" capacity="1" slotsperrow="1" itempos="23,-76" iteminterval="0,0" itemrotation="90" canbeselected = "true">
+      <Containable name="Railgun Shell"/>
+      <Containable name="Nuclear Shell"/>
+      <Containable name="Ancient Weapon"/>
+    </ItemContainer>      
+  </Item>
+  
+    <Item
+    name="Forward Railgun Loader"
+    category="Machine"
+    linkable="true"
+    >
+
+    <Sprite texture ="railgunetc2.png" depth="0.8" sourcerect="1,2,128,46"/>
+
+    <ItemContainer hideitems="false" drawinventory="true" capacity="1" slotsperrow="1" itempos="49.5,-22.7" iteminterval="0,0" itemrotation="0" canbeselected = "true">
+      <Containable name="Railgun Shell"/>
+      <Containable name="Nuclear Shell"/>
+      <Containable name="Ancient Weapon"/>
+    </ItemContainer>      
+  </Item>
+  
+      <Item
+    name="Rear Railgun Loader"
+    category="Machine"
+    linkable="true"
+    >
+
+    <Sprite texture ="railgunetc2.png" depth="0.8" sourcerect="1,50,128,46"/>
+
+    <ItemContainer hideitems="false" drawinventory="true" capacity="1" slotsperrow="1" itempos="76,-22.7" iteminterval="0,0" itemrotation="180" canbeselected = "true">
       <Containable name="Railgun Shell"/>
       <Containable name="Nuclear Shell"/>
       <Containable name="Ancient Weapon"/>


### PR DESCRIPTION
Tested code for new Railgun items
 
* "Rear Railgun Controller" - Rearward facing Railgun controller

* "Railgun Single Loader" - Vertical loader with 1 shell capacity
* "Forward Railgun Loader" - Forward facing loader with 1 shell capacity
* "Rear Railgun Loader" - Rearward facing loader with 1 shell capacity

Gives sub makers more variety and different ways to arm subs. Can also be used to make a challenging balance with the weapons that requires more teamwork to operate. Also useful for simulating torpedo's tubes

Sprite example:
https://imgur.com/muAIF9P

texture located in "content/items/weapons/railgunetc2.png", which it shares with the new Railgun Shell Rack.

All items tested and implemented.