### PR TITLE
Hash function is now case-insensitive. (fixes #3114)

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/ContentPackage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/ContentPackage.cs
@@ -525,7 +525,13 @@ namespace Barotrauma
                 {
                     using (MD5 tempMd5 = MD5.Create())
                     {
-                        filePaths = filePaths.OrderBy(f => ToolBox.StringToUInt32Hash(f.CleanUpPathCrossPlatform(true), tempMd5)).ToList();
+                        // TODO: ToLower() fixes discrepencies between windows folder name capitalization for server/client interactions.
+                        // The proper fix would probably be to save both a case-sensitive and non-casesensitive hash on the server,
+                        //     and only compare case-sensitive clients with the case-sensitive hash, and case-insensitive clients with the
+                        //     case insensitive hash.
+                        // Though ultimately, the only case where this will cause issues is if someone made a mod with identical folder names in the same path.
+                        // Windows... 😩
+                        filePaths = filePaths.OrderBy(f => ToolBox.StringToUInt32Hash(f.CleanUpPathCrossPlatform(true).ToLower(), tempMd5)).ToList();
                     }
                 }
 


### PR DESCRIPTION
Tested on my personal Dedicated Linux server and it indeed fixes #3114 .

This does create a different issue where if a mod creator somehow made _specifically_ a creature mod with two identical creature names with different cases it has a 50% chance of failing a hash check. Although Windows won't actually allow this by default (since it would see them as identical folders anyway):

![animation of folder conflict message that windows gives](https://i.imgur.com/iSjpf8a.gif)

By the way, it was **extraordinarily** easy to compile from source and test! Thanks for the great open-source game, I might mess around more in my free time as I get more familiar with the code-base.