### PR TITLE
Fix missing parens in TraitorMission.cs

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/Traitors/TraitorMission.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Traitors/TraitorMission.cs
@@ -249,7 +249,7 @@ namespace Barotrauma
                 {
                     return;
                 }
-                if (Traitors.Values.Any(traitor => (traitor.Character?.IsDead ?? true) || traitor.Character.Removed))
+                if (Traitors.Values.Any(traitor => traitor.Character is null || traitor.Character.IsDead || traitor.Character.Removed))
                 {
                     Traitors.Values.ForEach(traitor => traitor.UpdateCurrentObjective("", Identifier));
                     pendingObjectives.Clear();

--- a/Barotrauma/BarotraumaServer/ServerSource/Traitors/TraitorMission.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Traitors/TraitorMission.cs
@@ -249,7 +249,7 @@ namespace Barotrauma
                 {
                     return;
                 }
-                if (Traitors.Values.Any(traitor => traitor.Character?.IsDead ?? true || traitor.Character.Removed))
+                if (Traitors.Values.Any(traitor => (traitor.Character?.IsDead ?? true) || traitor.Character.Removed))
                 {
                     Traitors.Values.ForEach(traitor => traitor.UpdateCurrentObjective("", Identifier));
                     pendingObjectives.Clear();


### PR DESCRIPTION
While reading through the traitor code I noticed this small bug. According to https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/expressions#operator-precedence-and-associativity, the `||` operator has a higher precedence than the `??` operator, so it's evaluated first. This means the current boolean expression is the same as
```cs
traitor.Character?.IsDead ?? (true || traitor.Character.Removed)
```
which in turn is
```cs
traitor.Character?.IsDead ?? true
```
Cutting out the removed check. Adding the brackets in corrects the evaluation order.



Then I thought "better yet, make it clear what's actually being checked" and separated it out to 3 parts.