### PR TITLE
"set_delay" input for Delay Components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ bld/
 [Dd]ebug*/
 [Rr]elease*/
 *.o
+Content
 
 # Misc vs crap 
 *.v12.suo

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/DelayComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/DelayComponent.cs
@@ -110,12 +110,13 @@ namespace Barotrauma.Items.Components
                     float val;
                     if (float.TryParse(signal.value, out val))
                     {
-                        if (signalQueue.Count > 0 && val != Delay)
+						float clampval = MathHelper.Clamp(val, 0, 60);
+                        if (signalQueue.Count > 0 && clampval != Delay)
                         {
                             prevQueuedSignal = null; //might not be the best but hey it works???
                             signalQueue.Clear();
                         }
-                        Delay = MathHelper.Clamp(val, 0, 60);
+                        Delay = clampval;
                     }
                     break;
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/DelayComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/DelayComponent.cs
@@ -109,7 +109,14 @@ namespace Barotrauma.Items.Components
                 case "set_delay":
                     float val;
                     if (float.TryParse(signal.value, out val))
+                    {
+                        if (signalQueue.Count > 0 && val != Delay)
+                        {
+                            prevQueuedSignal = null; //might not be the best but hey it works???
+                            signalQueue.Clear();
+                        }
                         Delay = MathHelper.Clamp(val, 0, 60);
+                    }
                     break;
             }
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/DelayComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/DelayComponent.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Linq;
-
+using Microsoft.Xna.Framework;
 namespace Barotrauma.Items.Components
 {
     class DelayComponent : ItemComponent
@@ -105,6 +105,11 @@ namespace Barotrauma.Items.Components
                         SendDuration = 1
                     };
                     signalQueue.Enqueue(prevQueuedSignal);
+                    break;
+                case "set_delay":
+                    float val;
+                    if (float.TryParse(signal.value, out val))
+                        Delay = MathHelper.Clamp(val, 0, 60);
                     break;
             }
         }


### PR DESCRIPTION
Added a "set_delay" input to the delay component.
This input (obviously) sets the components delay to the signals value.

`<input name="set_delay" displayname="connection.setdelay" />`
Appears to be working on multiplayer.

(ignore the ".gitignore")