### PR TITLE
Add logic to allow junction boxes to send power and load signals

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
@@ -172,6 +172,9 @@ namespace Barotrauma.Items.Components
             //if the item can't be fixed, don't allow it to break
             if (!item.Repairables.Any() || !CanBeOverloaded) { return; }
 
+            item.SendSignal(((int)-CurrPowerConsumption).ToString(), "power_value_out");
+            item.SendSignal(((int)powerLoad).ToString(), "load_value_out");
+
             float maxOverVoltage = Math.Max(OverloadVoltage, 1.0f);
             Overload = -currPowerConsumption > Math.Max(powerLoad, 200.0f) * maxOverVoltage;
             if (Overload && (GameMain.NetworkMember == null || GameMain.NetworkMember.IsServer))


### PR DESCRIPTION
A very simple change to allow Junction Boxes to send their current power and load values out as signals. This does require xml changes as well. Adding:
`<output name="power_value_out" displayname="connection.powervalueout" />
<output name="load_value_out" displayname="connection.loadvalueout" />` (copied directly from reactor.xml)
to the ConnectionPanel section of the junctionbox item in poweritems.xml

This addition will allow more complex circuitry that checks the power load and available power in specific parts of the sub grid without relying on the "hidden reactor" trick occasionally employed by sub builders. 