### PR TITLE
Add `ammo_out` signal for turrets (#3218)

### DIFF
--- a/Barotrauma/BarotraumaShared/Content/Items/Weapons/coilgun.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Weapons/coilgun.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="coilgunloader" tags="coilgunequipment,coilgunammosource" category="Machine" linkable="true" allowedlinks="coilgun" scale="0.5" damagedbyexplosions="true" explosiondamagemultiplier="0.2">
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="full_%" displayname="connection.fullpercentage" />
+    </ConnectionPanel>
+  </Item>
+</Items>

--- a/Barotrauma/BarotraumaShared/Content/Items/Weapons/coilgun.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Weapons/coilgun.xml
@@ -7,4 +7,12 @@
       <output name="full_%" displayname="connection.fullpercentage" />
     </ConnectionPanel>
   </Item>
+
+  <Item name="" identifier="coilgunloadertriple" tags="coilgunequipment,coilgunammosource" category="Machine" linkable="true" allowedlinks="coilgun" scale="1.5" damagedbyexplosions="true" explosiondamagemultiplier="0.2">
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="full_%" displayname="connection.fullpercentage" />
+    </ConnectionPanel>
+  </Item>
 </Items>

--- a/Barotrauma/BarotraumaShared/Content/Items/Weapons/depthcharge.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Weapons/depthcharge.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="depthchargeloader" tags="depthchargeammosource" category="Machine" linkable="true" allowedlinks="depthchargelauncher" scale="0.5">
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="full_%" displayname="connection.fullpercentage" />
+    </ConnectionPanel>
+  </Item>
+</Items>

--- a/Barotrauma/BarotraumaShared/Content/Items/Weapons/railgun.xml
+++ b/Barotrauma/BarotraumaShared/Content/Items/Weapons/railgun.xml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="railgunloader" tags="railgunequipment,railgunammosource" category="Machine" linkable="true" allowedlinks="railgun" scale="0.5" damagedbyexplosions="true" explosiondamagemultiplier="0.2">
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="full_%" displayname="connection.fullpercentage" />
+    </ConnectionPanel>
+  </Item>
+
+  <Item name="" identifier="railgunloadersinglevertical" tags="railgunequipment,railgunammosource" category="Machine" linkable="true" allowedlinks="railgun" scale="0.5" damagedbyexplosions="true" explosiondamagemultiplier="0.2">
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="full_%" displayname="connection.fullpercentage" />
+    </ConnectionPanel>
+  </Item>
+
+  <Item name="" identifier="railgunloadersinglehorizontal" tags="railgunequipment,railgunammosource" category="Machine" linkable="true" allowedlinks="railgun" scale="0.5" damagedbyexplosions="true" explosiondamagemultiplier="0.2">
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="full_%" displayname="connection.fullpercentage" />
+    </ConnectionPanel>
+  </Item>
+</Items>

--- a/Barotrauma/BarotraumaShared/Content/Texts/English/EnglishVanilla.xml
+++ b/Barotrauma/BarotraumaShared/Content/Texts/English/EnglishVanilla.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<infotexts language="English" nowhitespace="false" translatedname="English">
+<connection.fullpercentage>full_%</connection.fullpercentage>
+</infotexts>

--- a/Barotrauma/BarotraumaShared/Content/Texts/English/EnglishVanilla.xml
+++ b/Barotrauma/BarotraumaShared/Content/Texts/English/EnglishVanilla.xml
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <infotexts language="English" nowhitespace="false" translatedname="English">
+<entityname.coilgunloadertriple>Coilgun Triple Loader</entityname.coilgunloadertriple>
+<entitydescription.coilgunloadertriple>Feeds up to 3 coilgun ammunition boxes into a linked coilgun.</entitydescription.coilgunloadertriple>
 <connection.fullpercentage>full_%</connection.fullpercentage>
 </infotexts>

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -24,6 +24,8 @@ namespace Barotrauma.Items.Components
             set { capacity = Math.Max(value, 1); }
         }
 
+        private float amountFilled = 0;
+
         private bool hideItems;
         [Serialize(true, false, description: "Should the items contained inside this item be hidden."
             + " If set to false, you should use the ItemPos and ItemInterval properties to determine where the items get rendered.")]
@@ -163,10 +165,20 @@ namespace Barotrauma.Items.Components
 
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                //tag = coilgunammo
-                containedItem.HasTag("coilgunammo"); // Special case since ammo boxes use Condition instead of actually containing bolts.
-                float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
-                Console.WriteLine(containedItem.Name + " contained in " + item.Name + ": " + fullPercentage.ToString());
+                //Console.WriteLine(containedItem.Name + " to be removed's tags: " + containedItem.Tags);
+                if (containedItem.HasTag("coilgunammo"))
+                { // Special case since ammo boxes use Condition instead of actually containing bolts.
+                    float containedConditionPercent = item.GetContainedItemConditionPercentage();
+                    this.amountFilled = (containedConditionPercent == -1 ? 0 : containedConditionPercent) * Capacity * Capacity; // -1 means empty.
+                    //Console.WriteLine(containedItem.Name + " contained In " + item.Name + ": " + this.amountFilled.ToString() + ", " + containedItem.GetContainedItemConditionPercentage() + ", " + containedItem.Condition.ToString() + ", " + containedItem.ConditionPercentage.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
+                }
+                else
+                { // railgun shell or depth charge
+                    this.amountFilled++;
+                    //Console.WriteLine(containedItem.Name + " contained iN " + item.Name + ": " + this.amountFilled.ToString());
+                }
+                //float fullPercentage = this.amountFilled / Capacity; // -1 means empty.
+                //Console.WriteLine(containedItem.Name + " contained in " + item.Name + ": " + fullPercentage.ToString());
             }
         }
 
@@ -179,9 +191,22 @@ namespace Barotrauma.Items.Components
 
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
-                Console.WriteLine(containedItem.Name + " removed from " + item.Name + ": " + fullPercentage.ToString());
-                item.SendSignal(0, fullPercentage.ToString(), "full_%", null);
+                //Console.WriteLine(containedItem.Name + " to be removed's tags: " + containedItem.Tags);
+                if (containedItem.HasTag("coilgunammo"))
+                { // Special case since ammo boxes use Condition instead of actually containing bolts.
+                    float containedConditionPercent = item.GetContainedItemConditionPercentage();
+                    this.amountFilled = (containedConditionPercent == -1 ? 0 : containedConditionPercent) * Capacity * Capacity; // -1 means empty.
+                    //Console.WriteLine(containedItem.Name + " removed FRom " + item.Name + ": " + this.amountFilled.ToString() + ", " + containedItem.GetContainedItemConditionPercentage() + ", " + containedItem.Condition.ToString() + ", " + containedItem.ConditionPercentage.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
+                }
+                else
+                { // railgun shell or depth charge
+                    this.amountFilled--;
+                    //Console.WriteLine(containedItem.Name + " removed frOM " + item.Name + ": " + this.amountFilled.ToString());
+                }
+                ////if tag == coilgunammo then this.amountFilled -= containedItem.Condition; else (rail/depth) this.amountFilled--;
+                //float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
+                //Console.WriteLine(containedItem.Name + " removed from " + item.Name + ": " + fullPercentage.ToString());
+                item.SendSignal(0, (this.amountFilled / Capacity).ToString(), "full_%", null);
             }
         }
 
@@ -200,9 +225,23 @@ namespace Barotrauma.Items.Components
         {
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
-                Console.WriteLine(item.Name + " updated: " + fullPercentage.ToString() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString() + ", " + Capacity.ToString());
-                item.SendSignal(0, fullPercentage.ToString(), "full_%", null);
+                //float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
+                //Console.WriteLine(item.Name + " updated: " + item.GetContainedItemConditionPercentage() + ", " + this.amountFilled.ToString() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString() + ", " + Capacity.ToString());
+                //item.SendSignal(0, fullPercentage.ToString(), "full_%", null);
+                //item.SendSignal(0, (item.GetContainedItemConditionPercentage() / Capacity).ToString(), "full_%", null);
+                //if (item.HasTag("coilgunammo"))
+                //{ // Special case since ammo boxes use Condition instead of actually containing bolts.
+                //    float containedConditionPercent = item.GetContainedItemConditionPercentage();
+                //    this.amountFilled = containedConditionPercent == -1 ? 0 : containedConditionPercent; // -1 means empty.
+                //    Console.WriteLine(item.Name + " UPdated " + item.Name + ": " + this.amountFilled.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
+                //    //item.SendSignal(0, this.amountFilled.ToString(), "full_%", null);
+                //}
+                //else
+                //{ // railgun shell or depth charge
+                    //Console.WriteLine(item.Name + " updatED " + item.Name + ": " + (this.amountFilled / Capacity - item.GetContainedItemConditionPercentage()).ToString() + ", " + (this.amountFilled / Capacity).ToString() + ", " + this.amountFilled.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
+                //}
+                //Console.WriteLine("sum: " + item.ContainedItems.Select(containedItem => containedItem == null ? "null" : (containedItem.Name + "=" + containedItem.Condition)).ToList().ToString());//.Items.Sum(containedItem => (float)(containedItem.HasTag("coilgunammo") ? item.Condition : 1.0f)).ToString());
+                item.SendSignal(0, (this.amountFilled / Capacity).ToString(), "full_%", null);
             }
             if (item.ParentInventory is CharacterInventory)
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -24,8 +24,6 @@ namespace Barotrauma.Items.Components
             set { capacity = Math.Max(value, 1); }
         }
 
-        private float fullPercentage = 0;
-
         private bool hideItems;
         [Serialize(true, false, description: "Should the items contained inside this item be hidden."
             + " If set to false, you should use the ItemPos and ItemInterval properties to determine where the items get rendered.")]
@@ -165,7 +163,10 @@ namespace Barotrauma.Items.Components
 
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                Console.WriteLine(containedItem.Name + " contained.");
+                //tag = coilgunammo
+                containedItem.HasTag("coilgunammo"); // Special case since ammo boxes use Condition instead of actually containing bolts.
+                float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
+                Console.WriteLine(containedItem.Name + " contained in " + item.Name + ": " + fullPercentage.ToString());
             }
         }
 
@@ -178,9 +179,9 @@ namespace Barotrauma.Items.Components
 
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                Console.WriteLine(containedItem.Name + " removed.");
-                this.fullPercentage = item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage(); // -1 means empty.
-                item.SendSignal(0, this.fullPercentage.ToString(), "full_%", null);
+                float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
+                Console.WriteLine(containedItem.Name + " removed from " + item.Name + ": " + fullPercentage.ToString());
+                item.SendSignal(0, fullPercentage.ToString(), "full_%", null);
             }
         }
 
@@ -199,9 +200,9 @@ namespace Barotrauma.Items.Components
         {
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                Console.WriteLine(item.Name + " updated.");
-                this.fullPercentage = item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage(); // -1 means empty.
-                item.SendSignal(0, this.fullPercentage.ToString(), "full_%", null);
+                float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
+                Console.WriteLine(item.Name + " updated: " + fullPercentage.ToString() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString() + ", " + Capacity.ToString());
+                item.SendSignal(0, fullPercentage.ToString(), "full_%", null);
             }
             if (item.ParentInventory is CharacterInventory)
             {
@@ -394,11 +395,10 @@ namespace Barotrauma.Items.Components
                 }
             }
 
-            if (item.GetComponent<ConnectionPanel>() != null)
-            {
-                Console.WriteLine(item.Name + " map load.");
-                item.SendSignal(0, "0", "full_%", null); // Initialize to empty.
-            }
+            //if (item.GetComponent<ConnectionPanel>() != null)
+            //{
+            //    item.SendSignal(0, "0", "full_%", null); // Initialize to empty. // doesn't work, likely signal sent before can be received
+            //}
         }
 
         protected override void ShallowRemoveComponentSpecific()
@@ -441,10 +441,10 @@ namespace Barotrauma.Items.Components
                 itemIds[i] = id;
             }
 
-            if (item.GetComponent<ConnectionPanel>() != null)
-            {
-                Console.WriteLine(item.Name + " load.");
-            }
+            //if (item.GetComponent<ConnectionPanel>() != null)
+            //{
+            //    item.SendSignal(0, "0", "full_%", null); // Initialize to empty. // doesn't work, likely signal sent before can be received
+            //}
         }
 
         public override XElement Save(XElement parentElement)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -165,20 +165,15 @@ namespace Barotrauma.Items.Components
 
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                //Console.WriteLine(containedItem.Name + " to be removed's tags: " + containedItem.Tags);
                 if (containedItem.HasTag("coilgunammo"))
                 { // Special case since ammo boxes use Condition instead of actually containing bolts.
                     float containedConditionPercent = item.GetContainedItemConditionPercentage();
                     this.amountFilled = (containedConditionPercent == -1 ? 0 : containedConditionPercent) * Capacity * Capacity; // -1 means empty.
-                    //Console.WriteLine(containedItem.Name + " contained In " + item.Name + ": " + this.amountFilled.ToString() + ", " + containedItem.GetContainedItemConditionPercentage() + ", " + containedItem.Condition.ToString() + ", " + containedItem.ConditionPercentage.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
                 }
                 else
                 { // railgun shell or depth charge
                     this.amountFilled++;
-                    //Console.WriteLine(containedItem.Name + " contained iN " + item.Name + ": " + this.amountFilled.ToString());
                 }
-                //float fullPercentage = this.amountFilled / Capacity; // -1 means empty.
-                //Console.WriteLine(containedItem.Name + " contained in " + item.Name + ": " + fullPercentage.ToString());
             }
         }
 
@@ -191,21 +186,15 @@ namespace Barotrauma.Items.Components
 
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                //Console.WriteLine(containedItem.Name + " to be removed's tags: " + containedItem.Tags);
                 if (containedItem.HasTag("coilgunammo"))
                 { // Special case since ammo boxes use Condition instead of actually containing bolts.
                     float containedConditionPercent = item.GetContainedItemConditionPercentage();
                     this.amountFilled = (containedConditionPercent == -1 ? 0 : containedConditionPercent) * Capacity * Capacity; // -1 means empty.
-                    //Console.WriteLine(containedItem.Name + " removed FRom " + item.Name + ": " + this.amountFilled.ToString() + ", " + containedItem.GetContainedItemConditionPercentage() + ", " + containedItem.Condition.ToString() + ", " + containedItem.ConditionPercentage.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
                 }
                 else
                 { // railgun shell or depth charge
                     this.amountFilled--;
-                    //Console.WriteLine(containedItem.Name + " removed frOM " + item.Name + ": " + this.amountFilled.ToString());
                 }
-                ////if tag == coilgunammo then this.amountFilled -= containedItem.Condition; else (rail/depth) this.amountFilled--;
-                //float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
-                //Console.WriteLine(containedItem.Name + " removed from " + item.Name + ": " + fullPercentage.ToString());
                 item.SendSignal(0, (this.amountFilled / Capacity).ToString(), "full_%", null);
             }
         }
@@ -225,22 +214,6 @@ namespace Barotrauma.Items.Components
         {
             if (item.GetComponent<ConnectionPanel>() != null)
             {
-                //float fullPercentage = (item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage()) / Capacity; // -1 means empty.
-                //Console.WriteLine(item.Name + " updated: " + item.GetContainedItemConditionPercentage() + ", " + this.amountFilled.ToString() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString() + ", " + Capacity.ToString());
-                //item.SendSignal(0, fullPercentage.ToString(), "full_%", null);
-                //item.SendSignal(0, (item.GetContainedItemConditionPercentage() / Capacity).ToString(), "full_%", null);
-                //if (item.HasTag("coilgunammo"))
-                //{ // Special case since ammo boxes use Condition instead of actually containing bolts.
-                //    float containedConditionPercent = item.GetContainedItemConditionPercentage();
-                //    this.amountFilled = containedConditionPercent == -1 ? 0 : containedConditionPercent; // -1 means empty.
-                //    Console.WriteLine(item.Name + " UPdated " + item.Name + ": " + this.amountFilled.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
-                //    //item.SendSignal(0, this.amountFilled.ToString(), "full_%", null);
-                //}
-                //else
-                //{ // railgun shell or depth charge
-                    //Console.WriteLine(item.Name + " updatED " + item.Name + ": " + (this.amountFilled / Capacity - item.GetContainedItemConditionPercentage()).ToString() + ", " + (this.amountFilled / Capacity).ToString() + ", " + this.amountFilled.ToString() + ", " + item.GetContainedItemConditionPercentage() + ", " + item.Condition.ToString() + ", " + item.ConditionPercentage.ToString());
-                //}
-                //Console.WriteLine("sum: " + item.ContainedItems.Select(containedItem => containedItem == null ? "null" : (containedItem.Name + "=" + containedItem.Condition)).ToList().ToString());//.Items.Sum(containedItem => (float)(containedItem.HasTag("coilgunammo") ? item.Condition : 1.0f)).ToString());
                 item.SendSignal(0, (this.amountFilled / Capacity).ToString(), "full_%", null);
             }
             if (item.ParentInventory is CharacterInventory)
@@ -434,10 +407,11 @@ namespace Barotrauma.Items.Components
                 }
             }
 
-            //if (item.GetComponent<ConnectionPanel>() != null)
-            //{
-            //    item.SendSignal(0, "0", "full_%", null); // Initialize to empty. // doesn't work, likely signal sent before can be received
-            //}
+            if (item.GetComponent<ConnectionPanel>() != null)
+            {
+               // doesn't work, likely signal sent before can be received
+               item.SendSignal(0, "0", "full_%", null); // Initialize to empty.
+            }
         }
 
         protected override void ShallowRemoveComponentSpecific()
@@ -479,11 +453,6 @@ namespace Barotrauma.Items.Components
                 if (!ushort.TryParse(itemIdStrings[i], out ushort id)) { continue; }
                 itemIds[i] = id;
             }
-
-            //if (item.GetComponent<ConnectionPanel>() != null)
-            //{
-            //    item.SendSignal(0, "0", "full_%", null); // Initialize to empty. // doesn't work, likely signal sent before can be received
-            //}
         }
 
         public override XElement Save(XElement parentElement)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -24,6 +24,8 @@ namespace Barotrauma.Items.Components
             set { capacity = Math.Max(value, 1); }
         }
 
+        private float fullPercentage = 0;
+
         private bool hideItems;
         [Serialize(true, false, description: "Should the items contained inside this item be hidden."
             + " If set to false, you should use the ItemPos and ItemInterval properties to determine where the items get rendered.")]
@@ -160,6 +162,11 @@ namespace Barotrauma.Items.Components
 
             //no need to Update() if this item has no statuseffects and no physics body
             IsActive = itemsWithStatusEffects.Count > 0 || Inventory.Items.Any(it => it?.body != null);
+
+            if (item.GetComponent<ConnectionPanel>() != null)
+            {
+                Console.WriteLine(containedItem.Name + " contained.");
+            }
         }
 
         public void OnItemRemoved(Item containedItem)
@@ -168,6 +175,13 @@ namespace Barotrauma.Items.Components
 
             //deactivate if the inventory is empty
             IsActive = itemsWithStatusEffects.Count > 0 || Inventory.Items.Any(it => it?.body != null);
+
+            if (item.GetComponent<ConnectionPanel>() != null)
+            {
+                Console.WriteLine(containedItem.Name + " removed.");
+                this.fullPercentage = item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage(); // -1 means empty.
+                item.SendSignal(0, this.fullPercentage.ToString(), "full_%", null);
+            }
         }
 
         public bool CanBeContained(Item item)
@@ -183,6 +197,12 @@ namespace Barotrauma.Items.Components
 
         public override void Update(float deltaTime, Camera cam)
         {
+            if (item.GetComponent<ConnectionPanel>() != null)
+            {
+                Console.WriteLine(item.Name + " updated.");
+                this.fullPercentage = item.GetContainedItemConditionPercentage() == -1 ? 0f : item.GetContainedItemConditionPercentage(); // -1 means empty.
+                item.SendSignal(0, this.fullPercentage.ToString(), "full_%", null);
+            }
             if (item.ParentInventory is CharacterInventory)
             {
                 item.SetContainedItemPositions();
@@ -373,6 +393,12 @@ namespace Barotrauma.Items.Components
                     }
                 }
             }
+
+            if (item.GetComponent<ConnectionPanel>() != null)
+            {
+                Console.WriteLine(item.Name + " map load.");
+                item.SendSignal(0, "0", "full_%", null); // Initialize to empty.
+            }
         }
 
         protected override void ShallowRemoveComponentSpecific()
@@ -413,6 +439,11 @@ namespace Barotrauma.Items.Components
             {
                 if (!ushort.TryParse(itemIdStrings[i], out ushort id)) { continue; }
                 itemIds[i] = id;
+            }
+
+            if (item.GetComponent<ConnectionPanel>() != null)
+            {
+                Console.WriteLine(item.Name + " load.");
             }
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -299,9 +299,6 @@ namespace Barotrauma.Items.Components
                 if (resetUserTimer <= 0.0f) { user = null; }
             }
 
-            //GetLoadedProjectiles();
-            //item.SendSignal(0, this.ammoAvailable.Format(3), "ammo_out", null);
-
             ApplyStatusEffects(ActionType.OnActive, deltaTime, null);
 
             UpdateProjSpecific(deltaTime);

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -299,7 +299,8 @@ namespace Barotrauma.Items.Components
                 if (resetUserTimer <= 0.0f) { user = null; }
             }
 
-            item.SendSignal(0, ((int)GetLoadedProjectiles().Count).ToString(), "ammo_out", null);
+            //GetLoadedProjectiles();
+            //item.SendSignal(0, this.ammoAvailable.Format(3), "ammo_out", null);
 
             ApplyStatusEffects(ActionType.OnActive, deltaTime, null);
 
@@ -405,6 +406,8 @@ namespace Barotrauma.Items.Components
                     if (projectileContainer != null)
                     {
                         linkedItem.Use(deltaTime, null);
+                        // Update linked ammo loaders so they send full_% signals.
+                        linkedItem.GetComponent<ItemContainer>().Update(deltaTime, this.cam);
                         var repairable = linkedItem.GetComponent<Repairable>();
                         if (repairable != null && failedLaunchAttempts < 2)
                         {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -299,6 +299,8 @@ namespace Barotrauma.Items.Components
                 if (resetUserTimer <= 0.0f) { user = null; }
             }
 
+            item.SendSignal(0, ((int)GetLoadedProjectiles().Count).ToString(), "ammo_out", null);
+
             ApplyStatusEffects(ActionType.OnActive, deltaTime, null);
 
             UpdateProjSpecific(deltaTime);


### PR DESCRIPTION
After poking around for a Coilgun Loader file, it looks like it's not actually its own item, but a type of _[ItemContainer.cs](https://github.com/Regalis11/Barotrauma/blob/master/Barotrauma/BarotraumaClient/ClientSource/Items/Components/ItemContainer.cs#L62-L64)_. So instead, it's easier to add `ammo_out` to the _[Turret.cs](https://github.com/Regalis11/Barotrauma/blob/master/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs#L933-L975)_ in its `Update` method.

Note this outputs a raw count of loaded ammo "3", rather than a percentage "60%" (which would need to know each linked ItemContainer's max storage).

I can't see how to actually add that `ammo_out` to the UI though, so perhaps it's inferred from `SendSignal` calls? Using https://github.com/Regalis11/Barotrauma/pull/3529 as guidance.