### PR TITLE
Husk inventory mismatch error no longer happens for monsters

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
@@ -231,7 +231,7 @@ namespace Barotrauma
 
             if (character.Inventory != null && husk.Inventory != null)
             {
-                if (character.Inventory.Capacity != husk.Inventory.Capacity)
+                if ((character.Inventory.Capacity != husk.Inventory.Capacity) && (character.IsHuman))
                 {
                     string errorMsg = "Failed to move items from the source character's inventory into a husk's inventory (inventory sizes don't match)";
                     DebugConsole.ThrowError(errorMsg);


### PR DESCRIPTION
This PR slightly tweaks the conditions necessary for the game to throw out an error when transferring the inventory items of an infected character to an AI husk character, making it so that the error only triggers if the infected character is a human and not a monster. 

Commit message

```
The error that happens when creating an AI husk if the source character and its husked version don't have the same inventory sizes no longer happens on monsters and will only trigger for humans being turned into husks.
```

It makes sense for the error in question to appear for infected humans, due to the fact that they almost always will have valuable items that shouldn't be lost when being turned into a husk, but for monsters whose inventories are comprised of simple lootable items, it doesn't seem like their inventories should be valued the same way.

The implementation of this change would also mean that monster inventories are no longer required to have the same slots as any sort of husked variant that they have, giving more freedom to what kind of loot they can have without causing errors if one of said monsters turns into a husk.

Fixes https://github.com/Regalis11/Barotrauma/issues/4856.