### PR TITLE
Steering Movement Keys uses Run bind for speed up

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Steering.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Steering.cs
@@ -706,7 +706,7 @@ namespace Barotrauma.Items.Components
                 if (PlayerInput.KeyDown(InputType.Right)) { input += Vector2.UnitX; }
                 if (PlayerInput.KeyDown(InputType.Up)) { input += Vector2.UnitY; }
                 if (PlayerInput.KeyDown(InputType.Down)) { input -= Vector2.UnitY; }
-                if (PlayerInput.KeyDown(Keys.LeftShift))
+                if (PlayerInput.KeyDown(InputType.Run))
                 {
                     SteeringInput += input * deltaTime * 200;
                     inputCumulation = 0;


### PR DESCRIPTION
Rather than hard coding the shift key to speed up the input rate, the key bound to run is used instead, which by default is shift