### PR TITLE
CustomInterface.IntegerInput➡NumberInput, can set floats, step, decimalplaces

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Signal/CustomInterface.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Signal/CustomInterface.cs
@@ -28,9 +28,14 @@ namespace Barotrauma.Items.Components
                 {
                     if (customInterfaceElementList[i].HasPropertyName)
                     {
-                        if (!customInterfaceElementList[i].IsIntegerInput)
+                        if (!customInterfaceElementList[i].IsNumberInput)
                         {
                             TextChanged(customInterfaceElementList[i], elementValues[i]);
+                        }
+                        else if (!customInterfaceElementList[i].IsIntegerInput) // Is float.
+                        {
+                            float.TryParse(elementValues[i], out float value);
+                            ValueChanged(customInterfaceElementList[i], value);
                         }
                         else
                         {


### PR DESCRIPTION
### Background
> v0.12.0.0 Modding: Added support for IntegerInput elements (with ["min" and "max" attributes](https://github.com/Regalis11/Barotrauma/blob/c6790d34b1e6e65feb2879bd6b7f290d3bcb0ba0/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/CustomInterface.cs#L48-L56)) for the CustomInterface component.

Since then, there are still no uses of `<IntegerInput />` in Vanilla, nor in popular XML-heavy mod packs like Into The Abyss, Thalassophobia, or EK.

### Proposal

Extending the **IntegerInput to also handle floats** expands the situations in which it can be valuable to modders; for example, there are 200+ public floats in SharedSource/Items/Components that are currently incompatible with `<IntegerInput />`. 

The included changes would improve the situation:
- Add `<NumberInput />` as a more generic `<IntegerInput />`.
- Refactor IntegerInput to be a case of NumberInput.
- Allow float NumberInputs with `numbertype="float"` property (defaults to "integer").
- Allow setting the increment via `step="0.5"` property.
- Allow setting the displayed decimal places  via `decimalplaces="2"` property.

These changes deprecate `<IntegerInput />` but preserve its existing functionality for backward compatibility, while extending the breadth of possibilities for both `int` and `float` `<NumberInput />`s.

### Examples
Add this to the `autoinjectorheadset` for quick testing.
```xml
<Item identifier="autoinjectorheadset" …>
  <CustomInterface signals="0.50" allowuioverlap="true" canbeselected="false" drawhudwhenequipped="true" hudlayer="-2">
    <TextBox      text="Auto-Inject Threshold A" propertyname="autoinjectthreshold" />
    <!-- ⬆️ Currently the only way to set floats but lacks features like min/max and up/down GUI buttons. -->
    <IntegerInput text="Auto-Inject Threshold B" propertyname="autoinjectthreshold" min="-1" max="1" />
    <!-- ↕️ These two are equivalent, making it easy to migrate from deprecated IntegerInput to NumberInput. -->
    <NumberInput  text="Auto-Inject Threshold C" propertyname="autoinjectthreshold" min="-1" max="1" />
    <NumberInput  text="Auto-Inject Threshold D" propertyname="autoinjectthreshold" numbertype="integer" min="-1" max="1" step="2" />
    <!-- ↕️ These two use all the new features in this PR: explicit numbertype, step, and decimalplaces. -->
    <NumberInput  text="Auto-Inject Threshold E" propertyname="autoinjectthreshold" numbertype="float" min="-1.00" max="1.00" step="0.05" decimalplaces="3" />
    <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
  </CustomInterface>
  …
</Item>
```

| Before changes | After changes |
| -- | -- |
| <img width="386" alt="Screen Shot 2021-12-05 at 8 48 47 PM" src="https://user-images.githubusercontent.com/2483420/144782528-164143dd-6828-48f9-9c55-7ac536239832.png"> | ![NumberInput](https://user-images.githubusercontent.com/2483420/144782543-176cbb9a-b685-4952-bac7-e933e70d3aec.gif) |

Please feel free to make and request modifications, or close with feedback. Thanks in advance for your consideration! 😇