### PR TITLE
QTE Minigame for repairing

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Repairable.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Repairable.cs
@@ -324,10 +324,12 @@ namespace Barotrauma.Items.Components
             {
                 return;
             }
-            RepairBoost(QTESuccess);
-            QTECooldown = QTECooldownTime;
-            //on failure reset cursor to beginning
+
+            if (!GameMain.IsMultiplayer)RepairBoost(QTESuccess);
+
+            //on failure during cooldown reset cursor to beginning
             if (!QTESuccess && QTECooldown > 0.0f) QTETimer = QTETime;
+            QTECooldown = QTECooldownTime;
             //this will be set on button down so we can reset it here
             requestStartFixAction = FixActions.None;
             item.CreateClientEvent(this);

--- a/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Repairable.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Repairable.cs
@@ -14,6 +14,7 @@ namespace Barotrauma.Items.Components
         {
             if (c.Character == null) { return; }
             var requestedFixAction = (FixActions)msg.ReadRangedInteger(0, 2);
+            var QTESuccess = msg.ReadBoolean();
             if (requestedFixAction != FixActions.None)
             {
                 if (!c.Character.IsTraitor && requestedFixAction == FixActions.Sabotage)
@@ -31,6 +32,11 @@ namespace Barotrauma.Items.Components
                     item.CreateServerEvent(this);
                 }
             }
+            else
+            {
+                RepairBoost(QTESuccess);
+                item.CreateServerEvent(this);
+            }
         }
 
         public void ServerWrite(IWriteMessage msg, Client c, object[] extraData = null)
@@ -40,6 +46,7 @@ namespace Barotrauma.Items.Components
             msg.Write(DeteriorateAlways);
             msg.Write(CurrentFixer == null ? (ushort)0 : CurrentFixer.ID);
             msg.WriteRangedInteger((int)currentFixerAction, 0, 2);
+            msg.Write(repairBoost);
         }
     }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Repairable.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Repairable.cs
@@ -16,6 +16,8 @@ namespace Barotrauma.Items.Components
         private float deteriorationTimer;
         private float deteriorateAlwaysResetTimer;
 
+        private float repairBoost;
+
         bool wasBroken;
         bool wasGoodCondition;
 
@@ -191,7 +193,19 @@ namespace Barotrauma.Items.Components
 
             return ((average + 100.0f) / 2.0f) / 100.0f;
         }
-        
+
+        public void RepairBoost(bool QTESuccess)
+        {
+            if (QTESuccess)
+            {
+                repairBoost = RepairDegreeOfSuccess(CurrentFixer, requiredSkills) * 3 * (currentFixerAction == FixActions.Repair ? 1.0f : -1.0f);
+            }
+            else
+            {
+                repairBoost = (1 - RepairDegreeOfSuccess(CurrentFixer, requiredSkills)) * 10 * (currentFixerAction == FixActions.Repair ? -1.0f : 1.0f);
+            }
+        }
+
         public bool StartRepairing(Character character, FixActions action)
         {
             if (character == null || character.IsDead || action == FixActions.None)
@@ -324,6 +338,12 @@ namespace Barotrauma.Items.Components
             if (item.ConditionPercentage > MinSabotageCondition)
             {
                 wasGoodCondition = true;
+            }
+
+            if (repairBoost != 0.0f)
+            {
+                item.Condition += repairBoost;
+                repairBoost = 0.0f;
             }
 
             float fixDuration = MathHelper.Lerp(FixDurationLowSkill, FixDurationHighSkill, successFactor);


### PR DESCRIPTION
Adds a mini-game for repairing, while maintaining the original progress bar.

Gif of how it looks
[https://i.imgur.com/F9gErVW.gif](url)

How it works:

- Press Repairing button while the white cursor is over the colored section of the progress bar.
    Success: itemCondition += RelevantSkill(0-1) * 3
    Miss: itemCondition -= 1 - RelevantSkill  * 10
- The cursor turns red or green depending on the outcome and stays for a little bit (broken on the GIF but works in the commit). If the player rushes and clicks during this time, it counts as a miss to prevent mindless button mashing.
- The Cursor slows down near the end and if it reaches all the way to the left it just stops there, so even very unskilled players or players not understanding the mechanic can succeed.
- Since the player wants to do it as fast as possible misses are a probable outcome.

Tested and works on multiplayer.