### PR TITLE
Make steamID work with multiplayer campaign on dedicated servers

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/Primitives/Peers/Server/LidgrenServerPeer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/Primitives/Peers/Server/LidgrenServerPeer.cs
@@ -446,6 +446,10 @@ namespace Barotrauma.Networking
                         return;
                     }
                     pendingClient.SteamID = steamId;
+
+                    LidgrenConnection c = (LidgrenConnection)pendingClient.Connection;
+                    c.setSteamId(steamId);
+
                     pendingClient.Connection.Name = name;
                     pendingClient.Name = name;
                     pendingClient.OwnerKey = ownKey;

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkConnection/LidgrenConnection.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkConnection/LidgrenConnection.cs
@@ -34,6 +34,11 @@ namespace Barotrauma.Networking
             EndPointString = IPString;
         }
 
+        public void setSteamId(UInt64 steamId)
+        {
+            SteamID = steamId;
+        }
+
         public override bool EndpointMatches(string endPoint)
         {
             if (IPEndPoint?.Address == null) { return false; }


### PR DESCRIPTION
This fixes the issue that on a dedicated server all clients have steamID set to 0. Those in multiplayer campaign save files characters are basically bound to IP addresses in "endpoint". For players with non-static IP addresses, it's painful.

The issue it seems is that Initial Lidgren connections have a default steamID of 0. And nothing is setting it to real ones after clients pass steam auth. Furthermore Barotrauma.Networking.NetworkConnection has a setter for steamID in protected mode.

I am not a c# developer, so this is just a concept that works in my tests.
IMHO steamID binding should be by default. Or if IP binding with steamids = 0 is still needed, this could be implemented on a switch