### PR TITLE
make sub turrets start round at mid-rotation

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -328,6 +328,7 @@ namespace Barotrauma.Items.Components
             FindLightComponent();
             if (loadedRotationLimits.HasValue) { RotationLimits = loadedRotationLimits.Value; }
             if (loadedBaseRotation.HasValue) { BaseRotation = loadedBaseRotation.Value; }
+            rotation = (minRotation + maxRotation) / 2;
             UpdateTransformedBarrelPos();
         }
 
@@ -1550,6 +1551,7 @@ namespace Barotrauma.Items.Components
                 if (item.FlippedX) { FlipX(relativeToSub: false); }
                 if (item.FlippedY) { FlipY(relativeToSub: false); }
             }
+            rotation = (minRotation + maxRotation) / 2;
         }
 
         public void ServerWrite(IWriteMessage msg, Client c, object[] extraData = null)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -162,6 +162,8 @@ namespace Barotrauma.Items.Components
             {
                 minRotation = MathHelper.ToRadians(Math.Min(value.X, value.Y));
                 maxRotation = MathHelper.ToRadians(Math.Max(value.X, value.Y));
+
+                rotation = (minRotation + maxRotation) / 2;
 #if CLIENT
                 if (lightComponent != null) 
                 {
@@ -326,7 +328,6 @@ namespace Barotrauma.Items.Components
             FindLightComponent();
             if (loadedRotationLimits.HasValue) { RotationLimits = loadedRotationLimits.Value; }
             if (loadedBaseRotation.HasValue) { BaseRotation = loadedBaseRotation.Value; }
-            rotation = (minRotation + maxRotation) / 2;
             targetRotation = rotation;
             UpdateTransformedBarrelPos();
         }
@@ -1550,7 +1551,6 @@ namespace Barotrauma.Items.Components
                 if (item.FlippedX) { FlipX(relativeToSub: false); }
                 if (item.FlippedY) { FlipY(relativeToSub: false); }
             }
-            rotation = (minRotation + maxRotation) / 2;
             targetRotation = rotation;
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -162,8 +162,6 @@ namespace Barotrauma.Items.Components
             {
                 minRotation = MathHelper.ToRadians(Math.Min(value.X, value.Y));
                 maxRotation = MathHelper.ToRadians(Math.Max(value.X, value.Y));
-
-                rotation = (minRotation + maxRotation) / 2;
 #if CLIENT
                 if (lightComponent != null) 
                 {
@@ -329,6 +327,7 @@ namespace Barotrauma.Items.Components
             if (loadedRotationLimits.HasValue) { RotationLimits = loadedRotationLimits.Value; }
             if (loadedBaseRotation.HasValue) { BaseRotation = loadedBaseRotation.Value; }
             rotation = (minRotation + maxRotation) / 2;
+            targetRotation = rotation;
             UpdateTransformedBarrelPos();
         }
 
@@ -1552,6 +1551,7 @@ namespace Barotrauma.Items.Components
                 if (item.FlippedY) { FlipY(relativeToSub: false); }
             }
             rotation = (minRotation + maxRotation) / 2;
+            targetRotation = rotation;
         }
 
         public void ServerWrite(IWriteMessage msg, Client c, object[] extraData = null)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -1466,7 +1466,7 @@ namespace Barotrauma.Items.Components
                 maxRotation += MathHelper.TwoPi;
             }
             rotation = (minRotation + maxRotation) / 2;
-
+            targetRotation = rotation;
             UpdateTransformedBarrelPos();
         }
 
@@ -1487,7 +1487,7 @@ namespace Barotrauma.Items.Components
                 maxRotation += MathHelper.TwoPi;
             }
             rotation = (minRotation + maxRotation) / 2;
-
+            targetRotation = rotation;
             UpdateTransformedBarrelPos();
         }
 
@@ -1546,12 +1546,12 @@ namespace Barotrauma.Items.Components
         {
             base.OnItemLoaded();
             FindLightComponent();
+            targetRotation = rotation;
             if (!loadedBaseRotation.HasValue)
             {
                 if (item.FlippedX) { FlipX(relativeToSub: false); }
                 if (item.FlippedY) { FlipY(relativeToSub: false); }
             }
-            targetRotation = rotation;
         }
 
         public void ServerWrite(IWriteMessage msg, Client c, object[] extraData = null)


### PR DESCRIPTION
targetrotation wasn't initialized (instantiated?) (apparently that means it's a 0!) so we explicitly set it to = rotation

fixes #7083

https://user-images.githubusercontent.com/5103517/146224707-2751523f-db0d-4b2b-b8c5-91b220f2cf66.mp4

3