### PR TITLE
Fix some number inputs having incorrect initial button state

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/GUINumberInput.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/GUINumberInput.cs
@@ -140,6 +140,7 @@ namespace Barotrauma
             {
                 if (value == intValue) { return; }
                 intValue = value;
+                ClampIntValue();
                 UpdateText();
             }
         }


### PR DESCRIPTION
This PR simply fixes number inputs having an incorrect initial state.

Here are some examples of number inputs in an incorrect initial state:
![image](https://user-images.githubusercontent.com/1026173/117104751-64fc2a80-ad18-11eb-9c92-ccfeec9a8647.png)
**Expectation**: Increment buttons are disabled and decrement buttons are enabled
**Reality**: Increment buttons are enabled and decrement buttons are disabled

![image](https://user-images.githubusercontent.com/1026173/117104761-6a597500-ad18-11eb-98ad-3be352048664.png)
**Expectation**: Both increment and decrement buttons enabled on upper limit input
**Reality**: Only increment button is enabled on upper limit input

Here are those same inputs after the fix:
![image](https://user-images.githubusercontent.com/1026173/117104769-6e859280-ad18-11eb-8deb-a5f02e3fb9e7.png)
![image](https://user-images.githubusercontent.com/1026173/117104774-70e7ec80-ad18-11eb-8251-5a964b6ec03a.png)

As a side effect of this change, any time the `IntValue` is set on a `GUINumberInput`, the value is clamped to [`MinValueInt`, `MaxValueInt`]. This could potentially cause issues if any inputs are used in such a way that the value is updated _before_ the bounds are.