### PR TITLE
Fixes #4160

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Deconstructor.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Deconstructor.cs
@@ -103,7 +103,7 @@ namespace Barotrauma.Items.Components
                     if (!linkedItem.Components.Any()) continue;
                 
                     var itemContainer = linkedItem.Components.First();
-                    if (itemContainer == null) { continue; }
+                    if (itemContainer == null || itemContainer.GuiFrame == null) continue;
 
                     if (!itemContainer.Item.DisplaySideBySideWhenLinked) continue;
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
@@ -220,7 +220,7 @@ namespace Barotrauma.Items.Components
                     if (!linkedItem.Components.Any()) continue;
                 
                     var itemContainer = linkedItem.Components.First();
-                    if (itemContainer == null) { continue; }
+                    if (itemContainer == null || itemContainer.GuiFrame == null) continue;
 
                     if (!itemContainer.Item.DisplaySideBySideWhenLinked) continue;
 


### PR DESCRIPTION
The bug was caused by the Fabricator's and Deconstructor's `SelectProjSpecific` and `Select` functions, because it did not handle if a GuiFrame wasn't defined for every component of the items, causing it to look for a GuiFrame in a LightComponent.