### PR TITLE
Allow player controlled monsters to eat bodies.

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -2258,7 +2258,7 @@ namespace Barotrauma
             {
                 SelectCharacter(FocusedCharacter);
             }
-            else if (FocusedCharacter != null && IsKeyHit(InputType.Grab) && FocusedCharacter.CanBeDragged && CanInteractMonster)
+            else if (FocusedCharacter != null && FocusedCharacter.IsDead && IsKeyHit(InputType.Grab) && FocusedCharacter.CanBeDragged && CanInteractMonster)
             {
                 SelectCharacter(FocusedCharacter);
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -395,6 +395,11 @@ namespace Barotrauma
             get { return AllowInput && IsHumanoid && !LockHands && !Removed && !IsIncapacitated; }
         }
 
+        public bool CanInteractMonster
+        {
+            get { return AllowInput && !IsHumanoid && Params.CanEat && !IsIncapacitated; }
+        }
+
         public Vector2 CursorPosition
         {
             get { return cursorPosition; }
@@ -2176,7 +2181,7 @@ namespace Barotrauma
                 {
                     if (findFocusedTimer <= 0.0f || Screen.Selected == GameMain.SubEditorScreen)
                     {
-                        FocusedCharacter = CanInteract ? FindCharacterAtPosition(mouseSimPos) : null;
+                        FocusedCharacter = CanInteract || CanInteractMonster ? FindCharacterAtPosition(mouseSimPos) : null;
                         if (FocusedCharacter != null && !CanSeeCharacter(FocusedCharacter)) { FocusedCharacter = null; }
                         float aimAssist = GameMain.Config.AimAssistAmount * (AnimController.InWater ? 1.5f : 1.0f);
                         if (HeldItems.Any(it => it?.GetComponent<Wire>()?.IsActive ?? false))
@@ -2250,6 +2255,10 @@ namespace Barotrauma
                 DeselectCharacter();
             }
             else if (FocusedCharacter != null && IsKeyHit(InputType.Grab) && FocusedCharacter.CanBeDragged && CanInteract)
+            {
+                SelectCharacter(FocusedCharacter);
+            }
+            else if (FocusedCharacter != null && IsKeyHit(InputType.Grab) && FocusedCharacter.CanBeDragged && CanInteractMonster)
             {
                 SelectCharacter(FocusedCharacter);
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Params/CharacterParams.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Params/CharacterParams.cs
@@ -64,6 +64,9 @@ namespace Barotrauma
         [Serialize("waterblood", true), Editable]
         public string BleedParticleWater { get; private set; }
 
+        [Serialize(false, true, description: "Can the creature eat bodies? Used by player controlled creatures to allow them to eat."), Editable]
+        public bool CanEat { get; set; }
+
         [Serialize(10f, true, description: "How effectively/easily the character eats other characters. Affects the forces, the amount of particles, and the time required before the target is eaten away"), Editable(MinValueFloat = 1, MaxValueFloat = 1000, ValueStep = 1)]
         public float EatingSpeed { get; set; }
 


### PR DESCRIPTION
This PR request implements a few changes that allow monsters to grab dead bodies by pressing G. This will cause them to start eating the body, and they can choose to stop eating the body by pressing G again.

In order to be able to eat a body, the creature you are playing as must have a new boolean parameter set to true: "CanEat". If it is set to true, you can grab and eat bodies while controlling the monster.

Based off of my own suggestion https://github.com/Regalis11/Barotrauma/discussions/4763.