### PR TITLE
Add String Partitioning Components

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/HeadComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/HeadComponent.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class HeadComponent : StringComponent
+    {
+        /*
+            signal_in1 - Input String
+            signal_in2 - Input Limit/Divider
+            signal_out - Output all characters in String LEFT of the first Limit
+        */
+        
+        public SplitComponent(Item item, XElement element)
+            : base(item, element)
+        {
+        }
+
+        protected override string Calculate(string signal1, string signal2)
+        {
+            int index = 0;
+            for (int iter = 0; iter < signal1.Length; iter++)
+            {
+                if (index >= signal2.Length)
+                {
+                    //Indicates there is a match
+                    return signal1.Substring(0,iter - index); //Returns text before signal 2
+                }
+
+                if (signal2[index] == signal1[iter])
+                { //If this letter matches with the i'th signal_2 letter
+                    index++; // Next check is on next letter in signal_2
+                }
+                else
+                {
+                    index = 0; //Next check is for first character in signal_2
+                }
+            }
+            if(index > 0) { //If limit is at end of string
+                return signal1.Substring(0, signal1.Length - index);
+            }
+            return ""; //Returns empty
+        }
+
+
+    }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/TailComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/TailComponent.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Xml.Linq;
+
+namespace Barotrauma.Items.Components
+{
+    class TailComponent : StringComponent
+    {
+        /*
+            signal_in1 - Input String
+            signal_in2 - Input Limit/Divider
+            signal_out - Output all characters in String RIGHT of the first Limit
+        */
+
+        public TailComponent(Item item, XElement element)
+            : base(item, element)
+        {
+        }
+
+        protected override string Calculate(string signal1, string signal2)
+        {
+            int index = 0;
+            for (int iter = 0; iter < signal1.Length; iter++)
+            {
+                if (index >= signal2.Length)
+                {
+                    //Indicates there is a match
+                    return signal1.Substring(iter); //Returns text after signal_2
+                }
+
+                if (signal2[index] == signal1[iter])
+                { //If this letter matches with the i'th signal_2 letter
+                    index++; // Next check is on next letter in signal_2
+                }
+                else
+                {
+                    index = 0; //Next check is for first character in signal_2
+                }
+            }
+            return ""; //Returns empty signal
+        }
+    }
+}


### PR DESCRIPTION
## Head and Tail String Partitioning Components
### Reasoning
Building off of JLobblet's String Component Class from [Pull#3278](https://github.com/Regalis11/Barotrauma/pull/3278), I thought that more string-based operations are needed. One thing that isn't possible in the game, is to take a string input and split it, which really limits the use of the terminal object for ship-based commands. 

An example command from a terminal that a sub builder could implement would be `battery <x>` where `<x>` is some number inbetween 0 - 100, with the purpose of setting a sub's battery recharge rate. With the current electronic components, the sub builder would have to check for every case of `battery 0`,`battery 1`,...,`battery 100`, which would require 100 signal check/regex components. By introducing a method of grabbing a substring from a string, it would lead to there being no need to check each case, as the sub builder could just get the substring `<x>` from the terminal output signal `battery <x>`, then send that as a signal to the battery. 

Fundamentally, it would mean a system which would require 100 repeated components, would (if this was implemented) now be possible with a single component.

### Components Details
The two components I've added are the HEAD and TAIL components, both take inputs *signal_in1* (the text) and *signal_in2* (the divisor), and output *signal_out* (all characters to the left/right of the divisor in the text). Example inputs and their results are below.
##### Head Component
```
"battery 56" -> signal_1in   HEAD   signal_out -> "battery" 
" "          -> signal_2in
```
##### Tail Component
```
"battery 56" -> signal_1in   TAIL   signal_out -> "56" 
" "          -> signal_2in
```

As you can see the head component outputs a substring of everything to the right of the divisor, and tail outputs a substring of everything to the left. 

### Assets
The assets for these components are based on WorkingJoe's Assets from [Issues#4140](https://github.com/Regalis11/Barotrauma/issues/4140), with the sprite and inventory icon following the same font as the Concatenation Component (ModeNine), and design similar. The assets are inside the google drive [here](https://drive.google.com/drive/folders/1Ek4G-iz30iM6MfEmhS9Y69Tcx2zEB1j8?usp=sharing).
