### PR TITLE
Improve handling of redirected output on server code.

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
@@ -73,17 +73,27 @@ namespace Barotrauma
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            int consoleWidth = Console.WindowWidth;
-            if (consoleWidth < 5) consoleWidth = 5;
-            int consoleHeight = Console.WindowHeight;
-            if (consoleHeight < 5) consoleHeight = 5;
+            int consoleWidth = 0;
+            int consoleHeight = 0;
+
+            if(!Console.IsOutputRedirected)
+            {
+                consoleWidth = Console.WindowWidth;
+                if (consoleWidth < 5) consoleWidth = 5;
+                consoleHeight = Console.WindowHeight;
+                if (consoleHeight < 5) consoleHeight = 5;
+            }
 
             //dequeue messages
             lock (queuedMessages)
             {
                 if (queuedMessages.Count > 0)
                 {
-                    Console.CursorLeft = 0;
+
+                    if (!Console.IsOutputRedirected)
+                    {
+                        Console.CursorLeft = 0;
+                    }
                     while (queuedMessages.Count > 0)
                     {
                         ColoredText msg = queuedMessages.Dequeue();
@@ -102,15 +112,21 @@ namespace Barotrauma
 
                         if (msg.IsCommand) commandMemory.Add(msgTxt);
 
-                        int paddingLen = consoleWidth - (msg.Text.Length % consoleWidth)-1;
-                        msgTxt += new string(' ', paddingLen>0 ? paddingLen : 0);
+                        if(!Console.IsOutputRedirected)
+                        {
+                            int paddingLen = consoleWidth - (msg.Text.Length % consoleWidth) - 1;
+                            msgTxt += new string(' ', paddingLen > 0 ? paddingLen : 0);
 
-                        Console.ForegroundColor = XnaToConsoleColor.Convert(msg.Color);
+                            Console.ForegroundColor = XnaToConsoleColor.Convert(msg.Color);
+                        }
                         Console.WriteLine(msgTxt);
 
                         if (sw.ElapsedMilliseconds >= maxTime) { break; }
                     }
-                    RewriteInputToCommandLine(input);
+                    if(!Console.IsOutputRedirected)
+                    {
+                        RewriteInputToCommandLine(input);
+                    }
                 }
                 if (Messages.Count > MaxMessages)
                 {
@@ -118,73 +134,78 @@ namespace Barotrauma
                 }
             }
 
-            //read player input
-            bool rewriteInput = false;
-            while (Console.KeyAvailable)
+            // No good way to display input when console output is redirected, and can't read from redirected input using KeyAvailable.
+            if(!Console.IsOutputRedirected && !Console.IsInputRedirected)
             {
-                if (sw.ElapsedMilliseconds >= maxTime)
+                //read player input
+                bool rewriteInput = false;
+                while (Console.KeyAvailable)
                 {
-                    rewriteInput = false;
-                    break;
-                }
-                rewriteInput = true;
-                ConsoleKeyInfo key = Console.ReadKey(true);
-                switch (key.Key)
-                {
-                    case ConsoleKey.Enter:
-                        lock (QueuedCommands)
-                        {
-                            QueuedCommands.Add(input);
-                        }
-                        input = "";
-                        memoryIndex = -1;
+                    if (sw.ElapsedMilliseconds >= maxTime)
+                    {
+                        rewriteInput = false;
                         break;
-                    case ConsoleKey.Backspace:
-                        if (input.Length > 0) input = input.Substring(0, input.Length - 1);
-                        memoryIndex = -1;
-                        break;
-                    case ConsoleKey.LeftArrow:
-                        input = AutoComplete(input, -1);
-                        break;
-                    case ConsoleKey.RightArrow:
-                        input = AutoComplete(input, 1);
-                        break;
-                    case ConsoleKey.UpArrow:
-                        memoryIndex--;
-                        if (memoryIndex < 0) memoryIndex = commandMemory.Count - 1;
-                        if (memoryIndex >= commandMemory.Count) memoryIndex = commandMemory.Count - 1;
-                        if (memoryIndex >= 0)
-                        {
-                            input = commandMemory[memoryIndex];
-                        }
-                        break;
-                    case ConsoleKey.DownArrow:
-                        memoryIndex++;
-                        if (memoryIndex < 0) memoryIndex = 0;
-                        if (memoryIndex >= commandMemory.Count) memoryIndex = 0;
-                        if (commandMemory.Count>0)
-                        {
-                            input = commandMemory[memoryIndex];
-                        }
-                        break;
-                    case ConsoleKey.Tab:
-                        if (input.Length > 0)
-                        {
-                            input = AutoComplete(input, 0);
+                    }
+                    rewriteInput = true;
+                    ConsoleKeyInfo key = Console.ReadKey(true);
+                    switch (key.Key)
+                    {
+                        case ConsoleKey.Enter:
+                            lock (QueuedCommands)
+                            {
+                                QueuedCommands.Add(input);
+                            }
+                            input = "";
                             memoryIndex = -1;
-                        }
-                        break;
-                    default:
-                        if (key.KeyChar != 0)
-                        {
-                            input += key.KeyChar;
+                            break;
+                        case ConsoleKey.Backspace:
+                            if (input.Length > 0) input = input.Substring(0, input.Length - 1);
+                            ResetAutoComplete();
                             memoryIndex = -1;
-                        }
-                        ResetAutoComplete();
-                        break;
+                            break;
+                        case ConsoleKey.LeftArrow:
+                            input = AutoComplete(input, -1);
+                            break;
+                        case ConsoleKey.RightArrow:
+                            input = AutoComplete(input, 1);
+                            break;
+                        case ConsoleKey.UpArrow:
+                            memoryIndex--;
+                            if (memoryIndex < 0) memoryIndex = commandMemory.Count - 1;
+                            if (memoryIndex >= commandMemory.Count) memoryIndex = commandMemory.Count - 1;
+                            if (memoryIndex >= 0)
+                            {
+                                input = commandMemory[memoryIndex];
+                            }
+                            break;
+                        case ConsoleKey.DownArrow:
+                            memoryIndex++;
+                            if (memoryIndex < 0) memoryIndex = 0;
+                            if (memoryIndex >= commandMemory.Count) memoryIndex = 0;
+                            if (commandMemory.Count>0)
+                            {
+                                input = commandMemory[memoryIndex];
+                            }
+                            break;
+                        case ConsoleKey.Tab:
+                            if (input.Length > 0)
+                            {
+                                input = AutoComplete(input, 0);
+                                memoryIndex = -1;
+                            }
+                            break;
+                        default:
+                            if (key.KeyChar != 0)
+                            {
+                                input += key.KeyChar;
+                                memoryIndex = -1;
+                            }
+                            ResetAutoComplete();
+                            break;
+                    }
                 }
+                if (rewriteInput) { RewriteInputToCommandLine(input); }
             }
-            if (rewriteInput) { RewriteInputToCommandLine(input); }
 
             sw.Stop();
         }

--- a/Barotrauma/BarotraumaServer/ServerSource/GameMain.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/GameMain.cs
@@ -361,7 +361,7 @@ namespace Barotrauma
                 }
 
 #if !DEBUG
-                if (Server?.OwnerConnection == null && !Console.IsOutputRedirected)
+                if (Server?.OwnerConnection == null)
                 {
                     DebugConsole.UpdateCommandLine((int)(Timing.Accumulator * 800));
                 }

--- a/Barotrauma/BarotraumaServer/ServerSource/Program.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Program.cs
@@ -42,6 +42,14 @@ namespace Barotrauma
 #endif
             Console.WriteLine("Barotrauma Dedicated Server " + GameMain.Version +
                 " (" + AssemblyInfo.BuildString + ", branch " + AssemblyInfo.GitBranch + ", revision " + AssemblyInfo.GitRevision + ")");
+            if(Console.IsOutputRedirected)
+            {
+                Console.WriteLine("Output redirection detected; colored text and command input will be disabled.");
+            }
+            if(Console.IsInputRedirected)
+            {
+                Console.WriteLine("Redirected input is detected but is not supported by this application. Input will be ignored.");
+            }
 
             string executableDir = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
             Directory.SetCurrentDirectory(executableDir);
@@ -152,7 +160,11 @@ namespace Barotrauma
             }
 
             string crashReport = sb.ToString();
-            Console.ForegroundColor = ConsoleColor.Red;
+
+            if (!Console.IsOutputRedirected)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+            }
             Console.Write(crashReport);
 
             File.WriteAllText(filePath,sb.ToString());


### PR DESCRIPTION
Rather than not outputting any text when output has been redirected, properly
wraps calls to unsupported Console properties when using redirected output.
This enables piping output to tee or docker logs without all the logs missing.
Command input is disabled for both redirected output and redirected input
scenarios.

Also, a small bugfix to reset the autocomplete on backspace being hit was made,
which enables proper autocomplete when removing characters. For example, if I
had typed "exi", but hit backspace twice, I would still only get "exit" as an
autocomplete suggestion. Adding ResetAutoComplete(); to the backspace handler
fixes this.

Fixes #2973