### PR TITLE
Additional playable monsters functionality

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
@@ -258,8 +258,11 @@ namespace Barotrauma
                     }
                     else
                     {
-                        //increased visibility range when controlling large a non-humanoid
-                        cam.OffsetAmount = MathHelper.Clamp(Mass, 250.0f, 1500.0f);
+                        // Visibility for monsters depends on character's sightrange but will always be slightly more than humans
+                        if (AIController is EnemyAIController enemyAI) 
+                        { 
+                            cam.OffsetAmount = MathHelper.Clamp(enemyAI.GetSightRange() * 350f, 300.0f, 2000.0f);
+                        }
                     }
                 }
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Map/Lights/LightManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/Lights/LightManager.cs
@@ -367,9 +367,17 @@ namespace Barotrauma.Lights
                 //ambient light decreases the brightness of the halo (no need for a bright halo if the ambient light is bright enough)
                 float ambientBrightness = (AmbientLight.R + AmbientLight.B + AmbientLight.G) / 255.0f / 3.0f;
                 Color haloColor = Color.White.Multiply(0.3f - ambientBrightness);
+                if (!character.IsHuman)
+                {
+                    haloColor.A = +75; // Monsters have night vision
+                }
                 if (haloColor.A > 0)
                 {
-                    float scale = 512.0f / LightSource.LightTexture.Width;
+                    var scale = 512.0f / LightSource.LightTexture.Width;
+                    if (!character.IsHuman)
+                    {
+                        scale = 5120.0f / LightSource.LightTexture.Width; // Monsters can see further
+                    }
                     spriteBatch.Draw(
                         LightSource.LightTexture, haloDrawPos, null, haloColor, 0.0f,
                         new Vector2(LightSource.LightTexture.Width, LightSource.LightTexture.Height) / 2, scale, SpriteEffects.None, 0.0f);

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
@@ -131,7 +131,7 @@ namespace Barotrauma
 
             if (GameMain.GameSession != null) { GameMain.GameSession.Draw(spriteBatch); }
 
-            if (Character.Controlled == null && !GUI.DisableHUD)
+            if ((Character.Controlled == null || !Character.Controlled.IsHuman) && !GUI.DisableHUD) // Spectators and player monsters can see the submarine icons
             {
                 for (int i = 0; i < Submarine.MainSubs.Length; i++)
                 {

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
@@ -3025,6 +3025,11 @@ namespace Barotrauma
             }
         }
 
+        public float GetSightRange()
+        {
+            return Sight;
+        }
+
         public void ReevaluateAttacks()
         {
             canAttackWalls = LatchOntoAI != null && LatchOntoAI.AttachToSub;

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -2339,7 +2339,19 @@ namespace Barotrauma
                     }
                 }
 #endif
-            }            
+            }
+            if (!IsHuman && IsKeyHit(InputType.PreviousFireMode)) // Make noise
+            {
+#if CLIENT
+                PlaySound(CharacterSound.SoundType.Idle);
+#endif
+            }
+            if (!IsHuman && IsKeyHit(InputType.NextFireMode)) // Make noise, but angry
+            {
+#if CLIENT
+                PlaySound(CharacterSound.SoundType.Attack);
+#endif
+            }
         }
 
         public static void UpdateAnimAll(float deltaTime)


### PR DESCRIPTION
This PR implements some changes that improve playable monster gameplay.

Commit message

```
Player monsters' sight is now dependent on the sight value defined in their character's AI parameters. The higher their sight the more their camera can zoom out.

Player monsters now have night vision.

Player monsters can see where submarines are if they are far away from them.

Player monsters can now manually make idle and attack noises by scrolling their mouse wheel.

```

There's really not much to say here apart from the addition of letting monsters see the submarine icon. I tried making this feature toggleable through a server setting but didn't really succeed, I'm not really sure if there should ever be a situation where player monsters shouldn't know where the submarine is, because monsters pretty much just exist to mess with the submarine, and if they can't find it, there would be nothing to do.