### PR TITLE
Add a setting to toggle directional voice for radio

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GameSettings.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSettings.cs
@@ -904,13 +904,28 @@ namespace Barotrauma
             GUITickBox directionalVoiceChat = new GUITickBox(new RectTransform(tickBoxScale, voiceChatContent.RectTransform), TextManager.Get("DirectionalVoiceChat"))
             {
                 Selected = UseDirectionalVoiceChat,
-                ToolTip = TextManager.Get("DirectionalVoiceChatToolTip"),
+                ToolTip = TextManager.Get("DirectionalVoiceChatToolTip")
+            };
+
+            GUITickBox directionalVoiceChatForRadio = new GUITickBox(new RectTransform(tickBoxScale, voiceChatContent.RectTransform), TextManager.Get("DirectionalVoiceChatForRadio"))
+            {
+                Visible = UseDirectionalVoiceChat,
+                Selected = UseDirectionalVoiceChatForRadio,
+                ToolTip = TextManager.Get("DirectionalVoiceChatForRadioToolTip"),
                 OnSelected = (tickBox) =>
                 {
-                    UseDirectionalVoiceChat = tickBox.Selected;
+                    UseDirectionalVoiceChatForRadio = tickBox.Selected;
                     UnsavedSettings = true;
                     return true;
                 }
+            };
+
+            directionalVoiceChat.OnSelected = (tickBox) =>
+            {
+                UseDirectionalVoiceChat = tickBox.Selected;
+                directionalVoiceChatForRadio.Visible = tickBox.Selected;
+                UnsavedSettings = true;
+                return true;
             };
 
             if (string.IsNullOrWhiteSpace(VoiceCaptureDevice) || !(CaptureDeviceNames?.Contains(VoiceCaptureDevice) ?? false))

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Client.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Client.cs
@@ -65,9 +65,18 @@ namespace Barotrauma.Networking
 
             if (character != null)
             {
+                
                 if (GameMain.Config.UseDirectionalVoiceChat)
                 {
-                    VoipSound.SetPosition(new Vector3(character.WorldPosition.X, character.WorldPosition.Y, 0.0f));
+                    if (!VoipSound.UseRadioFilter || (VoipSound.UseRadioFilter && GameMain.Config.UseDirectionalVoiceChatForRadio))
+                    {
+                        VoipSound.SetPosition(new Vector3(character.WorldPosition.X, character.WorldPosition.Y, 0.0f));
+                    }
+                    else
+                    {
+                        VoipSound.SetPosition(null);
+                    }
+                    
                 }
                 else
                 {

--- a/Barotrauma/BarotraumaShared/SharedSource/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSettings.cs
@@ -50,6 +50,7 @@ namespace Barotrauma
         public bool DynamicRangeCompressionEnabled { get; set; }
         public bool VoipAttenuationEnabled { get; set; }
         public bool UseDirectionalVoiceChat { get; set; }
+        public bool UseDirectionalVoiceChatForRadio { get; set; }
 
         public IList<string> AudioDeviceNames;
         public IList<string> CaptureDeviceNames;
@@ -1199,6 +1200,7 @@ namespace Barotrauma
                 new XAttribute("dynamicrangecompressionenabled", DynamicRangeCompressionEnabled),
                 new XAttribute("voipattenuationenabled", VoipAttenuationEnabled),
                 new XAttribute("usedirectionalvoicechat", UseDirectionalVoiceChat),
+                new XAttribute("usedirectionalvoicechatforradio", UseDirectionalVoiceChatForRadio),
                 new XAttribute("voicesetting", VoiceSetting),
                 new XAttribute("audiooutputdevice", System.Xml.XmlConvert.EncodeName(AudioOutputDevice ?? "")),
                 new XAttribute("voicecapturedevice", System.Xml.XmlConvert.EncodeName(VoiceCaptureDevice ?? "")),
@@ -1456,6 +1458,7 @@ namespace Barotrauma
                 MuteOnFocusLost = audioSettings.GetAttributeBool("muteonfocuslost", MuteOnFocusLost);
 
                 UseDirectionalVoiceChat = audioSettings.GetAttributeBool("usedirectionalvoicechat", UseDirectionalVoiceChat);
+                UseDirectionalVoiceChatForRadio = audioSettings.GetAttributeBool("usedirectionalvoicechatforradio", UseDirectionalVoiceChatForRadio);
                 VoiceCaptureDevice = System.Xml.XmlConvert.DecodeName(audioSettings.GetAttributeString("voicecapturedevice", VoiceCaptureDevice));
                 AudioOutputDevice = System.Xml.XmlConvert.DecodeName(audioSettings.GetAttributeString("audiooutputdevice", AudioOutputDevice));
                 NoiseGateThreshold = audioSettings.GetAttributeFloat("noisegatethreshold", NoiseGateThreshold);
@@ -1573,6 +1576,7 @@ namespace Barotrauma
             PauseOnFocusLost = true;
             MuteOnFocusLost = false;
             UseDirectionalVoiceChat = true;
+            UseDirectionalVoiceChatForRadio = false;
             VoiceSetting = VoiceMode.Disabled;
             VoiceCaptureDevice = null;
             NoiseGateThreshold = -45;


### PR DESCRIPTION
This change adds a config setting to allow players enable or disable the directional voice for radio chat.

This is part two of the modifications our group uses in our games, and I think it might be a good addition to the base game.
The first part is in a seperate PR.