### PR TITLE
Use PlayerName instead of server name for player when hosting server.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/MainMenuScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/MainMenuScreen.cs
@@ -913,7 +913,7 @@ namespace Barotrauma
                 ChildServerRelay.Start(processInfo);
                 Thread.Sleep(1000); //wait until the server is ready before connecting
 
-                GameMain.Client = new GameClient(name, System.Net.IPAddress.Loopback.ToString(), Steam.SteamManager.GetSteamID(), name, ownerKey, true);
+                GameMain.Client = new GameClient(GameMain.Config.PlayerName, IPAddress.Loopback.ToString(), Steam.SteamManager.GetSteamID(), name, ownerKey, true);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Change to use the player name from Config when hosting a P2P server. Previously
it was setting the player's name to be the server's name instead of what the
user configured (or the steam name if none was set previously).

Fixes #3868