### PR TITLE
Fix ColorComponent HSV color calculation

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ColorComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/ColorComponent.cs
@@ -36,9 +36,9 @@ namespace Barotrauma.Items.Components
             if (UseHSV)
             {
                 Color hsvColor = ToolBox.HSVToRGB(signalR, signalG, signalB);
-                signalR = hsvColor.R / (float) byte.MaxValue;
-                signalG = hsvColor.G / (float) byte.MaxValue;
-                signalB = hsvColor.B / (float) byte.MaxValue;
+                signalR = hsvColor.R;
+                signalG = hsvColor.G;
+                signalB = hsvColor.B;
             }
 
             output = signalR.ToString("G", CultureInfo.InvariantCulture);


### PR DESCRIPTION
The RGB output from ColorComponent that is in HSV mode was incorrectly divided by 255. This caused the output to be way too dark.