### PR TITLE
Added new "accessiblebyowner" attribute to inventories

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/CharacterInventory.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/CharacterInventory.cs
@@ -474,7 +474,7 @@ namespace Barotrauma
 
         public override void Update(float deltaTime, Camera cam, bool isSubInventory = false)
         {
-            if (!AccessibleWhenAlive && !character.IsDead)
+            if (!AccessibleWhenAlive && !character.IsDead && !AccessibleByOwner)
             {
                 syncItemsDelay = Math.Max(syncItemsDelay - deltaTime, 0.0f);
                 return;
@@ -1102,7 +1102,7 @@ namespace Barotrauma
         
         public void DrawOwn(SpriteBatch spriteBatch)
         {
-            if (!AccessibleWhenAlive && !character.IsDead) { return; }
+            if (!AccessibleWhenAlive && !character.IsDead && !AccessibleByOwner) { return; }
             if (capacity == 0) { return; }
             if (visualSlots == null) { CreateSlots(); }
             if (GameMain.GraphicsWidth != screenResolution.X ||

--- a/Barotrauma/BarotraumaServer/ServerSource/Items/Inventory.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Items/Inventory.cs
@@ -33,7 +33,7 @@ namespace Barotrauma
                 {
                     accessible = false;
                 }
-                else if (!characterInventory.AccessibleWhenAlive && !ownerCharacter.IsDead)
+                else if (!characterInventory.AccessibleWhenAlive && !ownerCharacter.IsDead && !characterInventory.AccessibleByOwner)
                 {
                     accessible = false;
                 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/CharacterInventory.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/CharacterInventory.cs
@@ -33,6 +33,12 @@ namespace Barotrauma
             private set;
         }
 
+        public bool AccessibleByOwner
+        {
+            get;
+            private set;
+        }
+
         private static string[] ParseSlotTypes(XElement element)
         {
             string slotString = element.GetAttributeString("slots", null);
@@ -47,6 +53,7 @@ namespace Barotrauma
             SlotTypes = new InvSlotType[capacity];
 
             AccessibleWhenAlive = element.GetAttributeBool("accessiblewhenalive", true);
+            AccessibleByOwner = element.GetAttributeBool("accessiblebyowner", false);
 
             string[] slotTypeNames = ParseSlotTypes(element);
             System.Diagnostics.Debug.Assert(slotTypeNames.Length == capacity);


### PR DESCRIPTION
This PR implements a new attribute for inventories which lets them be accessible to their owners when "accessiblewhenalive" is set to false.

Commit message

```
This new attribute is false by default and is only relevant if the "accessiblewhenalive" attribute is set to false.
If set to true, "accessiblebyowner" will allow the character to see their own inventory when player controlled, while keeping it hidden from others until death.

```

This would work well with player controlled humanoid monsters (such as husks) and with player controlled non-humanoid creatures that will eventually be allowed to hold items (such as updated fractal guardians).