### PR TITLE
Change AFK Kick Timer to 10 minutes

### DIFF
--- a/Barotrauma/BarotraumaShared/Source/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaShared/Source/Networking/ServerSettings.cs
@@ -742,7 +742,7 @@ namespace Barotrauma.Networking
             private set;
         }
 
-        [Serialize(120.0f, true)]
+        [Serialize(600.0f, true)]
         public float KickAFKTime
         {
             get;


### PR DESCRIPTION
This was a much-needed change. Many times, our crew would have a member go to the bathroom and they're kicked by the time they come back.

Can't we just leave the extreme AFK cases to vote kicking, complemented by this 10 minute hard cap?