### PR TITLE
Add screen overlay effect to afflictions

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Health/CharacterHealth.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Health/CharacterHealth.cs
@@ -1071,6 +1071,16 @@ namespace Barotrauma
                 UpdateAlignment();
             }
 
+            foreach (Affliction affliction in afflictions)
+            {
+                if (affliction.Prefab.AfflictionOverlay != null)
+                {
+                    Sprite ScreenAfflictionOverlay = affliction.Prefab.AfflictionOverlay;
+                    ScreenAfflictionOverlay?.Draw(spriteBatch, Vector2.Zero, Color.White * (affliction.GetAfflictionOverlayMultiplier()), Vector2.Zero, 0.0f,
+                        new Vector2(GameMain.GraphicsWidth / DamageOverlay.size.X, GameMain.GraphicsHeight / DamageOverlay.size.Y));
+                }
+            }
+
             float damageOverlayAlpha = DamageOverlayTimer;
             if (Vitality < MaxVitality * 0.1f)
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
@@ -172,6 +172,19 @@ namespace Barotrauma
                 (Strength - currentEffect.MinStrength) / (currentEffect.MaxStrength - currentEffect.MinStrength));
         }
 
+        public float GetAfflictionOverlayMultiplier()
+        {
+            if (Strength < Prefab.ActivationThreshold) { return 0.0f; }
+            AfflictionPrefab.Effect currentEffect = GetActiveEffect();
+            if (currentEffect == null) { return 0.0f; }
+            if (currentEffect.MaxAfflictionOverlayAlphaMultiplier - currentEffect.MinAfflictionOverlayAlphaMultiplier < 0.0f) { return 0.0f; }
+
+            return MathHelper.Lerp(
+                currentEffect.MinAfflictionOverlayAlphaMultiplier,
+                currentEffect.MaxAfflictionOverlayAlphaMultiplier,
+                (Strength - currentEffect.MinStrength) / (currentEffect.MaxStrength - currentEffect.MinStrength));
+        }
+
         public float GetScreenBlurStrength()
         {
             if (Strength < Prefab.ActivationThreshold) { return 0.0f; }

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
@@ -174,6 +174,8 @@ namespace Barotrauma
 
         public float GetAfflictionOverlayMultiplier()
         {
+            //If the overlay's alpha progresses linearly, then don't worry about affliction effects.
+            if (Prefab.AfflictionOverlayAlphaIsLinear) { return (Strength / Prefab.MaxStrength); }
             if (Strength < Prefab.ActivationThreshold) { return 0.0f; }
             AfflictionPrefab.Effect currentEffect = GetActiveEffect();
             if (currentEffect == null) { return 0.0f; }

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
@@ -323,6 +323,7 @@ namespace Barotrauma
         public readonly Color[] IconColors;
 
         public readonly Sprite AfflictionOverlay;
+        public readonly bool AfflictionOverlayAlphaIsLinear;
 
         private readonly List<Effect> effects = new List<Effect>();
         private readonly List<PeriodicEffect> periodicEffects = new List<PeriodicEffect>();
@@ -611,6 +612,7 @@ namespace Barotrauma
             SelfCauseOfDeathDescription = TextManager.Get("AfflictionCauseOfDeathSelf." + translationId, true) ?? element.GetAttributeString("selfcauseofdeathdescription", "");
 
             IconColors = element.GetAttributeColorArray("iconcolors", null);
+            AfflictionOverlayAlphaIsLinear = element.GetAttributeBool("afflictionoverlayalphaislinear", false);
             AchievementOnRemoved = element.GetAttributeString("achievementonremoved", "");
 
             foreach (XElement subElement in element.Elements())

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionPrefab.cs
@@ -131,6 +131,7 @@ namespace Barotrauma
             public float MinGrainStrength, MaxGrainStrength;
             public float MinRadialDistortStrength, MaxRadialDistortStrength;
             public float MinChromaticAberrationStrength, MaxChromaticAberrationStrength;
+            public float MinAfflictionOverlayAlphaMultiplier, MaxAfflictionOverlayAlphaMultiplier;
             public float MinSpeedMultiplier, MaxSpeedMultiplier;
             public float MinBuffMultiplier, MaxBuffMultiplier;
 
@@ -165,6 +166,10 @@ namespace Barotrauma
                 MinChromaticAberrationStrength = element.GetAttributeFloat("minchromaticaberration", 0.0f);
                 MaxChromaticAberrationStrength = element.GetAttributeFloat("maxchromaticaberration", 0.0f);
                 MaxChromaticAberrationStrength = Math.Max(MinChromaticAberrationStrength, MaxChromaticAberrationStrength);
+
+                MinAfflictionOverlayAlphaMultiplier = element.GetAttributeFloat("minafflictionoverlayalphamultiplier", 0.0f);
+                MaxAfflictionOverlayAlphaMultiplier = element.GetAttributeFloat("maxafflictionoverlayalphamultiplier", 1.0f);
+                MaxAfflictionOverlayAlphaMultiplier = Math.Max(MinAfflictionOverlayAlphaMultiplier, MaxAfflictionOverlayAlphaMultiplier);
 
                 MinGrainStrength = element.GetAttributeFloat(nameof(MinGrainStrength).ToLower(), 0.0f);
                 MaxGrainStrength = element.GetAttributeFloat(nameof(MaxGrainStrength).ToLower(), 0.0f);
@@ -316,6 +321,8 @@ namespace Barotrauma
 
         public readonly Sprite Icon;
         public readonly Color[] IconColors;
+
+        public readonly Sprite AfflictionOverlay;
 
         private readonly List<Effect> effects = new List<Effect>();
         private readonly List<PeriodicEffect> periodicEffects = new List<PeriodicEffect>();
@@ -612,6 +619,9 @@ namespace Barotrauma
                 {
                     case "icon":
                         Icon = new Sprite(subElement);
+                        break;
+                    case "afflictionoverlay":
+                        AfflictionOverlay = new Sprite(subElement);
                         break;
                 }
             }


### PR DESCRIPTION
This PR implements some new attributes for afflictions that allow them to apply a custom screen overlay effect for afflicted individuals.

Commit message

```
Afflictions now accept a new texture called "afflictionoverlay".
Affliction effects now accept two new parameters, "minafflictionoverlayalphamultiplier" and "maxafflictionoverlayalphamultiplier".
Afflictions now accept a new parameter, "afflictionoverlayalphaislinear".

The above elements allow afflictions to apply a custom screen overlay effect for afflicted individuals.
```

By using the min and max parameters inside affliction effects, you can easily modulate how the transparency of screen overlay effect progresses depending on the affliction's strength.
By using the linear progression parameter, the overlay's alpha value will simply increase as the affliction reaches its max strength value.