### PR TITLE
Add custom outputs to door with buttons

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Door.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Door.cs
@@ -181,7 +181,10 @@ namespace Barotrauma.Items.Components
 
         [Serialize(false, false, description: "If the door has integrated buttons, it can be opened by interacting with it directly (instead of using buttons wired to it).")]
         public bool HasIntegratedButtons { get; private set; }
-                
+
+        [Editable, Serialize(false, true, description: "If the door has integrated buttons, should clicking on it also still perform the default action of opening the door.")]
+        public bool SuppressDefaultAction { get; private set; }
+
         public float OpenState
         {
             get { return openState; }
@@ -324,8 +327,14 @@ namespace Barotrauma.Items.Components
                 OnFailedToOpen();
                 return;
             }
+            
+            item.SendSignal("1", "activate_out");
             lastUser = user;
-            SetState(PredictedState == null ? !isOpen : !PredictedState.Value, false, true, forcedOpen: actionType == ActionType.OnPicked);
+
+            if (!SuppressDefaultAction)
+            {
+                SetState(PredictedState == null ? !isOpen : !PredictedState.Value, false, true, forcedOpen: actionType == ActionType.OnPicked);
+            }           
         }
 
         public override bool Select(Character character)


### PR DESCRIPTION
What this PR does is adds an activate_out wiring output to doors with buttons, windowed doors with buttons, and hatches with buttons. It also allows users to suppress the default door open/close action that normally accompanies these integrated button/door assemblies. The idea is that this allows doors and hatches with integrated buttons to act as triggers for downstream logic circuits which may enable more advanced opening and closing functionality. This also has the added benefit that when AI goes to activate doors and hatches with buttons via waypoints to traverse thresholds it also triggers these custom logic circuits and #JustWorks. 


For example, with this change merged and the following XML, both players and AI just "clicking" on a door or hatch with buttons can now trigger complex door activation logic:

```xml
<Item identifier="doorwbuttons" … >
  …
  <ConnectionPanel … >
    …
    <output name="activate_out" displayname="connection.activateout" />
  </ConnectionPanel>
</Item>
```

```xml
<Item identifier="windoweddoorwbuttons" … >
  …
  <ConnectionPanel … >
    …
    <output name="activate_out" displayname="connection.activateout" />
  </ConnectionPanel>
</Item>
```

```xml
<Item identifier="hatchwbuttons" … >
    …
  <ConnectionPanel … >
    …
    <output name="activate_out" displayname="connection.activateout" />
  </ConnectionPanel>
</Item>
```

```xml
<connection.activateout>activate_out</connection.activateout>
```

AI waypoints in action with telescoping hatch logic:

https://user-images.githubusercontent.com/5521574/123562453-0b3e3c80-d76c-11eb-9cfe-6f197ec154c3.mp4



Hatch telescoping logic (suppressed default behaviour with complex opening logic) and door powered lightswitch raves (default door opening actions):

https://user-images.githubusercontent.com/5521574/123562447-05485b80-d76c-11eb-8e46-75fb7cdaf29b.mp4