### PR TITLE
Place items where hand is

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Holdable/Holdable.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Holdable/Holdable.cs
@@ -160,7 +160,18 @@ namespace Barotrauma.Items.Components
             if (item.body != null)
             {
                 item.body.ResetDynamics();
-                item.SetTransform(picker.SimPosition, 0.0f);
+                Limb heldHand;
+                if (picker.Inventory.IsInLimbSlot(item, InvSlotType.LeftHand))
+                {
+                    heldHand = picker.AnimController.GetLimb(LimbType.LeftHand);
+
+                }
+                else
+                {
+                    heldHand = picker.AnimController.GetLimb(LimbType.RightHand);
+                }
+
+                item.SetTransform(heldHand.SimPosition, 0.0f);
             }
 
             picker.DeselectItem(item);

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Holdable/Holdable.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Holdable/Holdable.cs
@@ -173,11 +173,10 @@ namespace Barotrauma.Items.Components
                     heldHand = picker.AnimController.GetLimb(LimbType.RightHand);
                     arm = picker.AnimController.GetLimb(LimbType.RightArm);
                 }
+                
                 float xDif = (heldHand.SimPosition.X - arm.SimPosition.X) / 2f;
                 float yDif = (heldHand.SimPosition.Y - arm.SimPosition.Y) / 2.5f;
-
-
-                //DebugConsole.NewMessage("hand rot at " + heldHand.SimPosition + " and simpos at " + arm, Color.Green);
+                //hand simPosition is actually in the wrist so need to move the item out from it slightly
                 item.SetTransform(heldHand.SimPosition + new Vector2(xDif,yDif), 0.0f);
             }
 

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Holdable/Holdable.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Holdable/Holdable.cs
@@ -161,17 +161,24 @@ namespace Barotrauma.Items.Components
             {
                 item.body.ResetDynamics();
                 Limb heldHand;
+                Limb arm;
                 if (picker.Inventory.IsInLimbSlot(item, InvSlotType.LeftHand))
                 {
                     heldHand = picker.AnimController.GetLimb(LimbType.LeftHand);
+                    arm = picker.AnimController.GetLimb(LimbType.LeftArm);
 
                 }
                 else
                 {
                     heldHand = picker.AnimController.GetLimb(LimbType.RightHand);
+                    arm = picker.AnimController.GetLimb(LimbType.RightArm);
                 }
+                float xDif = (heldHand.SimPosition.X - arm.SimPosition.X) / 2f;
+                float yDif = (heldHand.SimPosition.Y - arm.SimPosition.Y) / 2.5f;
 
-                item.SetTransform(heldHand.SimPosition, 0.0f);
+
+                //DebugConsole.NewMessage("hand rot at " + heldHand.SimPosition + " and simpos at " + arm, Color.Green);
+                item.SetTransform(heldHand.SimPosition + new Vector2(xDif,yDif), 0.0f);
             }
 
             picker.DeselectItem(item);


### PR DESCRIPTION
When you attach an item to a wall, attaches it where the holding hand is, not at your center of mass. 
E.g. now if you hold your left hand over your head while placing a button, if the button is in your left hand it will attach over your head at where the center of your left palm is.
Tested in single player and on a server with multiple players.