### PR TITLE
Added High Pressure pin to Water Detector

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/WaterDetector.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/WaterDetector.cs
@@ -104,6 +104,8 @@ namespace Barotrauma.Items.Components
                 int waterPercentage = MathHelper.Clamp((int)Math.Round(item.CurrentHull.WaterPercentage), 0, 100);
                 item.SendSignal(waterPercentage.ToString(), "water_%");
             }
+            string highPressureOut = (item.CurrentHull == null || item.CurrentHull.LethalPressure > 5.0f) ? "1" : "0";
+            item.SendSignal(highPressureOut, "high_pressure");
         }
     }
 }


### PR DESCRIPTION
Addeds extra pin to water sensor named "high_pressure" outputs 1 if the current hull lethal pressure > 5.0f 
or the detector is not in a hull, else its 0.
I have done the necessary localization and modified the item xml the commit doesn't appear to transfer that.