### PR TITLE
Allow option In-Game to have Wifi Component output to chat (with Anti-Greifing Option)

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Item.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Item.cs
@@ -696,7 +696,8 @@ namespace Barotrauma
                 if (inGame)
                 {
                     if (!ic.AllowInGameEditing) { continue; }
-                    if (SerializableProperty.GetProperties<InGameEditable>(ic).Count == 0) { continue; }
+                    if (SerializableProperty.GetProperties<InGameEditable>(ic).Count == 0 &&
+                        SerializableProperty.GetProperties<ConditionallyEditable>(ic).Any(p => p.GetAttribute<ConditionallyEditable>().isEditable())) { continue; }
                 }
                 else
                 {

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
@@ -729,6 +729,10 @@ namespace Barotrauma.Networking
                 TextManager.Get("ServerSettingsAllowRewiring"));
             GetPropertyData("AllowRewiring").AssignGUIComponent(allowRewiring);
 
+            var allowWifiChatter = new GUITickBox(new RectTransform(new Vector2(0.48f, 0.05f), tickBoxContainer.Content.RectTransform), 
+                TextManager.Get("ServerSettingsAllowWifiChat"));
+            GetPropertyData("AllowWifiChat").AssignGUIComponent(allowWifiChatter);
+
             var allowDisguises = new GUITickBox(new RectTransform(new Vector2(0.48f, 0.05f), tickBoxContainer.Content.RectTransform),
                 TextManager.Get("ServerSettingsAllowDisguises"));
             GetPropertyData("AllowDisguises").AssignGUIComponent(allowDisguises);

--- a/Barotrauma/BarotraumaClient/ClientSource/Serialization/SerializableEntityEditor.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Serialization/SerializableEntityEditor.cs
@@ -264,7 +264,12 @@ namespace Barotrauma
         }
 
         public SerializableEntityEditor(RectTransform parent, ISerializableEntity entity, bool inGame, bool showName, string style = "", int elementHeight = 24, ScalableFont titleFont = null)
-            : this(parent, entity, inGame ? SerializableProperty.GetProperties<InGameEditable>(entity) : SerializableProperty.GetProperties<Editable>(entity), showName, style, elementHeight, titleFont)
+            : this(parent, entity, inGame ? 
+                SerializableProperty.GetProperties<InGameEditable>(entity)
+                    .Union(SerializableProperty.GetProperties<ConditionallyEditable>(entity).Where(p => 
+                        //this guy
+                        p.GetAttribute<ConditionallyEditable>()?.isEditable() ?? false)) 
+                : SerializableProperty.GetProperties<Editable>(entity), showName, style, elementHeight, titleFont)
         {
         }
 

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -109,6 +109,8 @@ namespace Barotrauma.Networking
         //only used when connected to steam
         public int QueryPort => serverSettings?.QueryPort ?? 0;
 
+        public bool AllowWifiChatter => serverSettings?.AllowWifiChat ?? false;
+
         public NetworkConnection OwnerConnection { get; private set; }
         private readonly int? ownerKey;
         private readonly UInt64? ownerSteamId;

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/WifiComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/WifiComponent.cs
@@ -58,7 +58,7 @@ namespace Barotrauma.Items.Components
             set;
         }
 
-        [Editable, Serialize(false, false, description: "If enabled, any signals received from another chat-linked wifi component are displayed " +
+        [InGameEditable, Serialize(false, false, description: "If enabled, any signals received from another chat-linked wifi component are displayed " +
             "as chat messages in the chatbox of the player holding the item.", alwaysUseInstanceValues: true)]
         public bool LinkToChat
         {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/WifiComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/WifiComponent.cs
@@ -58,8 +58,9 @@ namespace Barotrauma.Items.Components
             set;
         }
 
-        [InGameEditable, Serialize(false, false, description: "If enabled, any signals received from another chat-linked wifi component are displayed " +
-            "as chat messages in the chatbox of the player holding the item.", alwaysUseInstanceValues: true)]
+        [ConditionallyEditable(ConditionallyEditable.ConditionalProperty.WifiChatter)
+         , Serialize(false, false, description: "If enabled, any signals received from another chat-linked wifi component are displayed " +
+                                                                     "as chat messages in the chatbox of the player holding the item.", alwaysUseInstanceValues: true)]
         public bool LinkToChat
         {
             get;

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
@@ -628,6 +628,13 @@ namespace Barotrauma.Networking
             set;
         }
 
+        [Serialize(false, true)]
+        public bool AllowWifiChat
+        {
+            get;
+            set;
+        }
+
         [Serialize(true, true)]
         public bool AllowFriendlyFire
         {

--- a/Barotrauma/BarotraumaShared/SharedSource/Serialization/SerializableProperty.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Serialization/SerializableProperty.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
+using Barotrauma.Networking;
 
 namespace Barotrauma
 {
@@ -58,6 +59,42 @@ namespace Barotrauma
     [AttributeUsage(AttributeTargets.Property)]
     class InGameEditable : Editable
     {
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    class ConditionallyEditable : Editable
+    {
+        public ConditionallyEditable(ConditionalProperty propCheck)
+        {
+            thisProperty = propCheck;
+        }
+
+        private ConditionalProperty thisProperty;
+
+        public enum ConditionalProperty
+        {
+            //These need to exist at compile time, so it is a little awkward
+            //I would love to see a better way to do this
+            WifiChatter
+        }
+
+        public bool isEditable()
+        {
+            if (thisProperty == ConditionalProperty.WifiChatter)
+            {
+#if SERVER
+                return GameMain.Server.AllowWifiChatter;
+#endif
+
+#if CLIENT
+                return GameMain.Client.ServerSettings.AllowWifiChat;
+#endif
+            }
+            else
+            {
+                return false;
+            }
+        }
     }
 
 


### PR DESCRIPTION
### The Scenario
In one of my friend-only game servers, we spent the time and effort to rewire a Humpback to output its charge level over one of the channels of the radio, but nothing happened.  It wasn't until later that I found out that the  "Allow Wifi Chat" is only accessible in the ship editor.  Dang.

### The Proposal
Pretty straight forward: if the server-owner wills it, any player who can get at a wifi component can allow it to output to radio chat.  However, due to its... _Highly abusable_ nature, it the option will be off by default and only reveal itself if the server owner manually turns it on.

### The Changes
Player facing changes are threefold:

1.  Allow the server admin to enable/disable the players being able to set wifi components being able to output over chat in the Anti-griefing tab of the host window.
![image](https://user-images.githubusercontent.com/3222168/102151791-3f3dba00-3e39-11eb-97f4-ad37e1122f66.png)

 2. If the setting is enabled (default: disabled), then the setting is shown to any player who physically accesses that component.
![image](https://user-images.githubusercontent.com/3222168/102152023-c2f7a680-3e39-11eb-9618-1acbf42bfdf1.png)

3. If the setting is disabled (by default), then the setting does not display at all to any player.  
![image](https://user-images.githubusercontent.com/3222168/102152436-9db76800-3e3a-11eb-8fb9-2a8e1fbd1fd1.png)

### Technical Notes 
Due to the addition to the griefing tab, a text entry needs to be added to the localization files under the tag `ServerSettingsAllowWifiChat` 

I had to do some vaguely unholy things to make this work, I would love feedback to make this adhere to your code standards better.  Most of the weirdness comes from the fact that I can't pass very interesting things to class tags, as they must be computable at compile time.  

Basically, I added a new tag: `[ConditionallyEditable]` .  It takes in an enum that gives it a hint as to what server property it should consult, and then can be evaluated at runtime with `isEditable()` .  Unfortunately, this strategy requires that I find all calls of `GetProperties<InGameEditable>()` and make it somehow take my new tag into account, so it is a bit more messy than I would have liked.  

Anyways, thanks for the consideration.  


