### PR TITLE
Modified ESC input interaction with the bug reporter message box

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GameMain.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameMain.cs
@@ -916,6 +916,11 @@ namespace Barotrauma
                         {
                             gameSession.ToggleTabMenu();
                         }
+                        else if (GUIMessageBox.VisibleBox as GUIMessageBox != null &&
+                                 GUIMessageBox.VisibleBox.UserData as string == "bugreporter")
+                        {
+                            ((GUIMessageBox)GUIMessageBox.VisibleBox).Close();
+                        }
                         else if (GUI.PauseMenuOpen)
                         {
                             GUI.TogglePauseMenu();


### PR DESCRIPTION
Made changes to the ESC input behavior such that pressing it while the bug reporter message box is visible, the ESC key will close that instead of the pause menu.