### PR TITLE
Fix NPE when can't find containerPrefab while spawning cargo.

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/GameSession/CargoManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSession/CargoManager.cs
@@ -217,7 +217,7 @@ namespace Barotrauma
 
                         if (containerPrefab == null)
                         {
-                            DebugConsole.ThrowError("Cargo spawning failed - could not find the item prefab for container \"" + containerPrefab.Name + "\"!");
+                            DebugConsole.ThrowError("Cargo spawning failed - could not find the item prefab for container \"" + pi.ItemPrefab.CargoContainerIdentifier + "\"!");
                             continue;
                         }
 


### PR DESCRIPTION
Fixes a small oversight which was causing the code to blow up if a
cargocontaineridentifier could not be found.