### PR TITLE
Clears cause of death after revival and skill punishment

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/GameSession/GameModes/MultiPlayerCampaign.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/GameSession/GameModes/MultiPlayerCampaign.cs
@@ -220,6 +220,7 @@ namespace Barotrauma
                 {
                     RespawnManager.ReduceCharacterSkills(characterInfo);
                     characterInfo.RemoveSavedStatValuesOnDeath();
+                    characterInfo.CauseOfDeath = null;
                 }
                 c.CharacterInfo = characterInfo;
                 characterData.RemoveAll(cd => cd.MatchesClient(c));

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/RespawnManager.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/RespawnManager.cs
@@ -399,6 +399,7 @@ namespace Barotrauma.Networking
                         {
                             ReduceCharacterSkills(characterInfos[i]);
                             characterInfos[i].RemoveSavedStatValuesOnDeath();
+                            characterInfos[i].CauseOfDeath = null;
                         }
                     }
                 }


### PR DESCRIPTION
I tested this and it seemed to be fine with nothing unexpected but it feels like I'm missing something that uses cause of death after this point.

This fixes skills repeatedly getting deducted after someone revives once mid round.

fixes #7755
fixes #7843
fixes #7791
