### PR TITLE
Vote kicking is now not allowed during a round

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/Networking/Voting.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/Voting.cs
@@ -8,9 +8,17 @@ namespace Barotrauma
 {
     partial class Voting
     {
-        private bool allowSubVoting, allowModeVoting;
+        private bool allowSubVoting, allowModeVoting, allowVoteKick;
 
-        public bool AllowVoteKick = true;
+        public bool AllowVoteKick {
+            get {
+                return this.allowVoteKick && !GameMain.NetworkMember.GameStarted;
+            }
+
+            set {
+                this.allowVoteKick = value;
+            }
+        }
 
         public bool AllowEndVoting = true;
 


### PR DESCRIPTION
Vote kicking is a flawed system in a game of deceit like Barotrauma. 

Assume this scenario in a public server:

1. The server is traitors maybe/yes.
2. You are a traitor and you have a target to kill
3. You kill your target.
4. Your target assumes you're a griefer and makes a vote kick on you.
5. The entire server gangs up against you because they think you're a griefer and use this meta information to stay far away from you.

A naive solution would be to not show vote kicks in chat, but this would be a bad idea because if there WAS a griefer then some players might not vote kick them.

An ever naiver solution would be to not vote kick traitors, but this is a really bad idea for hopefully obvious meta reasons.

Instead, this PR makes it so you can only vote kick while a round is in the waiting stage. This means that players will have the opportunity to see the traitors end game panel to say "Oh, that guy wasn't griefing, he was just a traitor".