### PR TITLE
Allow Afflictions to use StatusEffects of type OnDeath on afflicted Characters

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Threading;
 using System.Xml.Linq;
 
 namespace Barotrauma
@@ -25,7 +23,7 @@ namespace Barotrauma
 
         private bool subscribedToDeathEvent = false;
 
-        private bool staySubscribed = false;
+        private bool ringedThatDamnedBell = false;
 
         [Serialize(0f, true), Editable]
         public virtual float Strength
@@ -279,14 +277,14 @@ namespace Barotrauma
             // Don't use the property, because it's virtual and some afflictions like husk overload it for external use.
             _strength = MathHelper.Clamp(_strength, 0.0f, Prefab.MaxStrength);
 
-            staySubscribed = false;
+            ringedThatDamnedBell = false;
             foreach (StatusEffect statusEffect in currentEffect.StatusEffects)
             {
                 ApplyStatusEffect(statusEffect, deltaTime, characterHealth, targetLimb);
             }
 
-            // Unsubscribe if no OnDeath statuseffect has been found in currentEffect
-            if (!staySubscribed && subscribedToDeathEvent)
+            // Unsubscribe if no OnDeath statuseffect has been found when looping over statuseffects in currenteffect
+            if (!ringedThatDamnedBell && subscribedToDeathEvent)
             {
                 if (character != null) {
                     character.OnDeath -= ApplyStatusEffectsOnDeath;
@@ -324,7 +322,7 @@ namespace Barotrauma
                         character.OnDeath += ApplyStatusEffectsOnDeath;
                         subscribedToDeathEvent = true;
                     }
-                    staySubscribed = true;
+                    ringedThatDamnedBell = true;
                 }
                 else
                 {

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
@@ -353,12 +353,11 @@ namespace Barotrauma
             if (currentEffect == null) { return; }
             foreach (StatusEffect statusEffect in currentEffect.StatusEffects)
             {
-                // Apply OnDeath statuseffects on target character (afflicted)
+                // Apply OnDeath statuseffects on the afflicted character
                 if (statusEffect.type == ActionType.OnDeath && statusEffect.HasTargetType(StatusEffect.TargetType.Character))
                 {
                     statusEffect.Apply(ActionType.OnDeath, 1.0f, character, character);
-                }                
-                //statusEffect.Apply(ActionType.OnActive, deltaTime, characterHealth.Character, characterHealth.Character);
+                }             
             }
         }
 


### PR DESCRIPTION
## Functional additions
This PR includes changes to Affliction.cs to allow afflictions to properly use StatusEffects of type `OnDeath`.

This adds a number of functionalities that can not be done with the current affliction system or HuskAfflictions. To give a few ideas:

- Spawn a creature on the death of an afflicted character without removing the corpse
- Spawn multiple creatures on the death of an afflicted character
- Spawn different characters or a different number of characters depending on the strength of the affliction
- Change inventory items upon dying with a certain affliction applied

As an example, the following code is now usable to spawn one crawler if an afflicted character dies with a strength below 50, and two crawlers if the character dies with a strength above 50:
```xml
	<Affliction
		name="spawnondeath"
		identifier="spawnondeath"
		type="resistance"
		isbuff="true"
		showiconthreshold="1000"
		showicontoothersthreshold="1000"
		showinhealthscannerthreshold="0"
		maxstrength="100"
		limbspecific="false">

		<Effect minstrength="0" maxstrength="50" strengthchange="1">
			<StatusEffect type="OnDeath" target="Character" targetlimb="Head">
				<SpawnCharacter speciesname="Crawler" count="1"/>
			</StatusEffect>
		</Effect>
		<Effect minstrength="50" maxstrength="100" strengthchange="1">
			<StatusEffect type="OnDeath" target="Character" targetlimb="Head">
				<SpawnCharacter speciesname="Crawler" count="2"/>
			</StatusEffect>
		</Effect>
	</Affliction>
```

## Recap of code changes

The first change made is an addition in `ApplyStatusEffect`. Here StatusEffects that target `Character` and are of type `OnDeath`, are not applied immediately. Instead, the `OnDeathHandler OnDeath` of the character is subscribed to a new method named `ApplyStatusEffectsOnDeath`, provided that the character is not already subscribed.

https://github.com/Working-Joe/Barotrauma/blob/c77ef444262e6263a016a5e8d8b517bfc577fe67/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs#L316-L330

Thus, when the subscribed character dies it calls `ApplyStatusEffectsOnDeath`. `ApplyStatusEffectsOnDeath` simply applies all StatusEffects from the current effect that both target `Character` and are of type `OnDeath`. The StatusEffect is not applied if the affliction is removed by reducing the strength to zero, or if the character is removed.

https://github.com/Working-Joe/Barotrauma/blob/c77ef444262e6263a016a5e8d8b517bfc577fe67/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs#L349-L362

Lastly, some code was added to the loop that applies all StatusEffects of the current effect. This code unsubscribes the character's `OnDeathHandler` if the affliction strength changes to an effect without any statuseffects of type OnDeath. This is done by using a variable that starts as false and is set to true if an affliction of type `OnDeath` is encountered in `ApplyStatusEffect`. The `OnDeathHandler` is then unsubscribed if it was subscribed and this variable is false (as no afflictions of type `OnDeath` were found in the current effect).

https://github.com/Working-Joe/Barotrauma/blob/c77ef444262e6263a016a5e8d8b517bfc577fe67/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs#L280-L293

