### PR TITLE
Fixed AI not updating when not ragdolled, but having a miniscule amount of stun

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AICharacter.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AICharacter.cs
@@ -47,7 +47,7 @@ namespace Barotrauma
             base.Update(deltaTime, cam);
 
             if (!Enabled) { return; }
-            if (IsDead || Vitality <= 0.0f || Stun > 0.0f || IsIncapacitated)
+            if (Vitality <= 0.0f || IsCurrentlyRagdolled)
             {
                 //don't enable simple physics on dead/incapacitated characters
                 //the ragdoll controls the movement of incapacitated characters instead of the collider,

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -444,6 +444,11 @@ namespace Barotrauma
             }
         }
 
+        public bool IsCurrentlyRagdolled
+        {
+            get; private set;
+        }
+
         private float ragdollingLockTimer;
         public bool IsRagdolled;
         public bool IsForceRagdolled;
@@ -2227,6 +2232,8 @@ namespace Barotrauma
 
         public virtual void Update(float deltaTime, Camera cam)
         {
+            IsCurrentlyRagdolled = false;
+
             UpdateProjSpecific(deltaTime, cam);
 
             if (GameMain.NetworkMember != null && GameMain.NetworkMember.IsClient && this == Controlled && !isSynced) { return; }
@@ -2342,6 +2349,9 @@ namespace Barotrauma
             {
                 UpdateOxygen(deltaTime);
             }
+
+            IsCurrentlyRagdolled = IsDead || IsIncapacitated || Stun > 0.0f;
+
             CharacterHealth.Update(deltaTime);
 
             if (IsIncapacitated)


### PR DESCRIPTION
Bug Recreation:

Have a character (in my case a mudraptor) with an affliction with a constant stun effect of strength=1 (e.g. late stage Cyanide Poisoning), then inject them with hyperzine. They will not be incapacitated, but their stun amount will be non-zero, causing the AI controller update loop not to be called.

![devenv_8iXAkq3lVp](https://user-images.githubusercontent.com/5637889/92998025-bf414480-f517-11ea-845e-b0257b1f247c.png)


https://drive.google.com/file/d/1lqvwlCMRgpu15QKOtWxrdPz5CZ-X_nbz/view?usp=sharing
