### PR TITLE
Removed weird handling of hallway horizontal/vertical flags

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Outposts/OutpostModuleInfo.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Outposts/OutpostModuleInfo.cs
@@ -86,18 +86,6 @@ namespace Barotrauma
         public void SetFlags(IEnumerable<string> newFlags)
         {
             moduleFlags.Clear();
-            if (newFlags.Contains("hallwayhorizontal"))
-            {
-                moduleFlags.Add("hallwayhorizontal");
-                if (newFlags.Contains("ruin")) { moduleFlags.Add("ruin"); }
-                return;
-            }
-            if (newFlags.Contains("hallwayvertical"))
-            {
-                moduleFlags.Add("hallwayvertical");
-                if (newFlags.Contains("ruin")) { moduleFlags.Add("ruin"); }
-                return;
-            }
             if (!newFlags.Any())
             {
                 moduleFlags.Add("none");


### PR DESCRIPTION
When outposts generate you have no control over what hallways they will use, which can cause visual miss-matches to happen (e.g. a custom outpost using vanilla hallways). 

You can theoretically get around this by tagging all modules with a custom tag and allowing them only to connect to the custom tag, however [these lines of code](https://github.com/Regalis11/Barotrauma/blob/10e5fd5f3e5439f446f2ba42c41a1f094814678a/Barotrauma/BarotraumaShared/SharedSource/Map/Outposts/OutpostModuleInfo.cs#L89) prevent this from happening by exiting early before the other flags get the chance to be added. 

This prevents adding multiple tags to hallway modules both in the submarine editor and when loaded into the game, effectively killing any modded outpost that doesn't want to use vanilla hallways, for seemingly no reason.