### PR TITLE
Changes to utilize NLog as the logging backend.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/DebugConsole.cs
@@ -132,16 +132,6 @@ namespace Barotrauma
                 {
                     var newMsg = queuedMessages.Dequeue();
                     AddMessage(newMsg);
-
-                    if (GameSettings.SaveDebugConsoleLogs)
-                    {
-                        unsavedMessages.Add(newMsg);
-                        if (unsavedMessages.Count >= messagesPerFile)
-                        {
-                            SaveLogs();
-                            unsavedMessages.Clear();
-                        }
-                    }
                 }
             }
 
@@ -247,8 +237,6 @@ namespace Barotrauma
                 {
                     AddMessage(newMsg);
                 }
-
-                if (GameSettings.SaveDebugConsoleLogs) unsavedMessages.Add(newMsg);
             }
         }
 
@@ -1963,16 +1951,7 @@ namespace Barotrauma
                     NewMessage("Deleted temp save folder", Color.Green);
                 }
 
-                if (Barotrauma.IO.Directory.Exists(ServerLog.SavePath))
-                {
-                    var logFiles = Barotrauma.IO.Directory.GetFiles(ServerLog.SavePath);
-
-                    foreach (string logFile in logFiles)
-                    {
-                        Barotrauma.IO.File.Delete(logFile);
-                        NewMessage("Deleted " + logFile, Color.Green);
-                    }
-                }
+                LoggingUtils.DeleteLogsDirectory();
 
                 if (Barotrauma.IO.File.Exists("filelist.xml"))
                 {

--- a/Barotrauma/BarotraumaClient/ClientSource/GameMain.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameMain.cs
@@ -624,6 +624,11 @@ namespace Barotrauma
             {
                 DebugConsole.NewMessage("LOADING COROUTINE FINISHED", Color.Lime);
             }
+
+            if(!LoggingUtils.IsNLogConfigLoaded())
+            {
+                ShowNLogConfigFailedToLoadMessage();
+            }
         yield return CoroutineStatus.Success;
 
         }
@@ -1209,7 +1214,6 @@ namespace Barotrauma
             }
 
             if (GameSettings.SendUserStatistics) { GameAnalytics.OnQuit(); }
-            if (GameSettings.SaveDebugConsoleLogs) { DebugConsole.SaveLogs(); }
 
             base.OnExiting(sender, args);
         }
@@ -1231,6 +1235,20 @@ namespace Barotrauma
                 return true;
             };
             msgBox.Buttons[1].OnClicked = msgBox.Close;
+        }
+
+        public void ShowNLogConfigFailedToLoadMessage()
+        {
+            if (GUIMessageBox.VisibleBox?.UserData as string == "nlogprompt") { return; }
+
+            var msgBox = new GUIMessageBox(
+                "", 
+                "Failed to load NLog.config; logging for this session will be disabled. Check for syntax errors in the XML.", 
+                new string[] { TextManager.Get("Close") })
+            {
+                UserData = "nlogprompt"
+            };
+            msgBox.Buttons[0].OnClicked = msgBox.Close;
         }
     }
 }

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
@@ -432,16 +432,16 @@ namespace Barotrauma.Networking
             var randomizeLevelBox = new GUITickBox(new RectTransform(new Vector2(1.0f, 0.05f), serverTab.RectTransform), TextManager.Get("ServerSettingsRandomizeSeed"));
             GetPropertyData("RandomizeSeed").AssignGUIComponent(randomizeLevelBox);
 
-            var saveLogsBox = new GUITickBox(new RectTransform(new Vector2(1.0f, 0.05f), serverTab.RectTransform), TextManager.Get("ServerSettingsSaveLogs"))
+            var sendLogsBox = new GUITickBox(new RectTransform(new Vector2(1.0f, 0.05f), serverTab.RectTransform), TextManager.Get("ServerSettingsSendLogs"))
             {
                 OnSelected = (GUITickBox) =>
                 {
                     //TODO: fix?
-                    //showLogButton.Visible = SaveServerLogs;
+                    //showLogButton.Visible = SendServerLogsToClients;
                     return true;
                 }
             };
-            GetPropertyData("SaveServerLogs").AssignGUIComponent(saveLogsBox);
+            GetPropertyData("SendServerLogsToClients").AssignGUIComponent(sendLogsBox);
 
             //--------------------------------------------------------------------------------
             //                              game settings 

--- a/Barotrauma/BarotraumaClient/WindowsClient.csproj
+++ b/Barotrauma/BarotraumaClient/WindowsClient.csproj
@@ -123,6 +123,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NVorbis" Version="0.8.6" />
     <PackageReference Include="RestSharp" Version="106.6.10" />
   </ItemGroup>

--- a/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
@@ -88,15 +88,6 @@ namespace Barotrauma
                     {
                         ColoredText msg = queuedMessages.Dequeue();
                         Messages.Add(msg);
-                        if (GameSettings.SaveDebugConsoleLogs)
-                        {
-                            unsavedMessages.Add(msg);
-                            if (unsavedMessages.Count >= messagesPerFile)
-                            {
-                                SaveLogs();
-                                unsavedMessages.Clear();
-                            }
-                        }
 
                         string msgTxt = msg.Text;
 
@@ -260,15 +251,6 @@ namespace Barotrauma
                 {
                     var msg = queuedMessages.Dequeue();
                     Messages.Add(msg);
-                    if (GameSettings.SaveDebugConsoleLogs)
-                    {
-                        unsavedMessages.Add(msg);
-                        if (unsavedMessages.Count >= messagesPerFile)
-                        {
-                            SaveLogs();
-                            unsavedMessages.Clear();
-                        }
-                    }
                 }
                 if (Messages.Count > MaxMessages)
                 {

--- a/Barotrauma/BarotraumaServer/ServerSource/GameMain.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/GameMain.cs
@@ -11,11 +11,14 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Xml.Linq;
+using NLog;
 
 namespace Barotrauma
 {
     class GameMain
     {
+        private readonly static Logger Log = LogManager.GetCurrentClassLogger();
+
         public static readonly Version Version = Assembly.GetEntryAssembly().GetName().Version;
 
         public static World World;
@@ -78,18 +81,18 @@ namespace Barotrauma
             FarseerPhysics.Settings.VelocityIterations = 1;
             FarseerPhysics.Settings.PositionIterations = 1;
 
-            Console.WriteLine("Loading game settings");
+            Log.Info("Loading game settings");
             Config = new GameSettings();
 
-            Console.WriteLine("Loading MD5 hash cache");
+            Log.Info("Loading MD5 hash cache");
             Md5Hash.LoadCache();
 
-            Console.WriteLine("Initializing SteamManager");
+            Log.Info("Initializing SteamManager");
             SteamManager.Initialize();
-            Console.WriteLine("Initializing GameAnalytics");
+            Log.Info("Initializing GameAnalytics");
             if (GameSettings.SendUserStatistics) GameAnalyticsManager.Init();
 
-            Console.WriteLine("Initializing GameScreen");
+            Log.Info("Initializing GameScreen");
             GameScreen = new GameScreen();
         }
 
@@ -386,7 +389,6 @@ namespace Barotrauma
 
             SaveUtil.CleanUnnecessarySaveFiles();
 
-            if (GameSettings.SaveDebugConsoleLogs) { DebugConsole.SaveLogs(); }
             if (GameSettings.SendUserStatistics) { GameAnalytics.OnQuit(); }
         }
 

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/ServerLog.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/ServerLog.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using Barotrauma.IO;
+using System.Linq;
+using NLog;
+
+namespace Barotrauma.Networking
+{
+    public partial class ServerLog
+    {
+        private readonly static Logger Log = LogManager.GetCurrentClassLogger();
+        public readonly static string InternalLoggerName = Log.Name;
+
+        public static void WriteLine(string line, MessageType messageType)
+        {
+            Log.Info("{messageType:l}: {message:l}", messageType.ToString(), line);
+
+            var newText = new LogMessage(line, messageType);
+
+            DebugConsole.NewMessage(newText.SanitizedText, messageColor[messageType], logToNLog: false);
+        }
+    }
+}

--- a/Barotrauma/BarotraumaServer/WindowsServer.csproj
+++ b/Barotrauma/BarotraumaServer/WindowsServer.csproj
@@ -80,6 +80,10 @@
     <ProjectReference Include="..\..\Libraries\Lidgren.Network\Lidgren.NetStandard.csproj" AdditionalProperties="Configuration=Debug" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.7.0" />
+  </ItemGroup>
+
   <!-- Sourced from https://stackoverflow.com/a/45248069 -->
   <Target Name="GetGitRevision" BeforeTargets="WriteGitRevision" Condition="'$(BuildHash)' == ''">
     <PropertyGroup>

--- a/Barotrauma/BarotraumaShared/NLog.config
+++ b/Barotrauma/BarotraumaShared/NLog.config
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      throwExceptions="false">
+
+  <!-- Set the log level to 'Off' to turn off saving files for a particlar log. -->
+
+  <!-- This is the log level of server messages coming from other hosts when you have permission to recieve server logs. -->
+  <variable name="incomingServerLogLevel" value="Info"/>
+
+  <!-- This is the log level of the main log, for both client and server logs. -->
+  <variable name="mainLogLevel" value="Info"/>
+
+  <!-- This is the log level of the logs which are sent to the debug console and crash dump recorder. This should always either be Info or Debug, and should match mainLogLevel unless mainLogLevel is Off -->
+  <variable name="internalLogLevel" value="Info"/>
+
+
+
+  <targets async="true">
+    <!-- This target redirects NLog messages to the debug console in-game. Changing the layout will change how the messages are rendered in the console. -->
+    <target
+      xsi:type="DebugConsole"
+      name="debugconsole"
+      layout="${level:uppercase=true}: ${message} ${exception}${onexception: Exception\:
+      ${exception:format=message,method,stacktrace:maxInnerExceptionLevel=1:innerFormat=message,method}}"
+    />
+
+    <!-- This target is the main log for both the client and the server. It's set to only keep 10 log files total, and roll over when logs reach 1 MiB -->
+    <target
+      xsi:type="File"
+      name="mainlog"
+      layout="${longdate} - ${level:uppercase=true}: ${message}${onexception:${newline} EXCEPTION\: ${exception:format=ToString}}"
+      fileName="${basedir}/Logs/${gdc:item=project}/Barotrauma_${gdc:item=project}_[${cached:cached=true:Inner=${date:format=yyyy-MM-dd_hh.mm.ss}:clearCache=None}].log"
+      maxArchiveFiles="9"
+      archiveAboveSize="1048576"
+    />
+
+    <!-- This target is for incoming server logs from other hosts when this client has server log permissions. -->
+    <!-- Note: because of the way NLog archiver works in 4.7 we can't use maxArchiveFiles with the file name format used here. -->
+    <target
+      xsi:type="File"
+      name="incomingservertarget"
+      layout="${message}"
+      fileName="${basedir}/Logs/ReceivedLogs/${gdc:serverName} [${cached:cached=true:Inner=${date:format=yyyy-MM-dd_hh.mm.ss}:CacheKey=${gdc:serverName}}].log"
+      archiveAboveSize="1048576" 
+    />
+
+    <!-- This is an in-memory target which saves the last logs which occured. This is used to retrieve the last logs during a crash dump. -->
+    <target
+      xsi:type="Memory"
+      name="crashdumprecorder"
+      MaxLogsCount="50"
+      layout="${longdate} - ${level:uppercase=true}: ${message}${onexception:${newline} EXCEPTION\: ${exception:format=ToString}}"
+    />
+  </targets>
+  <rules>
+    <!-- This is just an example of what you can do if a file is set up to use NLog. In this case SoundChannel was instrumented with debug logging, and then here we filter to a particular set of sounds. -->
+    <logger name="Barotrauma.Sounds.SoundChannel" writeTo="mainlog" minLevel="Off">
+      <filters defaultAction='IgnoreFinal'>
+        <when condition="contains('${message}','Setting gain')" action="IgnoreFinal" />
+        <when condition="contains('${event-properties:item=debugSoundName}','Flow')" action="LogFinal" />
+      </filters>
+    </logger>
+
+    <!-- Default loggers. These three should always be here. -->
+    <logger name="IncomingServerLogger" writeTo="incomingservertarget" minlevel="${var:incomingServerLogLevel:default=Off}" final="true"/>
+    <logger name="*" writeTo="debugconsole,crashdumprecorder" minlevel="${var:internalLogLevel:default=Info}"/>
+    <logger name="*" writeTo="mainlog" minlevel="${var:mainLogLevel:default=Info}" />
+  </rules>
+</nlog>

--- a/Barotrauma/BarotraumaShared/SharedSource/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSettings.cs
@@ -704,7 +704,6 @@ namespace Barotrauma
         public List<string> CompletedTutorialNames { get; private set; }
 
         public static bool VerboseLogging { get; set; }
-        public static bool SaveDebugConsoleLogs { get; set; }
 
         public bool CampaignDisclaimerShown, EditorDisclaimerShown;
 
@@ -861,7 +860,6 @@ namespace Barotrauma
             RemoteContentUrl = doc.Root.GetAttributeString("remotecontenturl", RemoteContentUrl);
             WasGameUpdated = doc.Root.GetAttributeBool("wasgameupdated", WasGameUpdated);
             VerboseLogging = doc.Root.GetAttributeBool("verboselogging", VerboseLogging);
-            SaveDebugConsoleLogs = doc.Root.GetAttributeBool("savedebugconsolelogs", SaveDebugConsoleLogs);
             AutoUpdateWorkshopItems = doc.Root.GetAttributeBool("autoupdateworkshopitems", AutoUpdateWorkshopItems);
 
             LoadGeneralSettings(doc, resetLanguage);
@@ -902,7 +900,6 @@ namespace Barotrauma
                 new XAttribute("voicechatvolume", voiceChatVolume),
                 new XAttribute("voicechatcutoffprevention", VoiceChatCutoffPrevention),
                 new XAttribute("verboselogging", VerboseLogging),
-                new XAttribute("savedebugconsolelogs", SaveDebugConsoleLogs),
                 new XAttribute("submarineautosave", EnableSubmarineAutoSave),
                 new XAttribute("maxautosaves", MaximumAutoSaves),
                 new XAttribute("subeditorbackground", XMLExtensions.ColorToString(SubEditorBackgroundColor)),
@@ -1126,7 +1123,6 @@ namespace Barotrauma
                 new XAttribute("musicvolume", musicVolume),
                 new XAttribute("soundvolume", soundVolume),
                 new XAttribute("verboselogging", VerboseLogging),
-                new XAttribute("savedebugconsolelogs", SaveDebugConsoleLogs),
                 new XAttribute("submarineautosave", EnableSubmarineAutoSave),
                 new XAttribute("subeditorundobuffer", SubEditorMaxUndoBuffer),
                 new XAttribute("maxautosaves", MaximumAutoSaves),
@@ -1620,7 +1616,6 @@ namespace Barotrauma
             MasterServerUrl = "http://www.undertowgames.com/baromaster";
             WasGameUpdated = false;
             VerboseLogging = false;
-            SaveDebugConsoleLogs = false;
             AutoUpdateWorkshopItems = true;
         }
     }

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
@@ -275,7 +275,10 @@ namespace Barotrauma.Networking
 
         public ServerSettings(NetworkMember networkMember, string serverName, int port, int queryPort, int maxPlayers, bool isPublic, bool enableUPnP)
         {
-            ServerLog = new ServerLog(serverName);
+            ServerLog = new ServerLog();
+#if CLIENT
+            ServerLog.SetServerName(serverName);
+#endif
 
             Voting = new Voting();
 
@@ -461,7 +464,7 @@ namespace Barotrauma.Networking
         }
 
         [Serialize(true, true)]
-        public bool SaveServerLogs
+        public bool SendServerLogsToClients
         {
             get;
             private set;
@@ -503,19 +506,6 @@ namespace Barotrauma.Networking
             {
                 playstyleSelection = value;
                 ServerDetailsChanged = true;
-            }
-        }
-
-        [Serialize(800, true)]
-        private int LinesPerLogFile
-        {
-            get
-            {
-                return ServerLog.LinesPerFile;
-            }
-            set
-            {
-                ServerLog.LinesPerFile = value;
             }
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/BaroExceptionLayoutRenderer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/BaroExceptionLayoutRenderer.cs
@@ -1,0 +1,15 @@
+﻿using NLog;
+using NLog.LayoutRenderers;
+using System.Text;
+
+[LayoutRenderer("exception")]
+public class BaroExceptionLayoutRenderer : ExceptionLayoutRenderer
+{
+    protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+    {
+        StringBuilder stackTraceBuilder = new StringBuilder();
+        base.Append(stackTraceBuilder, logEvent);
+        stackTraceBuilder.Replace(AssemblyInfo.ProjectDir, "<DEV>");
+        builder.Append(stackTraceBuilder);
+    }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/BaroStackTraceLayoutRenderer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/BaroStackTraceLayoutRenderer.cs
@@ -1,0 +1,15 @@
+﻿using NLog;
+using NLog.LayoutRenderers;
+using System.Text;
+
+[LayoutRenderer("exception")]
+public class BaroStackTraceLayoutRenderer : StackTraceLayoutRenderer
+{
+    protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+    {
+        StringBuilder exceptionBuilder = new StringBuilder();
+        base.Append(exceptionBuilder, logEvent);
+        exceptionBuilder.Replace(AssemblyInfo.ProjectDir, "<DEV>");
+        builder.Append(exceptionBuilder);
+    }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/DebugConsoleTarget.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/DebugConsoleTarget.cs
@@ -1,0 +1,53 @@
+using NLog;
+using NLog.Targets;
+using Barotrauma;
+using Microsoft.Xna.Framework;
+using Barotrauma.Networking;
+
+[Target("DebugConsole")]
+public sealed class DebugConsoleTarget : TargetWithLayout
+{
+    public DebugConsoleTarget()
+    {
+    }
+
+    private Color GetColorForMessage(LogEventInfo logEvent)
+    {
+        if(logEvent.Level == LogLevel.Info)
+        {
+            return Color.Gray;
+        }
+        else if(logEvent.Level == LogLevel.Warn)
+        {
+            return Color.Yellow;
+        }
+        else if(logEvent.Level == LogLevel.Error)
+        {
+            return Color.Red;
+        }
+        return Color.Gray;
+    }
+
+    protected override void Write(LogEventInfo logEvent)
+    {
+        // Both DebugConsole and ServerLog capture anything logged the "old" way, and send it to an NLog logger.
+        // Since we're capturing messages from the NLog loggers, we don't want to double-log antyhing that we logged already.
+        var shouldLogToConsole = logEvent.LoggerName != DebugConsole.InternalLoggerName;
+#if SERVER
+        shouldLogToConsole = shouldLogToConsole && logEvent.LoggerName != ServerLog.InternalLoggerName;
+#endif
+        if (shouldLogToConsole)
+        {
+            string logMessage = this.Layout.Render(logEvent);
+
+            if (logEvent.Level == LogLevel.Error || logEvent.Level == LogLevel.Fatal)
+            {
+                DebugConsole.ThrowError(logMessage, logToNLog: false);
+            }
+            else
+            {
+                DebugConsole.NewMessage(logMessage, GetColorForMessage(logEvent), logToNLog: false);
+            }
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/LoggingUtils.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/Logging/LoggingUtils.cs
@@ -1,0 +1,230 @@
+using Barotrauma.IO;
+using Microsoft.Xna.Framework;
+using NLog;
+using NLog.LayoutRenderers;
+using NLog.Targets;
+using NLog.Targets.Wrappers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Barotrauma
+{
+    static class LoggingUtils
+    {
+        private static readonly string rootLogsDirectory = "Logs";
+        private static readonly string eventErrorLogDirectory = rootLogsDirectory + "\\EventErrors";
+
+        public static void InitializeLogging()
+        {
+#if DEBUG
+            GlobalDiagnosticsContext.Set("release", "Debug");
+#else
+            GlobalDiagnosticsContext.Set("release", "Release");
+#endif
+
+#if CLIENT
+            GlobalDiagnosticsContext.Set("project", "Client");
+#else
+            GlobalDiagnosticsContext.Set("project", "Server");
+#endif
+            GlobalDiagnosticsContext.Set("serverName", "UNKNOWN");
+
+            Target.Register("DebugConsole", typeof(DebugConsoleTarget));
+            LayoutRenderer.Register("exception", typeof(BaroExceptionLayoutRenderer));
+            LayoutRenderer.Register("stacktrace", typeof(BaroStackTraceLayoutRenderer));
+        }
+
+        public static void ShutdownLogging()
+        {
+            LogManager.Shutdown();
+        }
+
+        public static bool IsNLogConfigLoaded()
+        {
+            return LogManager.Configuration.AllTargets.Count > 0;
+        }
+
+        public static MemoryTarget GetCrashDumpRecorder()
+        {
+            Target target = LogManager.Configuration.FindTargetByName("crashdumprecorder");
+            if (target == null)
+            {
+                return null;
+            }
+
+            WrapperTargetBase wrapperTarget = target as WrapperTargetBase;
+
+            // Unwrap the target if necessary.
+            if (wrapperTarget == null)
+            {
+                return target as MemoryTarget;
+            }
+            else
+            {
+                return wrapperTarget.WrappedTarget as MemoryTarget;
+            }
+        }
+
+        public static void AppendLastLogMessages(StringBuilder sb)
+        {
+            var target = LoggingUtils.GetCrashDumpRecorder();
+            if (target == null)
+            {
+                sb.AppendLine("Unable to find or cast crashdumprecorder target! Check the NLog config. Defaulting to reading DebugConsole messages.");
+                try
+                {
+#if SERVER
+                    DebugConsole.Clear();
+#else
+                    DebugConsole.DequeueMessages();
+#endif
+                }
+                catch(Exception e)
+                {
+                    sb.AppendLine("Exception encountered while attempting to dequeue remaining messages: " + e.ToString());
+                }
+
+                for (int i = DebugConsole.Messages.Count - 1; i > 0 && i > DebugConsole.Messages.Count - 50; i--)
+                {
+                    sb.AppendLine("   " + DebugConsole.Messages[i].Time + " - " + DebugConsole.Messages[i].Text);
+                }
+            }
+            else
+            {
+                foreach (var message in target.Logs.Reverse())
+                {
+                    sb.AppendLine("   " + message);
+                }
+            }
+        }
+
+        public static void SetIncomingServerName(string serverName)
+        {
+            GlobalDiagnosticsContext.Set("serverName", ToolBox.RemoveInvalidFileNameChars(serverName));
+        }
+
+        public static void WriteEventErrorLog(string fileName, StringBuilder sb)
+        {
+            if(!Directory.Exists(eventErrorLogDirectory))
+            {
+                try
+                {
+                    Directory.CreateDirectory(eventErrorLogDirectory);
+                }
+                catch(Exception e)
+                {
+                    DebugConsole.ThrowError("Unable to create directory for saving event error log.", e);
+                    return;
+                }
+            }
+
+            var sanitizedFileName = ToolBox.RemoveInvalidFileNameChars(fileName);
+            string fileNameNoExt = Path.GetFileNameWithoutExtension(sanitizedFileName);
+            string fileExt = Path.GetExtension(sanitizedFileName);
+
+            var filePath = Path.Combine(eventErrorLogDirectory, sanitizedFileName);
+
+            var copyNumber = 1;
+            while (File.Exists(filePath))
+            {
+                filePath = Path.Combine(eventErrorLogDirectory, fileNameNoExt + " (" + copyNumber++ + ")" + fileExt);
+            }
+
+            try
+            {
+                File.WriteAllText(filePath, sb.ToString());
+            }
+            catch(Exception e)
+            {
+                DebugConsole.ThrowError("Unable to write event error log " + filePath, e);
+            }
+        }
+
+        private static string ToRelativePath(string fullPath, string basePath)
+        {
+            if(fullPath.StartsWith(basePath))
+            {
+                return fullPath.Substring(basePath.Length);
+            }
+            return fullPath;
+        }
+
+        private static void RecursiveDelete(System.IO.DirectoryInfo baseDir, string currentDir)
+        {
+            if (!baseDir.Exists)
+                return;
+
+            if (!Validation.CanWrite(baseDir.FullName))
+            {
+                DebugConsole.ThrowError("Can't delete directory (failed validation): " + ToRelativePath(baseDir.FullName, currentDir), logToNLog: false);
+                return;
+            }
+
+            var subDirectories = new System.IO.DirectoryInfo[0];
+            try
+            {
+                subDirectories = baseDir.GetDirectories();
+            }
+            catch(Exception e)
+            {
+                DebugConsole.ThrowError("Unable to list subdirectories in directory " + ToRelativePath(baseDir.FullName, currentDir) + ": " + e.Message, logToNLog: false);
+            }
+
+            foreach (var dir in subDirectories)
+            {
+                RecursiveDelete(dir, currentDir);
+            }
+
+            var files = new System.IO.FileInfo[0];
+            try
+            {
+                files = baseDir.GetFiles();
+            }
+            catch(Exception e)
+            {
+                DebugConsole.ThrowError("Unable to list files in directory " + ToRelativePath(baseDir.FullName, currentDir) + ": " + e.Message, logToNLog: false);
+            }
+            foreach (var file in files)
+            {
+                try
+                {
+                    file.Delete();
+                    DebugConsole.NewMessage("Deleted file " + ToRelativePath(file.FullName, currentDir), color: Color.Green, logToNLog: false);
+                }
+                catch (Exception e)
+                {
+                    DebugConsole.ThrowError("Unable to delete file " + ToRelativePath(file.FullName, currentDir) + ": " + e.Message, logToNLog: false);
+                }
+            }
+
+            try
+            {
+                baseDir.Delete(true);
+                DebugConsole.NewMessage("Deleted directory " + ToRelativePath(baseDir.FullName, currentDir), color: Color.Green, logToNLog: false);
+            }
+            catch (Exception e)
+            {
+                DebugConsole.ThrowError("Unable to delete directory " + ToRelativePath(baseDir.FullName, currentDir) + ": " + e.Message, logToNLog: false);
+            }
+        }
+
+        public static void DeleteLogsDirectory()
+        {
+            LogManager.DisableLogging();
+            LogManager.Flush();
+
+            var currentDir = Directory.GetCurrentDirectory();
+
+            System.IO.DirectoryInfo baseDir = new System.IO.DirectoryInfo(rootLogsDirectory);
+
+            DebugConsole.NewMessage("Attempting to delete logging directory " + baseDir.FullName, Color.White, logToNLog: false);
+
+            RecursiveDelete(baseDir, currentDir);
+
+            LogManager.EnableLogging();
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/config.xml
+++ b/Barotrauma/BarotraumaShared/config.xml
@@ -7,7 +7,6 @@
   musicvolume="0.5"
   soundvolume="0.5"
   verboselogging="false"
-  savedebugconsolelogs="false"
   enablesplashscreen="true"
   usesteammatchmaking="true"
   quickstartsub="Humpback"

--- a/Barotrauma/BarotraumaShared/serversettings.xml
+++ b/Barotrauma/BarotraumaShared/serversettings.xml
@@ -23,7 +23,7 @@
   startwhenclientsready="False"
   startwhenclientsreadyratio="0.8"
   allowspectating="True"
-  saveserverlogs="True"
+  sendserverlogstoclients="True"
   allowragdollbutton="True"
   allowfiletransfers="True"
   voicechatenabled="True"


### PR DESCRIPTION
### Preamble
This is a change I worked on to help me debug issues. I've found it to be quite useful as an additional tool to the regular debugger, and it has a lot of potential to help with debugging issues from end users without having to have them use a debug build or know how to use a debuggger. I've cleaned up the code to a point where I believe it is "production ready" and so I decided to put up a pull request. Although I believe this has a lot of merits over the current logging system, the Barotrauma team can of course decide it's not necessary. I have put it up as a pull request in case it provides a value-add for the main repo. 

### Original commit message:
This includes changes to start utilizing NLog as the logging backend. Included
is instrumentation to both send existing logging from DebugConsole to the NLog
log, as well as new messages made with NLog to the DebugConsole.

This has a number of advantages, some of which are outlined below:
- Logging available from very early on in the program, can log initialization.
- Much better handling of multi-threaded logging
- Finer control of changing log level on individual components; excellent for
  debugging.
- Much more resilient; don't have to worry about log files not being saved on
  crashes.
- Integrated replacement of full path in exceptions/stacktraces with \<DEV\>. No
  need to explicitly call CleanupStackTrace on every exception.

Notable changes:
- All log settings including size, save names, save location, and log levels
  are controlled by an NLog.config file. The VerboseLogging setting in the
  main config file has been retained for the time being.
- Logs are now put in a 'Logs' folder, with 'Client', 'Server', and
  'ReceivedLogs' sub-folders.
- Server logs always save by default now. The setting to save server logs is
  instead changed to toggle sending the server log messages to clients.
- For server and client logs, logs automatically roll over at a certain size,
  and will be removed if more than a specified number of logs exist. This keeps
  the log folders from becoming too bloated, and is of course fully
  configurable.

Translation requirements:
- "ServerSettingsSaveLogs" has been changed to "ServerSettingSendLogs" and
  needs updated translated text. "Save server logs" should change to "Send
  server logs to clients" or similar.
- Not currently translated, but GameMain::ShowNLogConfigFailedToLoadMessage
  could be a potential translation candidate. ServerSource/Program::Main also
  has the same string. 
  _(Note, on further inspection this message comes before language settings are loaded, so probably not a candidate)_