### PR TITLE
Added KeepCorpse bool to HuskAfflictionPrefab

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
@@ -183,8 +183,11 @@ namespace Barotrauma
                 yield return CoroutineStatus.Success;
             }
 
-            character.Enabled = false;
-            Entity.Spawner.AddToRemoveQueue(character);
+            if (Prefab is AfflictionPrefabHusk { KeepCorpse: false })
+            {
+                character.Enabled = false;
+                Entity.Spawner.AddToRemoveQueue(character);
+            }
 
             string huskedSpeciesName = GetHuskedSpeciesName(character.SpeciesName, Prefab as AfflictionPrefabHusk);
             CharacterPrefab prefab = CharacterPrefab.FindBySpeciesName(huskedSpeciesName);
@@ -222,18 +225,21 @@ namespace Barotrauma
                 }
             }
 
-            if (character.Inventory != null && husk.Inventory != null)
+            if (Prefab is AfflictionPrefabHusk { KeepCorpse: false })
             {
-                if (character.Inventory.Capacity != husk.Inventory.Capacity)
+                if (character.Inventory != null && husk.Inventory != null)
                 {
-                    string errorMsg = "Failed to move items from the source character's inventory into a husk's inventory (inventory sizes don't match)";
-                    DebugConsole.ThrowError(errorMsg);
-                    GameAnalyticsManager.AddErrorEventOnce("AfflictionHusk.CreateAIHusk:InventoryMismatch", GameAnalyticsSDK.Net.EGAErrorSeverity.Error, errorMsg);
-                    yield return CoroutineStatus.Success;
-                }
-                for (int i = 0; i < character.Inventory.Capacity && i < husk.Inventory.Capacity; i++)
-                {
-                    character.Inventory.GetItemsAt(i).ForEachMod(item => husk.Inventory.TryPutItem(item, i, true, false, null));
+                    if (character.Inventory.Capacity != husk.Inventory.Capacity)
+                    {
+                        string errorMsg = "Failed to move items from the source character's inventory into a husk's inventory (inventory sizes don't match)";
+                        DebugConsole.ThrowError(errorMsg);
+                        GameAnalyticsManager.AddErrorEventOnce("AfflictionHusk.CreateAIHusk:InventoryMismatch", GameAnalyticsSDK.Net.EGAErrorSeverity.Error, errorMsg);
+                        yield return CoroutineStatus.Success;
+                    }
+                    for (int i = 0; i < character.Inventory.Capacity && i < husk.Inventory.Capacity; i++)
+                    {
+                        character.Inventory.GetItemsAt(i).ForEachMod(item => husk.Inventory.TryPutItem(item, i, true, false, null));
+                    }
                 }
             }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
@@ -94,6 +94,7 @@ namespace Barotrauma
             SendMessages = element.GetAttributeBool("sendmessages", true);
             CauseSpeechImpediment = element.GetAttributeBool("causespeechimpediment", true);
             NeedsAir = element.GetAttributeBool("needsair", false);
+            KeepCorpse = element.GetAttributeBool("keepcorpse", false);
         }
 
         // Use any of these to define which limb the appendage is attached to.
@@ -109,6 +110,7 @@ namespace Barotrauma
         public readonly bool SendMessages;
         public readonly bool CauseSpeechImpediment;
         public readonly bool NeedsAir;
+        public readonly bool KeepCorpse;
     }
 
     class AfflictionPrefab : IPrefab, IDisposable, IHasUintIdentifier


### PR DESCRIPTION
To my knowledge is currently no sure-fire way for modders to spawn one character on the death of another without overriding existing characters. Overriding existing characters is usually not recommended, as it can lead to conflicts with other mods (or new content). This makes it hard to for instance make a parasitic affliction where an infected character spawns a new parasite when the host dies.

This small PR adds the KeepCorpse bool to the HuskAfflictionPrefab. If this bool is set to true, instead of copying the inventory of the original character over to a newly spawned husk character, the corpse of the old character is not removed and the husk character is simply spawned alongside it. 
