### PR TITLE
Update ArithmeticComponent.cs

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -52,15 +52,12 @@ namespace Barotrauma.Items.Components
 
         sealed public override void Update(float deltaTime, Camera cam)
         {
-            for (int i = 0; i < timeSinceReceived.Length; i++)
+            for (int i = 0; i < timeSinceReceived.Length; i++) { timeSinceReceived[i] += deltaTime; }
+            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame) 
             {
-                if (timeSinceReceived[i] > timeFrame) 
-                {
-                    IsActive = false;
-                }
-                timeSinceReceived[i] += deltaTime;
+                IsActive = false;
+                return;
             }
-            if (!IsActive) { return; }
             float output = Calculate(receivedSignal[0], receivedSignal[1]);
             if (MathUtils.IsValid(output))
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -53,10 +53,7 @@ namespace Barotrauma.Items.Components
         sealed public override void Update(float deltaTime, Camera cam)
         {
             for (int i = 0; i < timeSinceReceived.Length; i++) { timeSinceReceived[i] += deltaTime; }
-            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame) 
-            {
-                IsActive = false;
-            }
+            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame)  { IsActive = false; }
             if timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) { return; }
             float output = Calculate(receivedSignal[0], receivedSignal[1]);
             if (MathUtils.IsValid(output))

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -56,7 +56,6 @@ namespace Barotrauma.Items.Components
             if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame) 
             {
                 IsActive = false;
-                return;
             }
             if timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) { return; }
             float output = Calculate(receivedSignal[0], receivedSignal[1]);

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -52,14 +52,15 @@ namespace Barotrauma.Items.Components
 
         sealed public override void Update(float deltaTime, Camera cam)
         {
-            for (int i = 0; i < timeSinceReceived.Length; i++) { timeSinceReceived[i] += deltaTime; }
-            // Only stop Update() if both signals timed-out
-            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame)  
+            for (int i = 0; i < timeSinceReceived.Length; i++) 
+            { 
+                timeSinceReceived[i] += deltaTime; 
+            }
+            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame)  // Only stop Update() if both signals timed-out
                 { 
                     IsActive = false; 
                 }
-            // early return if either of the signal timed-out
-            if (timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) 
+            if (timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) // early return if either of the signal timed-out
                 { 
                     return; 
                 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -57,10 +57,10 @@ namespace Barotrauma.Items.Components
                 if (timeSinceReceived[i] > timeFrame) 
                 {
                     IsActive = false;
-                    return;
                 }
                 timeSinceReceived[i] += deltaTime;
             }
+            if (!IsActive) { return; }
             float output = Calculate(receivedSignal[0], receivedSignal[1]);
             if (MathUtils.IsValid(output))
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -53,8 +53,16 @@ namespace Barotrauma.Items.Components
         sealed public override void Update(float deltaTime, Camera cam)
         {
             for (int i = 0; i < timeSinceReceived.Length; i++) { timeSinceReceived[i] += deltaTime; }
-            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame)  { IsActive = false; }
-            if timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) { return; }
+            // Only stop Update() if both signals timed-out
+            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame)  
+                { 
+                    IsActive = false; 
+                }
+            // early return if either of the signal timed-out
+            if (timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) 
+                { 
+                    return; 
+                }
             float output = Calculate(receivedSignal[0], receivedSignal[1]);
             if (MathUtils.IsValid(output))
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -58,6 +58,7 @@ namespace Barotrauma.Items.Components
                 IsActive = false;
                 return;
             }
+            if timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) { return; }
             float output = Calculate(receivedSignal[0], receivedSignal[1]);
             if (MathUtils.IsValid(output))
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ArithmeticComponent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using System;
 using System.Globalization;
 using System.Xml.Linq;
@@ -52,18 +52,18 @@ namespace Barotrauma.Items.Components
 
         sealed public override void Update(float deltaTime, Camera cam)
         {
+            bool deactivate = true;
+            bool earlyReturn = false;
             for (int i = 0; i < timeSinceReceived.Length; i++) 
-            { 
+            {  
+                deactivate &= timeSinceReceived[i] > timeFrame;
+                earlyReturn |= timeSinceReceived[i] > timeFrame;
                 timeSinceReceived[i] += deltaTime; 
             }
-            if (timeSinceReceived[0] > timeFrame && timeSinceReceived[1] > timeFrame)  // Only stop Update() if both signals timed-out
-                { 
-                    IsActive = false; 
-                }
-            if (timeSinceReceived[0] > timeFrame || timeSinceReceived[1] > timeFrame) // early return if either of the signal timed-out
-                { 
-                    return; 
-                }
+            // only stop Update() if both signals timed-out. if IsActive == false, then the component stops updating.
+            IsActive = !deactivate;
+            // early return if either of the signal timed-out
+            if (earlyReturn) { return; }
             float output = Calculate(receivedSignal[0], receivedSignal[1]);
             if (MathUtils.IsValid(output))
             {


### PR DESCRIPTION
Fixed signal_in_2 never timing out if signal_in_1 timed out. 
In-game, the issue translates as being able to output if sending a signal to signal_in_2 and then signal_in_1 even though the signals weren't received at the same time.