### PR TITLE
Manageround command - only read save flag when ending

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -1337,9 +1337,9 @@ namespace Barotrauma.Networking
                     break;
                 case ClientPermissions.ManageRound:
                     bool end = inc.ReadBoolean();
-                    bool save = inc.ReadBoolean();
                     if (end)
                     {
+                        bool save = inc.ReadBoolean();
                         if (gameStarted)
                         {
                             Log("Client \"" + GameServer.ClientLogName(sender) + "\" ended the round.", ServerLog.MessageType.ServerMessage);


### PR DESCRIPTION
[This `save` flag was](https://github.com/Regalis11/Barotrauma/blob/7d43cb1e91ac686e5b87b1a9ce25051c7d9da0a7/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs#L1340) added to the server in commit https://github.com/Regalis11/Barotrauma/commit/80f39cd2a3acf881decade53467b7673bc1a2f0f, but only added in the client to the [GameClient.RequestRoundEnd](https://github.com/Regalis11/Barotrauma/blob/7d43cb1e91ac686e5b87b1a9ce25051c7d9da0a7/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs#L3005-L3014) method, not the [GameClient.RequestRoundStart](https://github.com/Regalis11/Barotrauma/blob/7d43cb1e91ac686e5b87b1a9ce25051c7d9da0a7/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs#L2911-L2920) method.

I think it's right that it's only used when ending the round, so with this change it's only read when ending.