### PR TITLE
Fixes Release build

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/Source/GameSettings.cs
@@ -62,6 +62,7 @@ namespace Barotrauma
             set { useSteamMatchmaking = value; }
         }
 #else
+        public bool UseSteam;
         public bool RequireSteamAuthentication
         {
             get { return requireSteamAuthentication && Steam.SteamManager.USE_STEAM; }
@@ -196,6 +197,8 @@ namespace Barotrauma
 
 #if DEBUG
             UseSteam = doc.Root.GetAttributeBool("usesteam", true);
+#else
+            UseSteam = true;
 #endif
 
             if (doc == null)


### PR DESCRIPTION
A few things were looking for GameMain.Config.UseSteam regardless of DEBUG, and if DEBUG is not defined, then UseSteam isn't either.

This defines UseSteam if DEBUG isn't set, and sets it to true.