### PR TITLE
AI ladder fixes

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/Characters/AI/IndoorsSteeringManager.cs
+++ b/Barotrauma/BarotraumaShared/Source/Characters/AI/IndoorsSteeringManager.cs
@@ -277,6 +277,11 @@ namespace Barotrauma
                         }
                         currentPath.SkipToNextNode();
                     }
+                    // next node's not a ladder, we should stop climbing
+                    if (!IsNextNodeLadder && Math.Abs(collider.SimPosition.Y - currentPath.CurrentNode.SimPosition.Y) < (collider.height / 2 + collider.radius) * 0.10f)
+                    {
+                        character.AnimController.Anim = AnimController.Animation.None;
+                    }
                 }
                 else if (nextLadderSameAsCurrent)
                 {


### PR DESCRIPTION
This patches the current behavior, but the real problem is in heightFromFloor not calculating correctly (instead seeing a different floor further down).

This is trivial to reproduce in the current master and dev build: start on the typhon sub, then tell the AI to man the top left (dorsal) coilgun. Alternatively, walk into the room and tell the AI to follow you. They consistently get stuck on the ladder in the access shaft and refuse to let go. I can provide some screenshots with debugdraw on if it's helpful.