### PR TITLE
Reactor can be controlled with movement keys

### DIFF
--- a/Barotrauma/BarotraumaClient/Source/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaClient/Source/Items/Components/Machines/Reactor.cs
@@ -186,7 +186,11 @@ namespace Barotrauma.Items.Components
                 ToolTip = TextManager.Get("ReactorTipTurbineOutput")
             };
 
-            GUILayoutGroup sliderControls = new GUILayoutGroup(new RectTransform(new Point(columnMid.Rect.Width, (int)(114 * GUI.Scale)), columnMid.RectTransform, Anchor.BottomCenter)) { Stretch = true };
+            GUILayoutGroup sliderControls = new GUILayoutGroup(new RectTransform(new Point(columnMid.Rect.Width, (int)(114 * GUI.Scale)), columnMid.RectTransform, Anchor.BottomCenter))
+            {
+                Stretch = true,
+                AbsoluteSpacing = (int)(5 * GUI.Scale)
+            };
             sliderControlsContainer = sliderControls;
 
             new GUITextBlock(new RectTransform(new Point(0, (int)(20 * GUI.Scale)), sliderControls.RectTransform, Anchor.TopLeft),
@@ -204,7 +208,7 @@ namespace Barotrauma.Items.Components
                 }
             };
 
-            new GUITextBlock(new RectTransform(new Point(0, (int)(20 * GUI.Scale)), sliderControls.RectTransform, Anchor.BottomLeft) { AbsoluteOffset = new Point(0, (int)(16 * GUI.Scale)) },
+            new GUITextBlock(new RectTransform(new Point(0, (int)(20 * GUI.Scale)), sliderControls.RectTransform, Anchor.BottomLeft),
                 TextManager.Get("ReactorTurbineOutput"));
             turbineOutputScrollBar = new GUIScrollBar(new RectTransform(new Point(sliderControls.Rect.Width, (int)(30 * GUI.Scale)), sliderControls.RectTransform, Anchor.BottomCenter),
                 style: "GUISlider", barSize: 0.1f, isHorizontal: true)

--- a/Barotrauma/BarotraumaClient/Source/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaClient/Source/Items/Components/Machines/Reactor.cs
@@ -426,7 +426,7 @@ namespace Barotrauma.Items.Components
             AutoTemp = autoTempSlider.BarScroll < 0.5f;
             shutDown = onOffSwitch.BarScroll > 0.5f;
 
-            if (sliderControlsContainer.Rect.Contains(PlayerInput.MousePosition) &&
+            if ((sliderControlsContainer.Rect.Contains(PlayerInput.MousePosition) || sliderControlsContainer.Children.Contains(GUIScrollBar.draggingBar)) &&
                 !PlayerInput.KeyDown(InputType.Deselect) && !PlayerInput.KeyHit(InputType.Deselect))
             {
                 Character.DisableControls = true;


### PR DESCRIPTION
This happens when the mouse is near the control bars or is currently dragging one of them.

Left and Right (default A and D) control the Fission rate
Up and Down (default W and S) control the Turbine output

Run (Default LeftShift) quadruples the speed.

This is where the mouse zone is, similar to the steering menu.
![image](https://user-images.githubusercontent.com/5211576/59134204-5f3d1500-8948-11e9-84db-57a86895a1dc.png)

I put the scrollbars into a GUILayoutFrame so their position was slightly shifted, I tried to get it close enough. Notably the labels are affected.

**OLD**
![image](https://user-images.githubusercontent.com/5211576/59132266-b809af00-8942-11e9-9e98-4e4d02269ffb.png)

**NEW**
![image](https://user-images.githubusercontent.com/5211576/59133739-f2754b00-8946-11e9-844e-08c0b4bf2ca6.png)

