### PR TITLE
Added max output length to ConcatComponent

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ConcatComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ConcatComponent.cs
@@ -1,9 +1,23 @@
 ﻿using System.Xml.Linq;
+using System;
 
 namespace Barotrauma.Items.Components
 {
     class ConcatComponent : StringComponent
     {
+        private int maxOutputLength;
+
+        [Editable, Serialize(256, false, description: "The maximum length of the output string. Warning: Large values can lead to large memory usage or networking load.")]
+        public int MaxOutputLength
+        {
+            get { return maxOutputLength; }
+            set
+            {
+                maxOutputLength = Math.Max(value, 0);
+            }
+        }
+
+
         public ConcatComponent(Item item, XElement element)
             : base(item, element)
         {
@@ -11,7 +25,8 @@ namespace Barotrauma.Items.Components
 
         protected override string Calculate(string signal1, string signal2)
         {
-            return signal1 + signal2;
+            string output = signal1 + signal2;
+            return output.Length <= maxOutputLength ? output : output.Substring(0, MaxOutputLength);
         }
     }
 }


### PR DESCRIPTION
The concatenation component can cause considerable memory usage and networking issues if it is placed in a feedback loop. Doing this can increase the length of a string each update leading to huge signals being sent around.

The concatenation component is the only component which has this problem as all other components already have an intrinsically limited output length.

To not limit the applications of the concatenation component, the maximum output length can be adjusted in the editor. It can not be adjusted in game to prevent griefing. 

I believe addinig this limit to the concatenation component only is a better solution than limiting all signal lengths. Limiting all signals will break existing circuits and limits the possibilities of contraptions that can be made. 