### PR TITLE
Fixes issue #4159

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveManager.cs
@@ -245,7 +245,7 @@ namespace Barotrauma
         public void SortObjectives()
         {
             CurrentOrder?.GetPriority();
-            Objectives.ForEach(o => o.GetPriority());
+            Objectives.ToArray().ForEach(o => o.GetPriority());
             if (Objectives.Any())
             {
                 Objectives.Sort((x, y) => y.Priority.CompareTo(x.Priority));


### PR DESCRIPTION
ForEach loop on line 248 in `Barotrauma\BarotraumaShared\SharedSource\Characters\AI\Objectives\AIObjectiveManager.cs` couldn't execute it's enumeration due to internal changes to the Objectives.

Fixed by not directly accessing the Objectives and instead converting it to an array before running the ForEach enumeration.