### PR TITLE
Allow the husk infection to carry player control over to the husk.

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -87,14 +87,19 @@ namespace Barotrauma
             }
         }
 
+        /// <summary>
+        /// Returns the client that is currently controlling the character
+        /// </summary>
         public Client GetCharacterClient
         {
             get
             {
-                dynamic controller = null;
+                Client controller = null;
 #if SERVER
+                // Loop through every client in the server
                 foreach (Client c in GameMain.Server.ConnectedClients)
                 {
+                    // If the client's current controlled character is this one, then this character's controller is that client
                     if (c.Character == this)
                     {
                         controller = c;

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -87,6 +87,26 @@ namespace Barotrauma
             }
         }
 
+        public Client GetCharacterClient
+        {
+            get
+            {
+                dynamic controller = null;
+#if SERVER
+                foreach (Client c in GameMain.Server.ConnectedClients)
+                {
+                    if (c.Character == this)
+                    {
+                        controller = c;
+                    }
+
+                }
+#endif
+                return controller;
+            }
+
+        }
+
         /// <summary>
         /// Is the character controlled by another human player (should always be false in single player)
         /// </summary>

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
@@ -211,30 +211,28 @@ namespace Barotrauma
                 husk.Info.Character = husk;
                 husk.Info.TeamID = CharacterTeamType.None;
             }
-#if CLIENT
+            var CanControlCharacter = false;
             if (Prefab is AfflictionPrefabHusk huskPrefab)
             {
-                if (originalCharacter == Character.Controlled && huskPrefab.ControlHusk)
-                {
-                    if (huskPrefab.ControlException.None(s => s.Equals(originalSpecies, StringComparison.OrdinalIgnoreCase)) || IgnoreHuskExceptions == true)
-                    {
-                        Character.Controlled = husk;
-                    }
-                }
+                // Check if this specific husk infection allows the player to control their husk, then check if their species DOESN'T appear in the exception list or if the server is currently ignoring exceptions altogether.
+                if (huskPrefab.ControlHusk && (huskPrefab.ControlException.None(s => s.Equals(originalSpecies, StringComparison.OrdinalIgnoreCase)) || IgnoreHuskExceptions)) { CanControlCharacter = true; }
             }
+            if (CanControlCharacter)
+            // If a player was controlling the character that just died to the husk infection, set their controlled character to the husk.
+            {
+#if CLIENT
+                if (originalCharacter == Character.Controlled)
+                {
+                    Character.Controlled = husk; 
+                }
 #endif
 #if SERVER
-            if (Prefab is AfflictionPrefabHusk huskPrefab)
-            {
-                if (huskController != null && huskPrefab.ControlHusk)
+                if (huskController != null)
                 {
-                    if (huskPrefab.ControlException.None(s => s.Equals(originalSpecies, StringComparison.OrdinalIgnoreCase)) || IgnoreHuskExceptions == true)
-                    {
-                        GameMain.Server.SetClientCharacter(huskController, husk);
-                    }
+                    GameMain.Server.SetClientCharacter(huskController, husk);
                 }
-            }
 #endif
+            }
 
             foreach (Limb limb in husk.AnimController.Limbs)
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
@@ -94,6 +94,8 @@ namespace Barotrauma
             SendMessages = element.GetAttributeBool("sendmessages", true);
             CauseSpeechImpediment = element.GetAttributeBool("causespeechimpediment", true);
             NeedsAir = element.GetAttributeBool("needsair", false);
+            ControlHusk = element.GetAttributeBool("controlhusk", true);
+            ControlException = element.GetAttributeStringArray("controlexception", new string[0] { }, trim: true, convertToLowerInvariant: true);
         }
 
         // Use any of these to define which limb the appendage is attached to.
@@ -109,6 +111,8 @@ namespace Barotrauma
         public readonly bool SendMessages;
         public readonly bool CauseSpeechImpediment;
         public readonly bool NeedsAir;
+        public readonly bool ControlHusk;
+        public readonly string[] ControlException;
     }
 
     class AfflictionPrefab : IPrefab, IDisposable, IHasUintIdentifier

--- a/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
@@ -720,6 +720,18 @@ namespace Barotrauma
                 };
             }, isCheat: true));
 
+            commands.Add(new Command("ignorehuskexceptions", "ignorehuskexceptions: Ignore any control exceptions for all husk infections).", (string[] args) =>
+            {
+                AfflictionHusk.IgnoreHuskExceptions = true;
+                NewMessage("All husk exceptions ignored", Color.Red);
+            }, isCheat: true));
+
+            commands.Add(new Command("restorehuskexceptions", "restorehuskexceptions: Restore all control exceptions for all husk infections).", (string[] args) =>
+            {
+                AfflictionHusk.IgnoreHuskExceptions = false;
+                NewMessage("All husk exceptions no longer ignored", Color.Red);
+            }, isCheat: true));
+
             commands.Add(new Command("freecamera|freecam", "freecam: Detach the camera from the controlled character.", (string[] args) =>
             {
 #if CLIENT


### PR DESCRIPTION
This PR implements a hefty amount of changes (that have probably been terribly written) that allow the husk infection affliction to give players control of their husk.

Commit message

```
The husk infection has two new parameters: "ControlHusk" and "ControlException".
ControlHusk decides whether or not the player should be allowed to control their husk.
ControlException will prevent the player from controlling their husk if their species is in this list.

Added two console commands: "ignorehuskexceptions" and "restorehuskexceptions". These commands will toggle a new boolean parameter of the husk infection which lets it ignore any exception lists if set to true.

Added a new function for characters that returns the name of the player controlling them when called.
```

If merged, the standard husk infection xml should be updated to look like this.
```
  <AfflictionHusk
    name="Husk infection"
    identifier="huskinfection"
    description="Something dark and unpleasant moves in the mouth. They are rendered completely mute, save for occasional clicking sounds apparently emanating from deep within the throat."
    type="alieninfection"
    targets="human,crawler"
    huskedspeciesname="[speciesname]husk"
    causeofdeathdescription="Taken over by a husk parasite"
    selfcauseofdeathdescription="You have been taken over by the husk parasite."
    limbspecific="false"
    indicatorlimb="Torso"
    activationthreshold="0"
    showiconthreshold="40"
    karmachangeonapplied="-1"
    maxstrength="100"
    achievementonremoved="healhusk"
    controlhusk="true"
    controlexception="human"
    iconcolors="60,140,195,255;60,107,195,255;60,0,195,255">
    <Effect minstrength="0" maxstrength="100"
      maxvitalitydecrease="0"
      strengthchange="0.3"/>
    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,640,128,128" color="60,107,195,255" origin="0,0"/>
  </AfflictionHusk>
```
This would always allow players to control crawlerhusks if they are infected while playing as a crawler, but also allows servers that use the new command to let players play as human husks after being infected as well.