### PR TITLE
Allow negative TriggerComponent.Force values

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/TriggerComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/TriggerComponent.cs
@@ -141,7 +141,7 @@ namespace Barotrauma.Items.Components
                     LevelTrigger.ApplyAttacks(attacks, item.WorldPosition, deltaTime);
                 }
 
-                if (Force < 0.01f)
+                if (Math.Abs(Force) < 0.01f)
                 {
                     // Just ignore very minimal forces
                     continue;


### PR DESCRIPTION
Allows the gravity sphere to act as a repulsor if the TriggerComponent's Force value is negative, as seen in this example where the outermost `TriggerComponent.Force = -1000`. Accepting this change would expand the possibilities for vanilla sub and outpost builders (as well as modders) without changing base game behavior. Currently TriggerComponent is only used by the gravitysphere and guardianpod; the latter has `Force = 0`.

![anti-gravitysphere](https://user-images.githubusercontent.com/2483420/140259724-fdbf0a23-c078-4122-8cc8-4326e7b7c4d9.gif)