### PR TITLE
More oscillator waves

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OscillatorComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OscillatorComponent.cs
@@ -12,6 +12,7 @@ namespace Barotrauma.Items.Components
         public enum WaveType
         {
             Pulse,
+            Sawtooth,
             Sine,
             Square,
         }
@@ -22,6 +23,7 @@ namespace Barotrauma.Items.Components
 
         [InGameEditable, Serialize(WaveType.Pulse, true, description: "What kind of a signal the item outputs." +
             " Pulse: periodically sends out a signal of 1." +
+            " Sawtooth: sends out a periodic wave that increases linearly from 0 to 1." +
             " Sine: sends out a sine wave oscillating between -1 and 1." +
             " Square: sends out a signal that alternates between 0 and 1.", alwaysUseInstanceValues: true)]
         public WaveType OutputType
@@ -62,6 +64,10 @@ namespace Barotrauma.Items.Components
                         item.SendSignal("1", "signal_out");
                         phase -= pulseInterval;
                     }
+                    break;
+                case WaveType.Sawtooth:
+                    phase = (phase + deltaTime * frequency) % 1.0f;
+                    item.SendSignal(phase.ToString(CultureInfo.InvariantCulture), "signal_out");
                     break;
                 case WaveType.Square:
                     phase = (phase + deltaTime * frequency) % 1.0f;

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OscillatorComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OscillatorComponent.cs
@@ -19,7 +19,7 @@ namespace Barotrauma.Items.Components
         }
 
         private float frequency;
-        private float period => 1f / frequency;
+
         private float phase;
 
         [InGameEditable, Serialize(WaveType.Pulse, true, description: "What kind of a signal the item outputs." +

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OscillatorComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OscillatorComponent.cs
@@ -15,17 +15,20 @@ namespace Barotrauma.Items.Components
             Sawtooth,
             Sine,
             Square,
+            Triangle,
         }
 
         private float frequency;
-
+        private float period => 1f / frequency;
         private float phase;
 
         [InGameEditable, Serialize(WaveType.Pulse, true, description: "What kind of a signal the item outputs." +
             " Pulse: periodically sends out a signal of 1." +
             " Sawtooth: sends out a periodic wave that increases linearly from 0 to 1." +
             " Sine: sends out a sine wave oscillating between -1 and 1." +
-            " Square: sends out a signal that alternates between 0 and 1.", alwaysUseInstanceValues: true)]
+            " Square: sends out a signal that alternates between 0 and 1." +
+            " Triangle: sends out a wave that alternates between increasing linearly from -1 to 1 and decreasing from 1 to -1.",
+                                   alwaysUseInstanceValues: true)]
         public WaveType OutputType
         {
             get;
@@ -76,6 +79,11 @@ namespace Barotrauma.Items.Components
                 case WaveType.Sine:
                     phase = (phase + deltaTime * frequency) % 1.0f;
                     item.SendSignal(Math.Sin(phase * MathHelper.TwoPi).ToString(CultureInfo.InvariantCulture), "signal_out");
+                    break;
+                case WaveType.Triangle:
+                    phase = (phase + deltaTime * frequency) % 1.0f;
+                    float output = 4.0f * MathF.Abs(ToolBox.FlooredModulus(phase - 0.25f, 1.0f) - 0.5f) - 1.0f;
+                    item.SendSignal(output.ToString(CultureInfo.InvariantCulture), "signal_out");
                     break;
             }
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/ToolBox.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/ToolBox.cs
@@ -696,5 +696,10 @@ namespace Barotrauma
             Point topLeft = new Point(center.X - halfSize.X, center.Y + halfSize.Y);
             return new Rectangle(topLeft, size);
         }
+
+        public static float FlooredModulus(float a, float b)
+        {
+            return ((a % b) + b) % b;
+        }
     }
 }


### PR DESCRIPTION
This PR adds two new waveforms to the oscillator component that are extremely useful but a bit of a pain to wire.

The first is the sawtooth wave, shown in the blue solid line on the graph. It increases linearly from 0 to 1 over the period of the wave.

The second is the triangle wave, shown in the red dashed line on the graph. It's like a sine wave but increases and decreases linearly instead, going from 0 to 1 to 0 to -1 to 0.

![image](https://user-images.githubusercontent.com/37539527/119386375-57a2e200-bcbf-11eb-8c9c-c736b07944cf.png)

