### PR TITLE
Use a sane step value for respawn duration.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
@@ -500,8 +500,8 @@ namespace Barotrauma.Networking
 
             CreateLabeledSlider(roundsTab, "ServerSettingsRespawnInterval", out slider, out sliderLabel);
             string intervalLabel = sliderLabel.Text;
-            slider.Step = 0.05f;
             slider.Range = new Vector2(10.0f, 600.0f);
+            slider.StepValue = 10.0f;
             GetPropertyData("RespawnInterval").AssignGUIComponent(slider);
             slider.OnMoved = (GUIScrollBar scrollBar, float barScroll) =>
             {


### PR DESCRIPTION
The respawn duration slider is annoying in that it gives random times
like 3m 7s as the steps. This changes the step for the respawn
duration to be 10 seconds per step. Would have liked for it to be
something more like 15 or 30, but with the way the slider is
programmed that leads to off numbers like 9m 55 seconds since the
minimum is 10 s. Tested with the smallest horizontal resolution and
it's still able to select at 10s intervals fine.