### PR TITLE
Railgun Shell Rack

### DIFF
--- a/Barotrauma/BarotraumaShared/Content/Items/Containers/containers.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Containers/containers.xml
@@ -11,6 +11,18 @@
     </ItemContainer>
   </Item>
 
+        <Item
+    name="Railgun Shell Rack"
+    pickdistance ="120">
+
+    <Sprite texture ="content/items/weapons/railgunetc2.png" depth="0.84" sourcerect="57,97,72,110"/>
+
+    <ItemContainer  hideitems="false" drawinventory="true" capacity="3" slotsperrow="3" itempos="17,-49.5" iteminterval="19,0" itemrotation="90" canbeselected = "true">
+      <Containable name="Railgun Shell"/>
+      <Containable name="Nuclear Shell"/>
+    </ItemContainer>
+  </Item>
+
   <Item
     name="Medicine Cabinet"
     linkable="true"


### PR DESCRIPTION
Adds a rack capable of holding 3 Railgun shells,
so players / sub makers won't have to store shells on the floor anymore. Also helps the crew keep track of how many Railgun shells the sub has. 

Because the racks take up space, it also would help with balancing subs for PvP and so on.

texture located in "content/items/weapons/railgunetc2.png", which it shares with the new loaders and rear facing controller.

Sprite example:
https://imgur.com/muAIF9P

This feature has been requested a lot lol, so I hope this will make a lot of people really happy