### PR TITLE
Fix water flow sound disappearing over time due to bad position.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Sounds/SoundPlayer.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sounds/SoundPlayer.cs
@@ -500,6 +500,12 @@ namespace Barotrauma
         {
             if (FlowSounds.Count == 0) { return; }
 
+            for(int i = 0; i < targetFlowLeft.Length; i++)
+            {
+                targetFlowLeft[i] = 0.0f;
+                targetFlowRight[i] = 0.0f;
+            }
+
             Vector2 listenerPos = new Vector2(GameMain.SoundManager.ListenerPosition.X, GameMain.SoundManager.ListenerPosition.Y);
             foreach (Gap gap in Gap.GapList)
             {


### PR DESCRIPTION
The issue was introduced in the latest unstable. A change was made so
that the targetFlow arrays were not allocated on every update, but
the code was relying on the new allocation to have 0.0f values as
starting state. This fix resets the values to 0.0f where it used to
be allocating the arrays.