### PR TITLE
Fix bug (#7873) correctly check if sub is owned before switching

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/Voting.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/Voting.cs
@@ -131,7 +131,7 @@ namespace Barotrauma
                     {
                         string subName = inc.ReadString();
                         SubmarineInfo subInfo = SubmarineInfo.SavedSubmarines.FirstOrDefault(s => s.Name == subName);
-                        if (GameMain.GameSession?.Campaign is MultiPlayerCampaign campaign && campaign.CanPurchaseSub(subInfo))
+                        if (GameMain.GameSession?.Campaign is MultiPlayerCampaign campaign && (campaign.CanPurchaseSub(subInfo) || GameMain.GameSession.IsSubmarineOwned(subInfo)))
                         {
                             StartSubmarineVote(subInfo, voteType, sender);
                         }


### PR DESCRIPTION
Code added to ServerSource\Networking\Voting.cs (line 132-137) checked to see if players could afford subs before switching to them, even if players had already bought the sub. Added an extra condition for cases where players own the sub.