### PR TITLE
Makes recipe hash generation more robust to reduce mod desync issues

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
@@ -106,9 +106,7 @@ namespace Barotrauma.Items.Components
             }
             fabricationRecipes.Sort((r1, r2) =>
             {
-                int hash1 = (int)r1.TargetItem.UIntIdentifier;
-                int hash2 = (int)r2.TargetItem.UIntIdentifier;
-                return hash1 - hash2;
+                return r1.RecipeHash - r2.RecipeHash;
             });
 
             state = FabricatorState.Stopped;

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Fabricator.cs
@@ -106,7 +106,7 @@ namespace Barotrauma.Items.Components
             }
             fabricationRecipes.Sort((r1, r2) =>
             {
-                return r1.RecipeHash - r2.RecipeHash;
+                return (int)r1.RecipeHash - (int)r2.RecipeHash;
             });
 
             state = FabricatorState.Stopped;

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
@@ -783,7 +783,16 @@ namespace Barotrauma
                 itemPrefab.FabricationRecipes.Clear();
                 foreach (XElement fabricationRecipe in itemPrefab.fabricationRecipeElements)
                 {
-                    itemPrefab.FabricationRecipes.Add(new FabricationRecipe(fabricationRecipe, itemPrefab));
+                    var newRecipe = new FabricationRecipe(fabricationRecipe, itemPrefab);
+                    var duplicateHashRecipe = itemPrefab.FabricationRecipes.FirstOrDefault(r => r.RecipeHash == newRecipe.RecipeHash);
+                    if(duplicateHashRecipe != null)
+                    {
+                        DebugConsole.AddWarning(
+                            $"{duplicateHashRecipe.DisplayName} has the same hash as {newRecipe.DisplayName}. " +
+                            $"This can cause issues with fabrication."
+                        );
+                    }
+                    itemPrefab.FabricationRecipes.Add(newRecipe);
                 }
             }
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
@@ -91,6 +91,7 @@ namespace Barotrauma
         public readonly bool RequiresRecipe;
         public readonly float OutCondition; //Percentage-based from 0 to 1
         public readonly List<Skill> RequiredSkills;
+        public readonly int RecipeHash;
 
         public int Amount { get; }
 
@@ -185,6 +186,21 @@ namespace Barotrauma
                         break;
                 }
             }
+
+            RecipeHash = GenerateHash();
+        }
+
+        private int GenerateHash()
+        {
+            var outputId = TargetItem.UIntIdentifier;
+
+            var requiredItems = string.Join(':', RequiredItems
+                .Select(i => i.ItemPrefabs.Select(p => p.UIntIdentifier))
+                .Select(i => string.Join(':', i)));
+
+            var requiredSkills = string.Join(':', RequiredSkills.Select(s => $"{s.Identifier}:{s.Level}"));
+
+            return $"{Amount}|{outputId}|{RequiredTime}|{requiredItems}|{requiredSkills}".GetHashCode();
         }
     }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Xml.Linq;
 
 namespace Barotrauma
@@ -91,7 +92,7 @@ namespace Barotrauma
         public readonly bool RequiresRecipe;
         public readonly float OutCondition; //Percentage-based from 0 to 1
         public readonly List<Skill> RequiredSkills;
-        public readonly int RecipeHash;
+        public readonly uint RecipeHash;
 
         public int Amount { get; }
 
@@ -190,7 +191,7 @@ namespace Barotrauma
             RecipeHash = GenerateHash();
         }
 
-        private int GenerateHash()
+        private uint GenerateHash()
         {
             var outputId = TargetItem.UIntIdentifier;
 
@@ -200,7 +201,10 @@ namespace Barotrauma
 
             var requiredSkills = string.Join(':', RequiredSkills.Select(s => $"{s.Identifier}:{s.Level}"));
 
-            return $"{Amount}|{outputId}|{RequiredTime}|{requiredItems}|{requiredSkills}".GetHashCode();
+            using(var md5 = MD5.Create())
+            {
+                return ToolBox.StringToUInt32Hash($"{Amount}|{outputId}|{RequiredTime}|{requiredItems}|{requiredSkills}", md5);
+            }
         }
     }
 


### PR DESCRIPTION
With large amount of mods even with the hash sorting there's still the issue of client and server recipe lists being desynced and blocking clients from crafting some recipes, or crafting the wrong one. If you have two recipes that make the same item they'll have the same hash, which in turn means that the mod order matters for those particular recipes. While changing load order can fix this to some extent it's good to reduce the downsides when load order is inevitably desynced.

This isn't really a great long term solution as recipes really need some form of load order independent id which the client could then communicate to the server, but it deals with most of the problem for now as long as no recipes share the same hash created by
`$"{Amount}|{outputId}|{RequiredTime}|{requiredItems}|{requiredSkills}"`

You may want to use something close to this to generate the hash in the end anyway. In the future only `GenerateHash()` should need to be modified.