### PR TITLE
Improve fabricator performance

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
@@ -297,6 +297,7 @@ namespace Barotrauma.Items.Components
                 int slotIndex = 0;
 
                 var missingItems = new List<FabricationRecipe.RequiredItem>();
+                
                 foreach (FabricationRecipe.RequiredItem requiredItem in targetItem.RequiredItems)
                 {
                     for (int i = 0; i < requiredItem.Amount; i++)
@@ -308,6 +309,8 @@ namespace Barotrauma.Items.Components
                 {
                     missingItems.Remove(missingItems.FirstOrDefault(mi => mi.ItemPrefabs.Contains(item.prefab)));
                 }
+                var missingCounts = missingItems.GroupBy(missingItem => missingItem).ToDictionary(x => x.Key, x => x.Count());
+                missingItems = missingItems.Distinct().ToList();
 
                 var availableIngredients = GetAvailableIngredients();
 
@@ -318,30 +321,30 @@ namespace Barotrauma.Items.Components
                         slotIndex++;
                     }
 
-                    requiredItem.ItemPrefabs.ForEach(requiredPrefab => {
-                        if (!availableIngredients.ContainsKey(requiredPrefab.Name)) { return; }
+                    requiredItem.ItemPrefabs
+                        .Where(requiredPrefab => availableIngredients.ContainsKey(requiredPrefab.Name))
+                        .ForEach(requiredPrefab => {
+                            var availablePrefabs = availableIngredients[requiredPrefab.Name];
 
-                        var availablePrefabs = availableIngredients[requiredPrefab.Name];
-                        
-                        availablePrefabs
-                            .Where(availablePrefab => availablePrefab.ParentInventory != inputContainer.Inventory)
-                            .Where(availablePrefab => availablePrefab.ParentInventory.visualSlots != null) //slots are null if the inventory has never been displayed 
-                            .ForEach(availablePrefab => {                                                  //(linked item, but the UI is not set to be displayed at the same time)
-                                int availableSlotIndex = item.ParentInventory.FindIndex(availablePrefab);
-                                
-                                if (availablePrefab.ParentInventory.visualSlots[availableSlotIndex].HighlightTimer <= 0.0f)
-                                {
-                                    availablePrefab.ParentInventory.visualSlots[availableSlotIndex].ShowBorderHighlight(GUI.Style.Green, 0.5f, 0.5f, 0.2f);
-                                    if (slotIndex < inputContainer.Capacity)
+                            availablePrefabs
+                                .Where(availablePrefab => availablePrefab.ParentInventory != inputContainer.Inventory)
+                                .Where(availablePrefab => availablePrefab.ParentInventory.visualSlots != null) //slots are null if the inventory has never been displayed 
+                                .ForEach(availablePrefab => {                                                  //(linked item, but the UI is not set to be displayed at the same time)
+                                    int availableSlotIndex = availablePrefab.ParentInventory.FindIndex(availablePrefab);
+
+                                    if (availablePrefab.ParentInventory.visualSlots[availableSlotIndex].HighlightTimer <= 0.0f)
                                     {
-                                        inputContainer.Inventory.visualSlots[slotIndex].ShowBorderHighlight(GUI.Style.Green, 0.5f, 0.5f, 0.2f);
+                                        availablePrefab.ParentInventory.visualSlots[availableSlotIndex].ShowBorderHighlight(GUI.Style.Green, 0.5f, 0.5f, 0.2f);
+                                        if (slotIndex < inputContainer.Capacity)
+                                        {
+                                            inputContainer.Inventory.visualSlots[slotIndex].ShowBorderHighlight(GUI.Style.Green, 0.5f, 0.5f, 0.2f);
+                                        }
                                     }
-                                }
-                            });
-                    });
+                                });
+                        });
 
                     if (slotIndex >= inputContainer.Capacity) { break; }
-                    
+                        
                     var itemIcon = requiredItem.ItemPrefabs.First().InventoryIcon ?? requiredItem.ItemPrefabs.First().sprite;
                     Rectangle slotRect = inputContainer.Inventory.visualSlots[slotIndex].Rect;
                     itemIcon.Draw(
@@ -349,6 +352,16 @@ namespace Barotrauma.Items.Components
                         slotRect.Center.ToVector2(),
                         color: requiredItem.ItemPrefabs.First().InventoryIconColor * 0.3f,
                         scale: Math.Min(slotRect.Width / itemIcon.size.X, slotRect.Height / itemIcon.size.Y));
+
+                    
+                    if (missingCounts[requiredItem] > 1)
+                    {
+                        Vector2 stackCountPos = new Vector2(slotRect.Right, slotRect.Bottom);
+                        string stackCountText = "x" + missingCounts[requiredItem];
+                        stackCountPos -= GUI.SmallFont.MeasureString(stackCountText) + new Vector2(4, 2);
+                        GUI.SmallFont.DrawString(spriteBatch, stackCountText, stackCountPos + Vector2.One, Color.Black);
+                        GUI.SmallFont.DrawString(spriteBatch, stackCountText, stackCountPos, Color.White);
+                    }
 
                     if (requiredItem.UseCondition && requiredItem.MinCondition < 1.0f)
                     {

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
@@ -322,9 +322,9 @@ namespace Barotrauma.Items.Components
                     }
 
                     requiredItem.ItemPrefabs
-                        .Where(requiredPrefab => availableIngredients.ContainsKey(requiredPrefab.Name))
+                        .Where(requiredPrefab => availableIngredients.ContainsKey(requiredPrefab.Identifier))
                         .ForEach(requiredPrefab => {
-                            var availablePrefabs = availableIngredients[requiredPrefab.Name];
+                            var availablePrefabs = availableIngredients[requiredPrefab.Identifier];
 
                             availablePrefabs
                                 .Where(availablePrefab => availablePrefab.ParentInventory != inputContainer.Inventory)

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
@@ -318,27 +318,27 @@ namespace Barotrauma.Items.Components
                         slotIndex++;
                     }
 
-                    //highlight suitable ingredients in linked inventories
-                    foreach (Item item in availableIngredients)
-                    {
-                        if (item.ParentInventory != inputContainer.Inventory && IsItemValidIngredient(item, requiredItem))
-                        {
-                            int availableSlotIndex = item.ParentInventory.FindIndex(item);
-                            //slots are null if the inventory has never been displayed 
-                            //(linked item, but the UI is not set to be displayed at the same time)
-                            if (item.ParentInventory.visualSlots != null)
-                            {
-                                if (item.ParentInventory.visualSlots[availableSlotIndex].HighlightTimer <= 0.0f)
+                    requiredItem.ItemPrefabs.ForEach(requiredPrefab => {
+                        if (!availableIngredients.ContainsKey(requiredPrefab.Name)) { return; }
+
+                        var availablePrefabs = availableIngredients[requiredPrefab.Name];
+                        
+                        availablePrefabs
+                            .Where(availablePrefab => availablePrefab.ParentInventory != inputContainer.Inventory)
+                            .Where(availablePrefab => availablePrefab.ParentInventory.visualSlots != null) //slots are null if the inventory has never been displayed 
+                            .ForEach(availablePrefab => {                                                  //(linked item, but the UI is not set to be displayed at the same time)
+                                int availableSlotIndex = item.ParentInventory.FindIndex(availablePrefab);
+                                
+                                if (availablePrefab.ParentInventory.visualSlots[availableSlotIndex].HighlightTimer <= 0.0f)
                                 {
-                                    item.ParentInventory.visualSlots[availableSlotIndex].ShowBorderHighlight(GUI.Style.Green, 0.5f, 0.5f, 0.2f);
+                                    availablePrefab.ParentInventory.visualSlots[availableSlotIndex].ShowBorderHighlight(GUI.Style.Green, 0.5f, 0.5f, 0.2f);
                                     if (slotIndex < inputContainer.Capacity)
                                     {
                                         inputContainer.Inventory.visualSlots[slotIndex].ShowBorderHighlight(GUI.Style.Green, 0.5f, 0.5f, 0.2f);
                                     }
                                 }
-                            }
-                        }
-                    }
+                            });
+                    });
 
                     if (slotIndex >= inputContainer.Capacity) { break; }
                     

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
@@ -344,7 +344,7 @@ namespace Barotrauma.Items.Components
                         });
 
                     if (slotIndex >= inputContainer.Capacity) { break; }
-                        
+
                     var itemIcon = requiredItem.ItemPrefabs.First().InventoryIcon ?? requiredItem.ItemPrefabs.First().sprite;
                     Rectangle slotRect = inputContainer.Inventory.visualSlots[slotIndex].Rect;
                     itemIcon.Draw(

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
@@ -290,9 +290,9 @@ namespace Barotrauma.Items.Components
                     {
                         foreach (ItemPrefab requiredPrefab in requiredItem.ItemPrefabs)
                         {
-                            if (!availableIngredients.ContainsKey(requiredPrefab.Name)) { continue; }
+                            if (!availableIngredients.ContainsKey(requiredPrefab.Identifier)) { continue; }
 
-                            var availablePrefabs = availableIngredients[requiredPrefab.Name];
+                            var availablePrefabs = availableIngredients[requiredPrefab.Identifier];
                             var availablePrefab = availablePrefabs.FirstOrDefault(potentialPrefab =>
                             {
                                 return potentialPrefab.ConditionPercentage >= requiredItem.MinCondition * 100.0f &&
@@ -381,9 +381,9 @@ namespace Barotrauma.Items.Components
                 int availablePrefabsAmount = 0;
                 foreach (ItemPrefab requiredPrefab in requiredItem.ItemPrefabs)
                 {
-                    if (!availableIngredients.ContainsKey(requiredPrefab.Name)) { continue; }
+                    if (!availableIngredients.ContainsKey(requiredPrefab.Identifier)) { continue; }
 
-                    var availablePrefabs = availableIngredients[requiredPrefab.Name];
+                    var availablePrefabs = availableIngredients[requiredPrefab.Identifier];
                     foreach (Item availablePrefab in availablePrefabs)
                     {
                         if (availablePrefab.Condition / availablePrefab.Prefab.Health >= requiredItem.MinCondition &&
@@ -469,13 +469,13 @@ namespace Barotrauma.Items.Components
             Dictionary<String, List<Item>> ingredientsDictionary = new Dictionary<String, List<Item>>();
             for (int i = 0; i < availableIngredients.Count; i++)
             {
-                var itemName = availableIngredients[i].Name;
-                if (!ingredientsDictionary.ContainsKey(itemName))
+                var itemIdentifier = availableIngredients[i].prefab.Identifier;
+                if (!ingredientsDictionary.ContainsKey(itemIdentifier))
                 {
-                    ingredientsDictionary[itemName] = new List<Item>(availableIngredients.Count);
+                    ingredientsDictionary[itemIdentifier] = new List<Item>(availableIngredients.Count);
                 }
 
-                ingredientsDictionary[itemName].Add(availableIngredients[i]);
+                ingredientsDictionary[itemIdentifier].Add(availableIngredients[i]);
             }
 
             return ingredientsDictionary;
@@ -498,9 +498,9 @@ namespace Barotrauma.Items.Components
                 {
                     foreach (ItemPrefab requiredPrefab in requiredItem.ItemPrefabs)
                     {
-                        if (!availableIngredients.ContainsKey(requiredPrefab.Name)) { continue; }
+                        if (!availableIngredients.ContainsKey(requiredPrefab.Identifier)) { continue; }
 
-                        var availablePrefabs = availableIngredients[requiredPrefab.Name];
+                        var availablePrefabs = availableIngredients[requiredPrefab.Identifier];
                         var availablePrefab = availablePrefabs.FirstOrDefault(potentialPrefab =>
                         {
                             return !usedItems.Contains(potentialPrefab) &&

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
@@ -372,7 +372,7 @@ namespace Barotrauma.Items.Components
 
         partial void UpdateRequiredTimeProjSpecific();
 
-        private bool CanBeFabricated(FabricationRecipe fabricableItem, Dictionary<String, List<Item>> availableIngredients)
+        private bool CanBeFabricated(FabricationRecipe fabricableItem, Dictionary<string, List<Item>> availableIngredients)
         {
             if (fabricableItem == null) { return false; }
 
@@ -434,7 +434,7 @@ namespace Barotrauma.Items.Components
         /// Get a list of all items available in the input container and linked containers
         /// </summary>
         /// <returns></returns>
-        private Dictionary<String, List<Item>> GetAvailableIngredients()
+        private Dictionary<string, List<Item>> GetAvailableIngredients()
         {
             List<Item> availableIngredients = new List<Item>();
             availableIngredients.AddRange(inputContainer.Inventory.AllItems);
@@ -466,7 +466,7 @@ namespace Barotrauma.Items.Components
             }
 #endif
 
-            Dictionary<String, List<Item>> ingredientsDictionary = new Dictionary<String, List<Item>>();
+            Dictionary<string, List<Item>> ingredientsDictionary = new Dictionary<string, List<Item>>();
             for (int i = 0; i < availableIngredients.Count; i++)
             {
                 var itemIdentifier = availableIngredients[i].prefab.Identifier;


### PR DESCRIPTION
This PR is made in an effort to improve fabricator performance especially in the cases where there are many linked inventories and/or possibly a lot of available to check whether they can fabricated or not. A lot of the improvements in this commit focus around the `CanBeFabricated` method, as well as converting the `GetAvailableIngredients` method to return a dictionary indexed by item identifier instead of just handing things a gigantic list to use all the time. A couple changes had to be made in a few other places to accommodate the new ingredient list format, and as an added bonus I also cleaned up the recipe display code so that it stacks required items of the same type with a count indicating how many of that item is required instead of just showing X amount of that individual item. 


I have done my best to test everything around the fabricator and how it works and I have also taken some benchmarks of the performance around this area before and after. 

Here's a benchmark of CPU and GPU usage on current master: 
![image](https://user-images.githubusercontent.com/5521574/123823729-b1985800-d8ba-11eb-85a9-cab510044121.png)

It is quite easy to see when I am using the fabricator and the couple moments where I stop using it during the benchmark. The Hot Path down at the bottom of the diagnostic is already honing in on the `UpdateHUD` method and it's calls to the `CanBeFabricated` method.

And here's a benchmark of the CPU and GPU usage on this branch while fabricating for comparison:
![image](https://user-images.githubusercontent.com/5521574/123820853-228a4080-d8b8-11eb-855d-fd11e225de85.png)

Frame time and frame rate are both dramatically improved and it's quite possibly even impossible to tell at which point I actually opened the fabricator and started doing fabricator things. 


If we compare the CPU time more carefully between the two branches:

Main:
![image](https://user-images.githubusercontent.com/5521574/123824319-2a97af80-d8bb-11eb-8db8-73bf28bf4894.png)
Post-Optimisation:
![image](https://user-images.githubusercontent.com/5521574/123830285-641ee980-d8c0-11eb-8d9f-9f64e8654d3d.png)


We can see that while `CanBeFabricated` is taking just over 56% of the CPU time on main, while on the post-optimised branch there is a significant reduction in CPU time being used on `UpdateHUD` and `CanBeFabricated`. `GetAvailableIngredients` actually became more than twice as expensive because of the time spent converting the list of ingredients into a dictionary from those lists, but as a result of almost doubling the cost of that extremely inexpensive method there was almost a tenfold reduction in the cost of the more expensive methods.  


Also, possibly important to note, memory usage has mostly remained the same. 

Main:
![image](https://user-images.githubusercontent.com/5521574/123817847-bb6b8c80-d8b5-11eb-97e6-773999e54b3d.png)
Post-Optimisation
![image](https://user-images.githubusercontent.com/5521574/123826817-55830300-d8bd-11eb-9879-48fad1369184.png)


And here's me showing off the new required item stacking and the overall improved framerate. It is important to note that items contained in linked storages aren't highlighting because I haven't opened any of those containers yet and that the number of storages linked to this fabricator are comprised of about 7 or 8 large storage lockers in total

https://user-images.githubusercontent.com/5521574/123829352-a0057f00-d8bf-11eb-8747-71b675b4b9ec.mp4


Sorry for the omega-long post. Please let me know what you think and I would be happy explain anything in more detail if there are any questions. 
