### PR TITLE
Crouch button on reactor for fine adjustments

### DIFF
--- a/Barotrauma/BarotraumaClient/Source/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaClient/Source/Items/Components/Machines/Reactor.cs
@@ -453,6 +453,7 @@ namespace Barotrauma.Items.Components
                 if (PlayerInput.KeyDown(InputType.Up)) input.Y += 1.0f;
                 if (PlayerInput.KeyDown(InputType.Down)) input.Y += -1.0f;
                 if (PlayerInput.KeyDown(InputType.Run)) rate = 200.0f;
+                else if (PlayerInput.KeyDown(InputType.Crouch)) rate = 20.0f;
 
                 rate *= deltaTime;
                 input.X *= rate;


### PR DESCRIPTION
Lets you hold the crouch button when using movement keys on the reactor to slow it down by 60%. If you hold the sprint button to speed it up, the sprint button takes priority and overrides the crouch.