### PR TITLE
Allow the `spawnitem` command to give items directly to the inventory of a specific player

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/Source/DebugConsole.cs
@@ -2140,8 +2140,23 @@ namespace Barotrauma
                     spawnInventory = Character.Controlled == null ? null : Character.Controlled.Inventory;
                     break;
                 default:
-                    extraParams = 0;
+                    int id = 0;
+                    int.TryParse(args.Last(), out id);
+                    if(id > 0) {
+                        var client = GameMain.Server.ConnectedClients.Find(c => c.ID == id);
+                        if (client != null && client.Character != null) {
+                            spawnInventory = client.Character.Inventory;
+                        }else{
+                            errorMsg = "Client with ID \"" + id + "\" isn't currently playing";
+                            return;
+                        }
+                        extraParams = 1;
+
+                    }else{
+                        extraParams = 0;
+                    }
                     break;
+
             }
 
             string itemName = string.Join(" ", args.Take(args.Length - extraParams)).ToLowerInvariant();

--- a/Barotrauma/BarotraumaShared/Source/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/Source/DebugConsole.cs
@@ -247,7 +247,7 @@ namespace Barotrauma
                 };
             }));
 
-            commands.Add(new Command("spawnitem", "spawnitem [itemname] [cursor/inventory]: Spawn an item at the position of the cursor, in the inventory of the controlled character or at a random spawnpoint if the last parameter is omitted.",
+            commands.Add(new Command("spawnitem", "spawnitem [itemname] [cursor/inventory/[clientid]]: Spawn an item at the position of the cursor, in the inventory of the controlled character, in the inventory of the client with the given clientid, or at a random spawnpoint if the last parameter is omitted.",
             (string[] args) =>
             {
                 string errorMsg;

--- a/Barotrauma/BarotraumaShared/Source/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/Source/DebugConsole.cs
@@ -2140,19 +2140,22 @@ namespace Barotrauma
                     spawnInventory = Character.Controlled == null ? null : Character.Controlled.Inventory;
                     break;
                 default:
+                    //Check if last arg matches the clientid of an in-game player
                     int id = 0;
                     int.TryParse(args.Last(), out id);
                     if(id > 0) {
                         var client = GameMain.Server.ConnectedClients.Find(c => c.ID == id);
                         if (client != null && client.Character != null) {
+                            //If a client id was provided and matched an in-game player, set the target inventory to their inventory
                             spawnInventory = client.Character.Inventory;
                         }else{
+                            //If the last arg was an int, but not one of a player who is in-game, throw an error
                             errorMsg = "Client with ID \"" + id + "\" isn't currently playing";
                             return;
                         }
                         extraParams = 1;
-
                     }else{
+                        //If the last arg wasn't an int, proceed as normal
                         extraParams = 0;
                     }
                     break;


### PR DESCRIPTION
This is one possible implementation of a solution to #436.  I chose to modify the `spawnitem` command to take a clientid in place of `inventory` or `cursor`, as in the issue's example, because this seemed to be the simplest way implement this without creating multiple redundant commands or complexities when separating player names from item names.  It is possible that this could cause problems if a player attempts to spawn an item with a name that ends in an integer in a random location, but since there are currently no items with names ending in an integer, this seems like a niche enough case to dismiss, and could be circumvented by using `cursor` as the last argument.    If you would recommend another implementation, to this issue, I would be happy to change my solution to meet it.  This just seemed like a good path to start with.

Closes #436