### PR TITLE
Add a setting to use local voice chat for voice activity

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GameSettings.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSettings.cs
@@ -1016,6 +1016,19 @@ namespace Barotrauma
             {
                 Visible = VoiceSetting != VoiceMode.Disabled
             };
+            GUITickBox localVoiceByDefault = new GUITickBox(
+                new RectTransform(tickBoxScale, voiceActivityGroup.RectTransform), TextManager.Get("LocalVoiceByDefault"))
+            {
+                Visible = VoiceSetting == VoiceMode.Activity,
+                Selected = UseLocalVoiceByDefault,
+                ToolTip = TextManager.Get("LocalVoiceByDefaultTooltip"),
+                OnSelected = (tickBox) =>
+                {
+                    UseLocalVoiceByDefault = tickBox.Selected;
+                    UnsavedSettings = true;
+                    return true;
+                }
+            };
             GUITextBlock noiseGateText = new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.5f), voiceActivityGroup.RectTransform), TextManager.Get("NoiseGateThreshold"), font: GUI.SubHeadingFont)
             {
                 Visible = VoiceSetting == VoiceMode.Activity,
@@ -1142,6 +1155,7 @@ namespace Barotrauma
 
                     noiseGateText.Visible = (vMode == VoiceMode.Activity);
                     noiseGateSlider.Visible = (vMode == VoiceMode.Activity);
+                    localVoiceByDefault.Visible = (vMode == VoiceMode.Activity);
                     voiceActivityGroup.Visible = (vMode != VoiceMode.Disabled);
                     voiceInputContainerHorizontal.Visible = (vMode == VoiceMode.PushToTalk);
                     UnsavedSettings = true;

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipCapture.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipCapture.cs
@@ -239,7 +239,7 @@ namespace Barotrauma.Networking
                 bool allowEnqueue = false;
                 if (GameMain.WindowActive)
                 {
-                    ForceLocal = captureTimer > 0 ? ForceLocal : false;
+                    ForceLocal = captureTimer > 0 ? ForceLocal : GameMain.Config.UseLocalVoiceByDefault;
                     bool pttDown = false;
                     if ((PlayerInput.KeyDown(InputType.Voice) || PlayerInput.KeyDown(InputType.LocalVoice)) &&
                             GUI.KeyboardDispatcher.Subscriber == null)

--- a/Barotrauma/BarotraumaShared/SharedSource/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSettings.cs
@@ -68,6 +68,8 @@ namespace Barotrauma
 
         public float NoiseGateThreshold { get; set; }
 
+        public bool UseLocalVoiceByDefault { get; set; }
+
 #if CLIENT
         private KeyOrMouse[] keyMapping;
         private KeyOrMouse[] inventoryKeyMapping;
@@ -1202,7 +1204,8 @@ namespace Barotrauma
                 new XAttribute("voicesetting", VoiceSetting),
                 new XAttribute("audiooutputdevice", System.Xml.XmlConvert.EncodeName(AudioOutputDevice ?? "")),
                 new XAttribute("voicecapturedevice", System.Xml.XmlConvert.EncodeName(VoiceCaptureDevice ?? "")),
-                new XAttribute("noisegatethreshold", NoiseGateThreshold));
+                new XAttribute("noisegatethreshold", NoiseGateThreshold),
+                new XAttribute("uselocalvoicebydefault", UseLocalVoiceByDefault));
 
             XElement gSettings = doc.Root.Element("graphicssettings");
             if (gSettings == null)
@@ -1459,6 +1462,7 @@ namespace Barotrauma
                 VoiceCaptureDevice = System.Xml.XmlConvert.DecodeName(audioSettings.GetAttributeString("voicecapturedevice", VoiceCaptureDevice));
                 AudioOutputDevice = System.Xml.XmlConvert.DecodeName(audioSettings.GetAttributeString("audiooutputdevice", AudioOutputDevice));
                 NoiseGateThreshold = audioSettings.GetAttributeFloat("noisegatethreshold", NoiseGateThreshold);
+                UseLocalVoiceByDefault = audioSettings.GetAttributeBool("uselocalvoicebydefault", UseLocalVoiceByDefault);
                 MicrophoneVolume = audioSettings.GetAttributeFloat("microphonevolume", MicrophoneVolume);
                 string voiceSettingStr = audioSettings.GetAttributeString("voicesetting", "");
                 if (Enum.TryParse(voiceSettingStr, out VoiceMode voiceSetting))
@@ -1576,6 +1580,7 @@ namespace Barotrauma
             VoiceSetting = VoiceMode.Disabled;
             VoiceCaptureDevice = null;
             NoiseGateThreshold = -45;
+            UseLocalVoiceByDefault = false;
             windowMode = WindowMode.BorderlessWindowed;
             losMode = LosMode.Transparent;
             UseSteamMatchmaking = true;


### PR DESCRIPTION
This change adds a config setting to allow players to use the voice activity mode for local voice chat, while keeping the option to use the radio with the push-to-talk key.

This is part one of the modifications our group uses in our games, and I think it might be a good addition to the base game.
The second part is in a seperate PR.