### PR TITLE
Fix disposed sounds constantly getting dispose called again.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Sounds/SoundManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sounds/SoundManager.cs
@@ -730,6 +730,7 @@ namespace Barotrauma.Sounds
                                 else
                                 {
                                     playingChannels[i][j].Dispose();
+                                    playingChannels[i][j] = null;
                                 }
                             }
                             else if (playingChannels[i][j].FadingOutAndDisposing)
@@ -738,6 +739,7 @@ namespace Barotrauma.Sounds
                                 if (playingChannels[i][j].Gain <= 0.0f)
                                 {
                                     playingChannels[i][j].Dispose();
+                                    playingChannels[i][j] = null;
                                 }
                             }
                         }
@@ -767,7 +769,11 @@ namespace Barotrauma.Sounds
                 {
                     for (int j = 0; j < playingChannels[i].Length; j++)
                     {
-                        if (playingChannels[i][j] != null) playingChannels[i][j].Dispose();
+                        if (playingChannels[i][j] != null)
+                        {
+                            playingChannels[i][j].Dispose();
+                            playingChannels[i][j] = null;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I noticed when debugging the water flow sound issue that when
returning to the menu, sounds which were disposed already were still
getting dispose called on every update loop. This fix sets the
playingChannels reference to null after disposing of the sound so
that it no longer wastes cycles on disposed sounds.

It looks like when a SoundChannel is disposed, it can never start
playing again, and if any exceptions occur in SoundChannel.Dispose a
crash occurs, so no point in calling Dispose more than once.