### PR TITLE
Nearbycharacters status effects now checks conditionals for each target character

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/DelayedEffect.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/DelayedEffect.cs
@@ -92,6 +92,7 @@ namespace Barotrauma
             currentTargets.Clear();
             foreach (ISerializableEntity target in targets)
             {
+                if (!HasRequiredConditions(target.ToEnumerable())) { continue; }
                 if (!IsValidTarget(target)) { continue; }
                 currentTargets.Add(target);
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
@@ -906,6 +906,7 @@ namespace Barotrauma
             currentTargets.Clear();
             foreach (ISerializableEntity target in targets)
             {
+                if (!HasRequiredConditions(target.ToEnumerable())) { continue; }
                 if (!IsValidTarget(target)) { continue; }
                 currentTargets.Add(target);
             }


### PR DESCRIPTION
This PR adds a new if statement to the code that applies status effects which allows "nearbycharacters" status effects to work as expected by checking if each target actually meets the required conditionals, rather than applying the effect to every character in range as long as there is a single character that meets the requirements.

Commit Message

```
Before applying a status effect, check if the singular target meets the required conditionals.

This prevents "nearbycharacters" status effects from affecting every single character in range instead of only those that meet the specified conditions if there are any nearby, which is a more expected result.

Doesn't affect the functionality of "nearbycharacters" status effects that don't have any conditionals.
```

Fixes https://github.com/Regalis11/Barotrauma/issues/4970.