### PR TITLE
Optimize fabricator GUI performance by only updating visible recipes

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
@@ -596,10 +596,17 @@ namespace Barotrauma.Items.Components
             var availableIngredients = GetAvailableIngredients();
             if (character != null)
             {
+                var listBottom = itemList.Rect.Y + itemList.Rect.Height;
                 foreach (GUIComponent child in itemList.Content.Children)
                 {
                     var itemPrefab = child.UserData as FabricationRecipe;
                     if (itemPrefab == null) continue;
+
+                    // Virtualize prefab updates
+                    if (itemPrefab != selectedItem &&
+                        (child.Rect.Y > listBottom ||
+                        child.Rect.Y + child.Rect.Height < itemList.Rect.Y))
+                        continue;
 
                     bool canBeFabricated = CanBeFabricated(itemPrefab, availableIngredients);
                     if (itemPrefab == selectedItem)


### PR DESCRIPTION
Currently the performance of the fabricator GUI suffers from too many items in linked inventories or item recipes. With item-heavy mods or Workshop subs, FPS can drop to single digit with the fabricator GUI open.

This is mostly due to each item having to update their fabrication possibility on every frame. Since the outcome is only used to style the fabricate button and item sprite, we can solve this issue by only updating recipes visible in the list, or is selected.

My proposed fix calls update only for items that are either selected, or at least partially visible in the recipe list. When rapidly scrolling through the list, some tooltips appear to briefly flash at the top and bottom of screen, but this issue is also visible in vanilla.