### PR TITLE
Redesign campaign buymenu to use a quantity field

### DIFF
--- a/Barotrauma/BarotraumaClient/Source/GameSession/GameModes/MultiPlayerCampaign.cs
+++ b/Barotrauma/BarotraumaClient/Source/GameSession/GameModes/MultiPlayerCampaign.cs
@@ -92,9 +92,10 @@ namespace Barotrauma
             msg.Write(map.SelectedLocationIndex == -1 ? UInt16.MaxValue : (UInt16)map.SelectedLocationIndex);
 
             msg.Write((UInt16)CargoManager.PurchasedItems.Count);
-            foreach (ItemPrefab ip in CargoManager.PurchasedItems)
+            foreach (PurchasedItem pi in CargoManager.PurchasedItems)
             {
-                msg.Write((UInt16)MapEntityPrefab.List.IndexOf(ip));
+                msg.Write((UInt16)MapEntityPrefab.List.IndexOf(pi.itemPrefab));
+                msg.Write((UInt16)pi.quantity);
             }
         }
 
@@ -111,11 +112,12 @@ namespace Barotrauma
             int money = msg.ReadInt32();
 
             UInt16 purchasedItemCount = msg.ReadUInt16();
-            List<ItemPrefab> purchasedItems = new List<ItemPrefab>();
+            List<PurchasedItem> purchasedItems = new List<PurchasedItem>();
             for (int i = 0; i < purchasedItemCount; i++)
             {
                 UInt16 itemPrefabIndex = msg.ReadUInt16();
-                purchasedItems.Add(MapEntityPrefab.List[itemPrefabIndex] as ItemPrefab);
+                UInt16 itemQuantity = msg.ReadUInt16();
+                purchasedItems.Add(new PurchasedItem(MapEntityPrefab.List[itemPrefabIndex] as ItemPrefab, itemQuantity));
             }
 
             MultiPlayerCampaign campaign = GameMain.GameSession?.GameMode as MultiPlayerCampaign;

--- a/Barotrauma/BarotraumaClient/Source/Networking/Voting.cs
+++ b/Barotrauma/BarotraumaClient/Source/Networking/Voting.cs
@@ -152,7 +152,12 @@ namespace Barotrauma
                 {
                     int votes = inc.ReadByte();
                     string subName = inc.ReadString();
-                    Submarine sub = Submarine.SavedSubmarines.FirstOrDefault(sm => sm.Name == subName);
+                    List<Submarine> serversubs = new List<Submarine>();
+                    foreach (GUIComponent item in GameMain.NetLobbyScreen?.SubList?.children)
+                    {
+                        if (item.UserData != null && item.UserData is Submarine) serversubs.Add(item.UserData as Submarine);
+                    }
+                    Submarine sub = serversubs.FirstOrDefault(sm => sm.Name == subName);
                     SetVoteText(GameMain.NetLobbyScreen.SubList, sub, votes);
                 }
             }

--- a/Barotrauma/BarotraumaClient/Source/Screens/CampaignUI.cs
+++ b/Barotrauma/BarotraumaClient/Source/Screens/CampaignUI.cs
@@ -85,7 +85,7 @@ namespace Barotrauma
             int sellColumnWidth = (tabs[(int)Tab.Store].Rect.Width - 40) / 2 - 20;
 
             selectedItemList = new GUIListBox(new Rectangle(0, 30, sellColumnWidth, tabs[(int)Tab.Store].Rect.Height - 80), Color.White * 0.7f, "", tabs[(int)Tab.Store]);
-            selectedItemList.OnSelected = SellItem;
+            //selectedItemList.OnSelected = SellItem;
             
             storeItemList = new GUIListBox(new Rectangle(0, 30, sellColumnWidth, tabs[(int)Tab.Store].Rect.Height - 80), Color.White * 0.7f, Alignment.TopRight, "", tabs[(int)Tab.Store]);
             storeItemList.OnSelected = BuyItem;
@@ -218,55 +218,91 @@ namespace Barotrauma
             OnLocationSelected?.Invoke(location, connection);
         }
 
-        private void CreateItemFrame(MapEntityPrefab ep, GUIListBox listBox, int width)
+        private void CreateItemFrame(PurchasedItem pi, GUIListBox listBox, int width)
         {
             GUIFrame frame = new GUIFrame(new Rectangle(0, 0, 0, 50), "ListBoxElement", listBox);
-            frame.UserData = ep;
+            frame.UserData = pi;
             frame.Padding = new Vector4(5.0f, 5.0f, 5.0f, 5.0f);
 
-            frame.ToolTip = ep.Description;
+            frame.ToolTip = pi.itemPrefab.Description;
 
             ScalableFont font = listBox.Rect.Width < 280 ? GUI.SmallFont : GUI.Font;
 
             GUITextBlock textBlock = new GUITextBlock(
                 new Rectangle(50, 0, 0, 25),
-                ep.Name,
+                pi.itemPrefab.Name,
                 null, null,
                 Alignment.Left, Alignment.CenterX | Alignment.Left,
                 "", frame);
             textBlock.Font = font;
             textBlock.Padding = new Vector4(5.0f, 0.0f, 5.0f, 0.0f);
-            textBlock.ToolTip = ep.Description;
+            textBlock.ToolTip = pi.itemPrefab.Description;
 
-            if (ep.sprite != null)
+            if (pi.itemPrefab.sprite != null)
             {
-                GUIImage img = new GUIImage(new Rectangle(0, 0, 40, 40), ep.sprite, Alignment.CenterLeft, frame);
-                img.Color = ep.SpriteColor;
+                GUIImage img = new GUIImage(new Rectangle(0, 0, 40, 40), pi.itemPrefab.sprite, Alignment.CenterLeft, frame);
+                img.Color = pi.itemPrefab.SpriteColor;
                 img.Scale = Math.Min(Math.Min(40.0f / img.SourceRect.Width, 40.0f / img.SourceRect.Height), 1.0f);
             }
 
             textBlock = new GUITextBlock(
-                new Rectangle(width - 80, 0, 80, 25),
-                ep.Price.ToString(),
+                new Rectangle(width - 160, 0, 80, 25),
+                pi.itemPrefab.Price.ToString(),
                 null, null, Alignment.TopLeft,
                 Alignment.TopLeft, "", frame);
             textBlock.Font = font;
-            textBlock.ToolTip = ep.Description;
+            textBlock.ToolTip = pi.itemPrefab.Description;
+
+            //If its the store menu, quantity will always be 0
+            if (pi.quantity > 0)
+            {
+                var amountInput = new GUINumberInput(new Rectangle(width - 80, 0, 50, 40), "", GUINumberInput.NumberType.Int, frame);
+                amountInput.MinValueInt = 0;
+                amountInput.MaxValueInt = 1000;
+                amountInput.UserData = pi;
+                amountInput.IntValue = pi.quantity;
+                amountInput.OnValueChanged += (numberInput) =>
+                {
+                    PurchasedItem purchasedItem = numberInput.UserData as PurchasedItem;
+
+                    //Attempting to buy
+                    if (numberInput.IntValue > purchasedItem.quantity)
+                    {
+                        int quantity = numberInput.IntValue - purchasedItem.quantity;
+                        //Cap the numberbox based on the amount we can afford.
+                        quantity = Math.Max((quantity * (purchasedItem.itemPrefab.Price / Campaign.Money)), quantity);
+                        for (int i = 0; i < quantity; i++)
+                        {
+                            BuyItem(numberInput, purchasedItem);
+                        }
+                        numberInput.IntValue = purchasedItem.quantity;
+                    }
+                    //Attempting to sell
+                    else
+                    {
+                        int quantity = purchasedItem.quantity - numberInput.IntValue;
+                        for (int i = 0; i < quantity; i++)
+                        {
+                            SellItem(numberInput, purchasedItem);
+                        }
+                    }
+                };
+            }
         }
 
         private bool BuyItem(GUIComponent component, object obj)
         {
-            ItemPrefab prefab = obj as ItemPrefab;
-            if (prefab == null) return false;
+            PurchasedItem pi = obj as PurchasedItem;
+            if (pi == null || pi.itemPrefab == null) return false;
 
             if (GameMain.Client != null && !GameMain.Client.HasPermission(Networking.ClientPermissions.ManageCampaign))
             {
                 return false;
             }
 
-            if (prefab.Price > campaign.Money) return false;
+            if (pi.itemPrefab.Price > campaign.Money) return false;
             
-            campaign.CargoManager.PurchaseItem(prefab);
+            campaign.CargoManager.PurchaseItem(pi.itemPrefab, 1);
             GameMain.Client?.SendCampaignState();
 
             return false;
@@ -274,15 +310,15 @@ namespace Barotrauma
 
         private bool SellItem(GUIComponent component, object obj)
         {
-            ItemPrefab prefab = obj as ItemPrefab;
-            if (prefab == null) return false;
+            PurchasedItem pi = obj as PurchasedItem;
+            if (pi == null || pi.itemPrefab == null) return false;
 
             if (GameMain.Client != null && !GameMain.Client.HasPermission(Networking.ClientPermissions.ManageCampaign))
             {
                 return false;
             }
             
-            campaign.CargoManager.SellItem(prefab);
+            campaign.CargoManager.SellItem(pi.itemPrefab,1);
             GameMain.Client?.SendCampaignState();
 
             return false;
@@ -291,10 +327,12 @@ namespace Barotrauma
         private void RefreshItemTab()
         {
             selectedItemList.ClearChildren();
-            foreach (ItemPrefab ip in campaign.CargoManager.PurchasedItems)
+            foreach (PurchasedItem pi in campaign.CargoManager.PurchasedItems)
             {
-                CreateItemFrame(ip, selectedItemList, selectedItemList.Rect.Width);
+                CreateItemFrame(pi, selectedItemList, selectedItemList.Rect.Width);
             }
+            selectedItemList.children.Sort((x, y) => (x.UserData as PurchasedItem).itemPrefab.Name.CompareTo((y.UserData as PurchasedItem).itemPrefab.Name));
+            selectedItemList.children.Sort((x, y) => (x.UserData as PurchasedItem).itemPrefab.Category.CompareTo((y.UserData as PurchasedItem).itemPrefab.Category));
             selectedItemList.UpdateScrollBarSize();
         }
         
@@ -314,16 +352,16 @@ namespace Barotrauma
             storeItemList.ClearChildren();
 
             MapEntityCategory category = (MapEntityCategory)selection;
-            var items = MapEntityPrefab.List.FindAll(ep => ep.Price > 0.0f && ep.Category.HasFlag(category));
+            var items = MapEntityPrefab.List.FindAll(ep => ep.Price > 0.0f && ep.Category.HasFlag(category) && ep is ItemPrefab);
 
             int width = storeItemList.Rect.Width;
 
-            foreach (MapEntityPrefab ep in items)
+            foreach (ItemPrefab ep in items)
             {
-                CreateItemFrame(ep, storeItemList, width);
+                CreateItemFrame(new PurchasedItem((ItemPrefab)ep,0), storeItemList, width);
             }
 
-            storeItemList.children.Sort((x, y) => (x.UserData as MapEntityPrefab).Name.CompareTo((y.UserData as MapEntityPrefab).Name));
+            storeItemList.children.Sort((x, y) => (x.UserData as PurchasedItem).itemPrefab.Name.CompareTo((y.UserData as PurchasedItem).itemPrefab.Name));
 
             foreach (GUIComponent child in button.Parent.children)
             {

--- a/Barotrauma/BarotraumaShared/Source/GameSession/GameModes/MultiPlayerCampaign.cs
+++ b/Barotrauma/BarotraumaShared/Source/GameSession/GameModes/MultiPlayerCampaign.cs
@@ -194,9 +194,10 @@ namespace Barotrauma
             msg.Write(Money);
 
             msg.Write((UInt16)CargoManager.PurchasedItems.Count);
-            foreach (ItemPrefab ip in CargoManager.PurchasedItems)
+            foreach (PurchasedItem pi in CargoManager.PurchasedItems)
             {
-                msg.Write((UInt16)MapEntityPrefab.List.IndexOf(ip));
+                msg.Write((UInt16)MapEntityPrefab.List.IndexOf(pi.itemPrefab));
+                msg.Write((UInt16)pi.quantity);
             }
         }
         
@@ -205,11 +206,12 @@ namespace Barotrauma
             UInt16 selectedLocIndex = msg.ReadUInt16();
             UInt16 purchasedItemCount = msg.ReadUInt16();
 
-            List<ItemPrefab> purchasedItems = new List<ItemPrefab>();
+            List<PurchasedItem> purchasedItems = new List<PurchasedItem>();
             for (int i = 0; i < purchasedItemCount; i++)
             {
                 UInt16 itemPrefabIndex = msg.ReadUInt16();
-                purchasedItems.Add(MapEntityPrefab.List[itemPrefabIndex] as ItemPrefab);
+                UInt16 itemQuantity = msg.ReadUInt16();
+                purchasedItems.Add(new PurchasedItem(MapEntityPrefab.List[itemPrefabIndex] as ItemPrefab, itemQuantity));
             }
 
             if (!sender.HasPermission(ClientPermissions.ManageCampaign))
@@ -220,15 +222,15 @@ namespace Barotrauma
 
             Map.SelectLocation(selectedLocIndex == UInt16.MaxValue ? -1 : selectedLocIndex);
 
-            List<ItemPrefab> currentItems = new List<ItemPrefab>(CargoManager.PurchasedItems);
-            foreach (ItemPrefab ip in currentItems)
+            List<PurchasedItem> currentItems = new List<PurchasedItem>(CargoManager.PurchasedItems);
+            foreach (PurchasedItem pi in currentItems)
             {
-                CargoManager.SellItem(ip);
+                CargoManager.SellItem(pi.itemPrefab, pi.quantity);
             }
 
-            foreach (ItemPrefab ip in purchasedItems)
+            foreach (PurchasedItem pi in purchasedItems)
             {
-                CargoManager.PurchaseItem(ip);
+                CargoManager.PurchaseItem(pi.itemPrefab, pi.quantity);
             }
         }
     }

--- a/Barotrauma/BarotraumaShared/Source/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/GameServer.cs
@@ -1334,13 +1334,10 @@ namespace Barotrauma.Networking
             {
                 if (sub == null) continue;
 
-                List<ItemPrefab> spawnList = new List<ItemPrefab>();
+                List<PurchasedItem> spawnList = new List<PurchasedItem>();
                 foreach (KeyValuePair<ItemPrefab, int> kvp in extraCargo)
                 {
-                    for (int i = 0; i < kvp.Value; i++)
-                    {
-                        spawnList.Add(kvp.Key);
-                    }
+                    spawnList.Add(new PurchasedItem(kvp.Key, kvp.Value));
                 }
 
                 CargoManager.CreateItems(spawnList);


### PR DESCRIPTION
Maybe it needs some refactoring/renaming or generally looking neater/more optimized but I implemented a new buymenu for the singleplayer and multiplayer campaign, I however did have to edit the methods using spawncargo.

This should work with multiplayer and single, and write less data as it writes 2 ints / item type.

The ability to click an item to sell it was commented out (Selecting a child element removed the item).

the buymenu list sorts itself by name then category to mimic the buy category (Easier to find/use).

Additionally added a fix for #509 