### PR TITLE
Fix variant multipliers of husked monsters not working properly

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -1134,7 +1134,7 @@ namespace Barotrauma
                 {
                     nonHuskedSpeciesName = AfflictionHusk.GetNonHuskedSpeciesName(speciesName, matchingAffliction);
                 }
-                if (ragdollParams == null)
+                if (ragdollParams == null && prefab.VariantOf == null)
                 {
                     string name = Params.UseHuskAppendage ? nonHuskedSpeciesName : speciesName;
                     ragdollParams = IsHumanoid ? RagdollParams.GetDefaultRagdollParams<HumanRagdollParams>(name) : RagdollParams.GetDefaultRagdollParams<FishRagdollParams>(name) as RagdollParams;


### PR DESCRIPTION
Monsters who have the parameter "husk" set to true can now properly reflect scale and attack multipliers if a variant is made of them.

This would allow to easily implement a husked variant of the "swarmcrawler" to the game if desired.

```xml
<Charactervariant inherit="Crawlerhusk" speciesname="Swarmcrawlerhusk" speciestranslationoverride="Crawler">
  <health vitality="85"/>
  <ai fleehealththreshold="0"/>
  <ragdoll scalemultiplier="1.15"/>
  <attack damagemultiplier="1.15"/>
</Charactervariant>
```

Fixes https://github.com/Regalis11/Barotrauma/issues/4829.