### PR TITLE
Change Reactor key controls to work anywhere in the UI

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Reactor.cs
@@ -53,6 +53,8 @@ namespace Barotrauma.Items.Components
 
         private GUIFrame inventoryContainer;
 
+        private GUILayoutGroup paddedFrame;
+
         private readonly Dictionary<string, GUIButton> warningButtons = new Dictionary<string, GUIButton>();
 
         private static readonly string[] warningTexts = new string[]
@@ -74,7 +76,7 @@ namespace Barotrauma.Items.Components
             tempRangeIndicator = new Sprite(element.GetChildElement("temprangeindicator")?.GetChildElement("sprite"));
             graphLine = new Sprite(element.GetChildElement("graphline")?.GetChildElement("sprite"));
 
-            var paddedFrame = new GUILayoutGroup(new RectTransform(
+            paddedFrame = new GUILayoutGroup(new RectTransform(
                     GuiFrame.Rect.Size - GUIStyle.ItemFrameMargin, GuiFrame.RectTransform, Anchor.Center) 
                     { AbsoluteOffset = GUIStyle.ItemFrameOffset }, 
                 isHorizontal: true)
@@ -533,8 +535,7 @@ namespace Barotrauma.Items.Components
             warningButtons["ReactorWarningMeltdown"].Selected = meltDownTimer > MeltdownDelay * 0.5f || item.Condition == 0.0f && lightOn;
             warningButtons["ReactorWarningSCRAM"].Selected = temperature > 0.1f && !PowerOn;
 
-            if ((FissionRateScrollBar.Rect.Contains(PlayerInput.MousePosition) || FissionRateScrollBar.Children.Contains(GUIScrollBar.DraggingBar) ||
-                TurbineOutputScrollBar.Rect.Contains(PlayerInput.MousePosition) || TurbineOutputScrollBar.Children.Contains(GUIScrollBar.DraggingBar)) &&
+            if (paddedFrame.Rect.Contains(PlayerInput.MousePosition) &&
                 !PlayerInput.KeyDown(InputType.Deselect) && !PlayerInput.KeyHit(InputType.Deselect))
             {
                 Character.DisableControls = true;


### PR DESCRIPTION
The movement keys can be used to control the Reactor's Fission Rate and Turbine Output only when the cursor on the scrollbars.

This PR changes it so the cursor can be anywhere on the Reactor screen.