### PR TITLE
Change log names to be sortable by file name

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/Networking/ServerLog.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/ServerLog.cs
@@ -139,7 +139,7 @@ namespace Barotrauma.Networking
                 }                
             }
 
-            string fileName = serverName + "_" + DateTime.Now.ToShortDateString() + "_" + DateTime.Now.ToShortTimeString() + ".txt";
+            string fileName = serverName + "_" + DateTime.Now.ToString("yyyy-MM-dd_HH:mm") + ".txt";
 
             var invalidChars = Path.GetInvalidFileNameChars();
             foreach (char invalidChar in invalidChars)


### PR DESCRIPTION
Would close #417

This uses the format proposed in the relevant issue in place of the current date format for log file, resolving any problems in sorting the file stemming from format of the log file name.  See the issue for more details.