### PR TITLE
Adds "Hull toggles" for automagical features (Nav Blue rooms, AI Forbidden)

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/MiniMap.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/MiniMap.cs
@@ -210,15 +210,12 @@ namespace Barotrauma.Items.Components
                     GetLinkedHulls(hull, hullData.LinkedHulls);
                     hullDatas.Add(hull, hullData);
                 }
-                
+
                 Color neutralColor = Color.DarkCyan;
-                if (hull.RoomName != null)
+                if (hull.WetRoom)
                 {
-                    if (hull.RoomName.Contains("ballast") || hull.RoomName.Contains("Ballast") ||
-                        hull.RoomName.Contains("airlock") || hull.RoomName.Contains("Airlock"))
-                    {
-                        neutralColor = new Color(9, 80, 159);
-                    }
+                    // Colour the room as "supposed to be wet/flooded"
+                    neutralColor = new Color(9, 80, 159);
                 }
 
                 if (hullData.Distort)

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/IndoorsSteeringManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/IndoorsSteeringManager.cs
@@ -517,6 +517,8 @@ namespace Barotrauma
                     bool canAccess = CanAccessDoor(door, button =>
                     {
                         if (currentWaypoint == null) { return true; }
+                        if (button.Item.IgnoreByAI) { return false; }
+
                         // Check that the button is on the right side of the door.
                         if (door.LinkedGap.IsHorizontal)
                         {

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveIdle.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveIdle.cs
@@ -514,9 +514,7 @@ namespace Barotrauma
         public static bool IsForbidden(Hull hull)
         {
             if (hull == null) { return true; }
-            string hullName = hull.RoomName;
-            if (hullName == null) { return false; }
-            return hullName.Contains("ballast", StringComparison.OrdinalIgnoreCase) || hullName.Contains("airlock", StringComparison.OrdinalIgnoreCase);
+            return hull.IsForbidden;
         }
 
         public override void Reset()

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectivePumpWater.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectivePumpWater.cs
@@ -34,6 +34,7 @@ namespace Barotrauma
             if (pump.Item.CurrentHull == null) { return false; }
             if (pump.Item.Submarine.TeamID != character.TeamID) { return false; }
             if (pump.Item.ConditionPercentage <= 0) { return false; }
+            if (pump.Item.CurrentHull.IsWetRoom) { return false; }
             if (pump.Item.CurrentHull.FireSources.Count > 0) { return false; }
             if (character.Submarine != null)
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/SpawnAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/SpawnAction.cs
@@ -306,10 +306,10 @@ namespace Barotrauma
             }
 
             //don't spawn in an airlock module if there are other options
-            var airlockSpawnPoints = validSpawnPoints.Where(wp => wp.CurrentHull?.OutpostModuleTags?.Contains("airlock") ?? false);
-            if (airlockSpawnPoints.Count() < validSpawnPoints.Count())
+            var forbiddenSpawnpoints = validSpawnPoints.Where(wp => wp.CurrentHull?.IsForbidden ?? false);
+            if (forbiddenSpawnpoints.Count() < validSpawnPoints.Count())
             {
-                validSpawnPoints = validSpawnPoints.Except(airlockSpawnPoints);
+                validSpawnPoints = validSpawnPoints.Except(forbiddenSpawnpoints);
             }
 
             if (!validSpawnPoints.Any())

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
@@ -520,6 +520,10 @@ namespace Barotrauma
                         tags.Add(string.Join(":", splitTag));
                     }
                 }
+
+                if (Tags.Contains("forbidden")) {
+                    IgnoreByAI = true;
+                }
             }
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
@@ -189,6 +189,45 @@ namespace Barotrauma
                 if (roomName == value) { return; }
                 roomName = value;
                 DisplayName = TextManager.Get(roomName, returnNull: true) ?? roomName;
+
+                // Rooms that are expected to be flooded:
+                if (roomName.Contains("ballast", StringComparison.OrdinalIgnoreCase) ||
+                    roomName.Contains("void", StringComparison.OrdinalIgnoreCase) ||
+                    roomName.Contains("bilge", StringComparison.OrdinalIgnoreCase) ||
+                    roomName.Contains("airlock", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Only enable the wetRoom tag, if its already ON leave it as is.
+                    wetRoom = true;
+                }
+
+                if (roomName.Contains("ballast", StringComparison.OrdinalIgnoreCase) ||
+                    roomName.Contains("void", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Only add the forbidden tag, leave it alone if the user already enabled it
+                    isForbidden = true;
+                }
+            }
+        }
+
+        private bool isWetRoom;
+        [Editable, Serialize(false, true, description: "Marks a Hull that is supposed to be flooded, like ballast/airlock/bilge. Colours it specially in the minimal")]
+        public bool IsWetRoom
+        {
+            get { return isWetRoom; }
+            set
+            {
+                isWetRoom = value;
+            }
+        }
+
+        private bool isForbidden;
+        [Editable, Serialize(false, true, description: "Forbidden for Bots to enter this, usually denotes dangerous locations. Tried to prevent spawns here")]
+        public bool IsForbiden
+        {
+            get { return isForbidden; }
+            set
+            {
+                isForbidden = value;
             }
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
@@ -298,11 +298,12 @@ namespace Barotrauma
             List<Pump> pumps = new List<Pump>();
             List<Item> allItems = GetItems(true);
 
-            bool anyHasTag = allItems.Any(i => i.HasTag("ballast"));
+            bool anyHasTag = allItems.Any(i => i.HasTag("ballast") || i.HasTag("infectablepump"));
 
             foreach (Item item in allItems)
             {
-                if ((!anyHasTag || item.HasTag("ballast")) && item.GetComponent<Pump>() is { } pump)
+                if (item.GetComponent<Pump>() is { } pump &&
+                    (!anyHasTag || item.HasTag("ballast") || item.HasTag("infectablepump")))
                 {
                     pumps.Add(pump);
                 }


### PR DESCRIPTION
This (should) add editable toggles for:
 * `wetrooms` for rooms that are expected to flood, such as ballast, airlock, bilge, etc.
 * `forbidden` for rooms that should be avoided by the AI (dangerous), can be applied to killboxes, or other dangerous locations.

This allows any room name to be used without losing these two capabilities (including in other languages potentially), but also allows you to toggle this OFF for certain rooms, e.g. a ballast that might serve as a "passageway". This also adds the keyword `void`, usually used for unusable spaces which can contain flood-damage.

Notes:
 * This might work better as "hull tags"?   But I have no idea how to add that.
 * I haven't built/tested this yet, just feeling out the waters to see if this kind of stuff is mergeable.  If it seems like a good Idea ping me and I can maybe try to figure out how to fully build/test this.

(Also adds "infectable" tag for non-ballast pumps, didn't feel it was worth a separate PR for it, but can be split out if one/either feature is not-considered)