### PR TITLE
Enable nvidia optimus on Windows.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Program.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Program.cs
@@ -54,6 +54,7 @@ namespace Barotrauma
             executableDir = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
             Directory.SetCurrentDirectory(executableDir);
             SteamManager.Initialize();
+            EnableNvOptimus();
             Game = new GameMain(args);
             Game.Run();
             Game.Dispose();
@@ -263,6 +264,24 @@ namespace Barotrauma
                     " if you'd like to help fix this bug, you may post it on Barotrauma's GitHub issue tracker: https://github.com/Regalis11/Barotrauma/issues/", filePath);
             }
         }
+        
+        private static void EnableNvOptimus()
+        {
+#if WINDOWS && X64
+            try
+            {
+                // We force load nvapi64.dll so nvidia gives us the dedicated GPU on optimus laptops.
+                // This is not a method for getting optimus that is documented by nvidia, but it works, so...
+                NativeLibrary.Load("nvapi64.dll");
+            }
+            catch (Exception)
+            {
+                // If this fails whatever, probably not an nvidia user. No harm done.
+            }
+#endif
+        }
+        
     }
 #endif
+    
         }


### PR DESCRIPTION
While nvidia's only documented way for end applications to enable optimus appears to be exporting the NvOptimusEnablement symbol (not easily doable with a C# project...), it turns out that `LoadLibrary("nvapi64.dll")` before initializing any rendering stuff also works!

This isn't technically supported probably but hey, better than nothing?

For what it's worth, I've been using this [in my own project](https://github.com/space-wizards/RobustToolbox/blob/8f870403d250482ae388d7277346c7733e7a8952/Robust.Client/Graphics/Clyde/Clyde.DllMap.cs#L14-L28) with no reports of problems yet. Seems to work pretty smoothly.

This should fix problems like #2688 without requiring users to manually add an application override for Barotrauma.exe.

[Relevant StackOverflow post](https://stackoverflow.com/a/46749111/4678631)