### PR TITLE
Expansion of Barotrauma's logic system.

### DIFF
--- a/Barotrauma/BarotraumaShared/BarotraumaShared.projitems
+++ b/Barotrauma/BarotraumaShared/BarotraumaShared.projitems
@@ -1470,7 +1470,15 @@
     <Compile Include="$(MSBuildThisFileDirectory)Source\Characters\DamageModifier.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Events\Missions\MissionPrefab.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\GameAnalyticsManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\ColorComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\EqualsComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\GreaterComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\MemoryComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\DivideComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\MultiplyComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\SubtractComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\AdderComponent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Items\Components\Signal\XorComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\StatusEffects\DelayedEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Characters\HuskInfection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Characters\Jobs\Job.cs" />

--- a/Barotrauma/BarotraumaShared/Content/Items/Electricity/poweritems.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Electricity/poweritems.xml
@@ -60,7 +60,11 @@
       </StatusEffect>
       <requireditem name="Screwdriver" type="Equipped"/>
       <input name="power_out"/>
-      <input name="power_in"/>      
+      <input name="power_in"/>
+      <input name="set_rate"/>
+      <output name="charge"/>
+      <output name="charge_%"/>
+      <output name="charge_rate"/>
     </ConnectionPanel>
 
     <ItemContainer capacity="3" canbeselected="true" hideitems="true">
@@ -87,6 +91,10 @@
       <requireditem name="Screwdriver" type="Equipped"/>
       <input name="power_out"/>
       <input name="power_in"/>
+      <input name="set_rate"/>
+      <output name="charge"/>
+      <output name="charge_%"/>
+      <output name="charge_rate"/>
     </ConnectionPanel>
   </Item>
 

--- a/Barotrauma/BarotraumaShared/Content/Items/Electricity/signalitems.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Electricity/signalitems.xml
@@ -191,6 +191,72 @@
   </Item>
 
   <Item
+    name="Equals Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="false"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Outputs the sum of the received signals.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="80,64,16,16"/>
+
+    <EqualsComponent canbeselected="true"/>
+
+    <Body width="16" height="16" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_in1"/>
+      <input name="signal_in2"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
+    name="Greater Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="false"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Outputs the sum of the received signals.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="80,64,16,16"/>
+
+    <GreaterComponent canbeselected="true"/>
+
+    <Body width="16" height="16" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_in1"/>
+      <input name="signal_in2"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
     name="Adder Component"
     category="Electrical"
     Tags="smallitem"
@@ -207,6 +273,140 @@
     <Sprite texture="signalcomp.png" depth="0.8" sourcerect="17,80,16,16"/>
 
     <AdderComponent canbeselected="true"/>
+
+    <Body width="16" height="16" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_in1"/>
+      <input name="signal_in2"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
+    name="Color Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="false"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Outputs a combined color signal for light control.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="64,80,16,16"/>
+
+    <ColorComponent canbeselected="true"/>
+
+    <Body width="16" height="16" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_r"/>
+      <input name="signal_g"/>
+      <input name="signal_b"/>
+      <input name="signal_a"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
+    name="Subtract Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="false"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Outputs the subtracted value of the received signals.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="17,80,16,16"/>
+
+    <SubtractComponent canbeselected="true"/>
+
+    <Body width="16" height="16" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_in1"/>
+      <input name="signal_in2"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
+    name="Multiply Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="false"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Outputs the product of the received signals.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="17,80,16,16"/>
+
+    <MultiplyComponent canbeselected="true"/>
+
+    <Body width="16" height="16" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_in1"/>
+      <input name="signal_in2"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
+    name="Divide Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="false"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Outputs the devided value of the received signals.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="17,80,16,16"/>
+
+    <DivideComponent canbeselected="true"/>
 
     <Body width="16" height="16" density="30"/>
 
@@ -240,6 +440,40 @@
     <Sprite texture="signalcomp.png" depth="0.8" sourcerect="16,0,16,16"/>
 
     <OrComponent canbeselected = "true"/>
+
+    <Body width="16" height="16" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_in1"/>
+      <input name="signal_in2"/>
+      <input name="set_output"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
+    name="Xor Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="true"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Sends a signal if either of the inputs but not both receive a signal.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="16,0,16,16"/>
+
+    <XorComponent canbeselected = "true"/>
 
     <Body width="16" height="16" density="30"/>
 
@@ -364,6 +598,39 @@
     <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
       <requireditem name="Screwdriver,Wire" type="Equipped"/>
       <input name="signal_in"/>
+      <output name="signal_out"/>
+    </ConnectionPanel>
+  </Item>
+
+  <Item
+    name="Memory Component"
+    category="Electrical"
+    Tags="smallitem"
+    linkable="true"
+    cargocontainername="Metal Crate"
+    price="10"
+    description="Output a stored signal that can be updated from other sources.">
+
+    <Deconstruct time="10">
+      <Item name="Steel Bar"/>
+      <Item name="FPGA Circuit"/>
+    </Deconstruct>
+
+    <Sprite texture="signalcomp.png" depth="0.8" sourcerect="16,32,16,8"/>
+
+    <MemoryComponent canbeselected = "true"/>
+
+    <Body width="16" height="8" density="30"/>
+
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="Detach [Wrench]" PickingTime="5.0"
+              aimpos="65,-10" handle1="0,0" attachable="true" aimable="true">
+      <requireditem name="Wrench" type="Equipped"/>
+    </Holdable>
+
+    <ConnectionPanel selectkey="Action" canbeselected = "true" msg="Rewire [Screwdriver]">
+      <requireditem name="Screwdriver,Wire" type="Equipped"/>
+      <input name="signal_in"/>
+      <input name="signal_store"/>
       <output name="signal_out"/>
     </ConnectionPanel>
   </Item>

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/ColorComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/ColorComponent.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 
 namespace Barotrauma.Items.Components
 {
-    class AdderComponent : ItemComponent
+    class ColorComponent : ItemComponent
     {
         //an array to keep track of how long ago a signal was received on both inputs
         protected float[] timeSinceReceived;
@@ -13,20 +13,6 @@ namespace Barotrauma.Items.Components
 
         //the output is sent if both inputs have received a signal within the timeframe
         protected float timeFrame;
-
-        [InGameEditable(MinValueFloat = -999999.0f, MaxValueFloat = 999999.0f), Serialize(999999.0f, true)]
-        public float ClampMax
-        {
-            get;
-            set;
-        }
-
-        [InGameEditable(MinValueFloat = -999999.0f, MaxValueFloat = 999999.0f), Serialize(-999999.0f, true)]
-        public float ClampMin
-        {
-            get;
-            set;
-        }
 
         [InGameEditable, Serialize(0.0f, true)]
         public float TimeFrame
@@ -38,11 +24,11 @@ namespace Barotrauma.Items.Components
             }
         }
 
-        public AdderComponent(Item item, XElement element)
+        public ColorComponent(Item item, XElement element)
             : base(item, element)
         {
-            timeSinceReceived = new float[] { Math.Max(timeFrame * 2.0f, 0.1f), Math.Max(timeFrame * 2.0f, 0.1f) };
-            receivedSignal = new float[2];
+            timeSinceReceived = new float[] { Math.Max(timeFrame * 2.0f, 0.1f), Math.Max(timeFrame * 2.0f, 0.1f), Math.Max(timeFrame * 2.0f, 0.1f), Math.Max(timeFrame * 2.0f, 0.1f) };
+            receivedSignal = new float[4];
             IsActive = true;
         }
 
@@ -56,22 +42,34 @@ namespace Barotrauma.Items.Components
             }
             if (sendOutput)
             {
-                float output = receivedSignal[0] + receivedSignal[1];
-                item.SendSignal(0, Math.Max( ClampMin, Math.Min( output, ClampMax )).ToString(), "signal_out", null);
+                string output = receivedSignal[0].ToString();
+                output += "," + receivedSignal[1].ToString();
+                output += "," + receivedSignal[2].ToString();
+                output += "," + receivedSignal[3].ToString();
+
+                item.SendSignal(0, output, "signal_out", null);
             }
         }
 
-        public override void ReceiveSignal(int stepsTaken, string signal, Connection connection, Item source, Character sender, float power=0.0f)
+        public override void ReceiveSignal(int stepsTaken, string signal, Connection connection, Item source, Character sender, float power = 0.0f)
         {
             switch (connection.Name)
             {
-                case "signal_in1":
+                case "signal_r":
                     float.TryParse(signal, out receivedSignal[0]);
                     timeSinceReceived[0] = 0.0f;
                     break;
-                case "signal_in2":
+                case "signal_g":
                     float.TryParse(signal, out receivedSignal[1]);
                     timeSinceReceived[1] = 0.0f;
+                    break;
+                case "signal_b":
+                    float.TryParse(signal, out receivedSignal[2]);
+                    timeSinceReceived[2] = 0.0f;
+                    break;
+                case "signal_a":
+                    float.TryParse(signal, out receivedSignal[3]);
+                    timeSinceReceived[3] = 0.0f;
                     break;
             }
         }

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/DivideComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/DivideComponent.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class DivideComponent : AdderComponent
+    {
+        public DivideComponent(Item item, XElement element)
+            : base(item, element)
+        {
+            IsActive = true;
+        }
+
+        public override void Update(float deltaTime, Camera cam)
+        {
+            bool sendOutput = true;
+            for (int i = 0; i < timeSinceReceived.Length; i++)
+            {
+                if (timeSinceReceived[i] > timeFrame) sendOutput = false;
+                timeSinceReceived[i] += deltaTime;
+            }
+            if (sendOutput)
+            {
+                item.SendSignal(0, (receivedSignal[0] / receivedSignal[1]).ToString(), "signal_out", null);
+            }
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/EqualsComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/EqualsComponent.cs
@@ -3,8 +3,10 @@ using System.Xml.Linq;
 
 namespace Barotrauma.Items.Components
 {
-    class AdderComponent : ItemComponent
+    class EqualsComponent : ItemComponent
     {
+        protected string output, falseOutput;
+
         //an array to keep track of how long ago a signal was received on both inputs
         protected float[] timeSinceReceived;
 
@@ -14,31 +16,21 @@ namespace Barotrauma.Items.Components
         //the output is sent if both inputs have received a signal within the timeframe
         protected float timeFrame;
 
-        [InGameEditable(MinValueFloat = -999999.0f, MaxValueFloat = 999999.0f), Serialize(999999.0f, true)]
-        public float ClampMax
+        [InGameEditable, Serialize("1", true)]
+        public string Output
         {
-            get;
-            set;
+            get { return output; }
+            set { output = value; }
         }
 
-        [InGameEditable(MinValueFloat = -999999.0f, MaxValueFloat = 999999.0f), Serialize(-999999.0f, true)]
-        public float ClampMin
+        [InGameEditable, Serialize("", true)]
+        public string FalseOutput
         {
-            get;
-            set;
+            get { return falseOutput; }
+            set { falseOutput = value; }
         }
 
-        [InGameEditable, Serialize(0.0f, true)]
-        public float TimeFrame
-        {
-            get { return timeFrame; }
-            set
-            {
-                timeFrame = Math.Max(0.0f, value);
-            }
-        }
-
-        public AdderComponent(Item item, XElement element)
+        public EqualsComponent(Item item, XElement element)
             : base(item, element)
         {
             timeSinceReceived = new float[] { Math.Max(timeFrame * 2.0f, 0.1f), Math.Max(timeFrame * 2.0f, 0.1f) };
@@ -48,20 +40,23 @@ namespace Barotrauma.Items.Components
 
         public override void Update(float deltaTime, Camera cam)
         {
-            bool sendOutput = true;
+            bool sendOutput = false;
             for (int i = 0; i < timeSinceReceived.Length; i++)
             {
-                if (timeSinceReceived[i] > timeFrame) sendOutput = false;
+                if (timeSinceReceived[i] <= timeFrame) sendOutput = true;
                 timeSinceReceived[i] += deltaTime;
             }
+
             if (sendOutput)
             {
-                float output = receivedSignal[0] + receivedSignal[1];
-                item.SendSignal(0, Math.Max( ClampMin, Math.Min( output, ClampMax )).ToString(), "signal_out", null);
+                string signalOut = receivedSignal[0] == receivedSignal[1] ? output : falseOutput;
+                if (string.IsNullOrEmpty(signalOut)) return;
+
+                item.SendSignal(0, signalOut, "signal_out", null);
             }
         }
 
-        public override void ReceiveSignal(int stepsTaken, string signal, Connection connection, Item source, Character sender, float power=0.0f)
+        public override void ReceiveSignal(int stepsTaken, string signal, Connection connection, Item source, Character sender, float power = 0.0f)
         {
             switch (connection.Name)
             {

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/GreaterComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/GreaterComponent.cs
@@ -1,0 +1,31 @@
+﻿using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class GreaterComponent : EqualsComponent
+    {
+        public GreaterComponent(Item item, XElement element)
+            : base(item, element)
+        {
+            IsActive = true;
+        }
+
+        public override void Update(float deltaTime, Camera cam)
+        {
+            bool sendOutput = false;
+            for (int i = 0; i < timeSinceReceived.Length; i++)
+            {
+                if (timeSinceReceived[i] <= timeFrame) sendOutput = true;
+                timeSinceReceived[i] += deltaTime;
+            }
+
+            if (sendOutput)
+            {
+                string signalOut = receivedSignal[0] > receivedSignal[1] ? output : falseOutput;
+                if (string.IsNullOrEmpty(signalOut)) return;
+
+                item.SendSignal(0, signalOut, "signal_out", null);
+            }
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/MemoryComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/MemoryComponent.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Globalization;
+using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class MemoryComponent : ItemComponent
+    {
+        [InGameEditable(MinValueFloat = -999999.0f, MaxValueFloat = 999999.0f), Serialize(1.0f, true)]
+        public float Value
+        {
+            get;
+            set;
+        }
+
+        public float TempValue
+        {
+            get;
+            set;
+        }
+
+        protected bool writeable;
+
+        public MemoryComponent(Item item, XElement element)
+            : base(item, element)
+        {
+            IsActive = true;
+        }
+
+        public override void Update(float deltaTime, Camera cam)
+        {
+            item.SendSignal(0, Value.ToString(), "signal_out", null);
+        }
+
+        public override void ReceiveSignal(int stepsTaken, string signal, Connection connection, Item source, Character sender, float power = 0.0f)
+        {
+            switch (connection.Name)
+            {
+                case "signal_in":
+                    if ( writeable )
+                    {
+                        float tempValue;
+                        if (float.TryParse(signal, NumberStyles.Any, CultureInfo.InvariantCulture, out tempValue))
+                        {
+                            if (!MathUtils.IsValid(tempValue)) return;
+                            Value = tempValue;
+                        }
+                    }
+                    break;
+                case "signal_store":
+                    writeable = (signal == "1");
+                    break;
+            }
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/MultiplyComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/MultiplyComponent.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class MultiplyComponent : AdderComponent
+    {
+        public MultiplyComponent(Item item, XElement element)
+            : base(item, element)
+        {
+            IsActive = true;
+        }
+
+        public override void Update(float deltaTime, Camera cam)
+        {
+            bool sendOutput = true;
+            for (int i = 0; i < timeSinceReceived.Length; i++)
+            {
+                if (timeSinceReceived[i] > timeFrame) sendOutput = false;
+                timeSinceReceived[i] += deltaTime;
+            }
+            if (sendOutput)
+            {
+                item.SendSignal(0, (receivedSignal[0] * receivedSignal[1]).ToString(), "signal_out", null);
+            }
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/SubtractComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/SubtractComponent.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class SubtractComponent : AdderComponent
+    {
+        public SubtractComponent(Item item, XElement element)
+            : base(item, element)
+        {
+            IsActive = true;
+        }
+
+        public override void Update(float deltaTime, Camera cam)
+        {
+            bool sendOutput = true;
+            for (int i = 0; i < timeSinceReceived.Length; i++)
+            {
+                if (timeSinceReceived[i] > timeFrame) sendOutput = false;
+                timeSinceReceived[i] += deltaTime;
+            }
+            if (sendOutput)
+            {
+                item.SendSignal(0, (receivedSignal[0] - receivedSignal[1]).ToString(), "signal_out", null);
+            }
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/XorComponent.cs
+++ b/Barotrauma/BarotraumaShared/Source/Items/Components/Signal/XorComponent.cs
@@ -1,0 +1,28 @@
+﻿using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class XorComponent : AndComponent
+    {
+        public XorComponent(Item item, XElement element)
+            : base(item, element)
+        {
+            IsActive = true;
+        }
+
+        public override void Update(float deltaTime, Camera cam)
+        {
+            int sendOutput = 0;
+            for (int i = 0; i < timeSinceReceived.Length; i++)
+            {
+                if (timeSinceReceived[i] <= timeFrame) sendOutput += 1;
+                timeSinceReceived[i] += deltaTime;
+            }
+
+            string signalOut = sendOutput == 1 ? output : falseOutput;
+            if (string.IsNullOrEmpty(signalOut)) return;
+
+            item.SendSignal(0, signalOut, "signal_out", null);
+        }
+    }
+}


### PR DESCRIPTION
This is the first time I have tried to contribute to a Github project.
If I have done something wrong with git please explain my mistake so I can learn.

Changed:
- AdderComponent and children can clamp their output
- Powercontainer signals for charge,charge% and charge rate

Added:
- ColorComponent: Dynamic signals for light set_color inputs
- MemoryComponent: Stores and sends a signal that is edge latched
- DivideComponent: Standard division
- MultiplyComponent: Standard multiplication
- SubtractComponent: Standard subtraction
- XorComponent: Exclusive or
- EqualsComponent: Equals comparison
- GreaterComponent: Greater than comparison