### PR TITLE
Allow servers to send chat messages with custom colors

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/ChatMessage.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/ChatMessage.cs
@@ -46,6 +46,11 @@ namespace Barotrauma.Networking
                     senderName = senderCharacter.Name;
                 }
             }
+
+            Color? textColor = null;
+            if (msg.ReadBoolean())
+                textColor = msg.ReadColorR8G8B8A8();
+
             msg.ReadPadBits();
 
             switch (type)
@@ -135,14 +140,18 @@ namespace Barotrauma.Networking
                         //only show the message box if the text differs from the text in the currently visible box
                         if ((GUIMessageBox.VisibleBox as GUIMessageBox)?.Text?.Text != txt)
                         {
-                            new GUIMessageBox("", txt);
+                            GUIMessageBox messageBox = new GUIMessageBox("", txt);
+                            if (textColor != null) messageBox.Text.TextColor = textColor.Value;
                         }
                         break;
                     case ChatMessageType.ServerMessageBoxInGame:
-                        new GUIMessageBox("", txt, new string[0], type: GUIMessageBox.Type.InGame, iconStyle: styleSetting);
+                        {
+                            GUIMessageBox messageBox = new GUIMessageBox("", txt, new string[0], type: GUIMessageBox.Type.InGame, iconStyle: styleSetting);
+                            if (textColor != null) messageBox.Text.TextColor = textColor.Value;
+                        }
                         break;
                     case ChatMessageType.Console:
-                        DebugConsole.NewMessage(txt, MessageColor[(int)ChatMessageType.Console]);
+                        DebugConsole.NewMessage(txt, textColor == null ? MessageColor[(int)ChatMessageType.Console] : textColor.Value);
                         break;
                     case ChatMessageType.ServerLog:
                         if (!Enum.TryParse(senderName, out ServerLog.MessageType messageType))
@@ -152,7 +161,7 @@ namespace Barotrauma.Networking
                         GameMain.Client.ServerSettings.ServerLog?.WriteLine(txt, messageType);
                         break;
                     default:
-                        GameMain.Client.AddChatMessage(txt, type, senderName, senderClient, senderCharacter, changeType);
+                        GameMain.Client.AddChatMessage(txt, type, senderName, senderClient, senderCharacter, changeType, textColor: textColor);
                         break;
                 }
                 LastID = id;

--- a/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
@@ -2251,7 +2251,35 @@ namespace Barotrauma
                     NewMessage(tag, Color.Yellow);
                 }
             }));
-            
+
+            commands.Add(new Command("sendchatmessage", "Sends a chat message with specified type and color.", (string[] args) =>
+            {
+                if (args.Length < 2)
+                    return;
+
+                ChatMessageType chatMessageType = ChatMessageType.Default;
+                Color? chatMessageColor = null;
+
+                if (args.Length >= 3 && int.TryParse(args[2], out int result))
+				{
+                    chatMessageType = (ChatMessageType)result;
+				}
+
+                if (args.Length >= 7 &&
+                    int.TryParse(args[3], out int r) &&
+                    int.TryParse(args[4], out int g) &&
+                    int.TryParse(args[5], out int b) &&
+                    int.TryParse(args[6], out int a))
+				{
+                    chatMessageColor = new Color(r, g, b, a);
+				}
+
+                foreach (var client in GameMain.Server.ConnectedClients)
+                {
+                    GameMain.Server.SendDirectChatMessage(ChatMessage.Create(args[0], args[1], chatMessageType, null, null, textColor: chatMessageColor), client);
+                }
+            }));
+
             AssignOnClientRequestExecute(
                 "setskill",
                 (senderClient, cursorWorldPos, args) =>

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/ChatMessage.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/ChatMessage.cs
@@ -212,6 +212,11 @@ namespace Barotrauma.Networking
             {
                 msg.Write(Sender.ID);
             }
+            msg.Write(customTextColor != null);
+            if (customTextColor != null)
+            {
+                msg.WriteColorR8G8B8A8(customTextColor.Value);
+            }
             msg.WritePadBits();
             if (Type == ChatMessageType.ServerMessageBoxInGame)
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/ChatMessage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/ChatMessage.cs
@@ -79,9 +79,19 @@ namespace Barotrauma.Networking
 
         public readonly string SenderName;
 
+        private Color? customTextColor;
         public Color Color
         {
-            get { return MessageColor[(int)Type]; }
+            get 
+            {
+                if (customTextColor != null) return customTextColor.Value;
+                return MessageColor[(int)Type]; 
+            }
+
+			set
+			{
+                customTextColor = value;
+			}
         }
 
         public static string GetTimeStamp()
@@ -105,7 +115,7 @@ namespace Barotrauma.Networking
             set;
         }
 
-        protected ChatMessage(string senderName, string text, ChatMessageType type, Character sender, Client client, PlayerConnectionChangeType changeType = PlayerConnectionChangeType.None)
+        protected ChatMessage(string senderName, string text, ChatMessageType type, Character sender, Client client, PlayerConnectionChangeType changeType = PlayerConnectionChangeType.None, Color? textColor = null)
         {
             Text = text;
             Type = type;
@@ -115,11 +125,13 @@ namespace Barotrauma.Networking
 
             SenderName = senderName;
             ChangeType = changeType;
-        }        
 
-        public static ChatMessage Create(string senderName, string text, ChatMessageType type, Character sender, Client client = null, PlayerConnectionChangeType changeType = PlayerConnectionChangeType.None)
+            customTextColor = textColor;
+        }
+
+        public static ChatMessage Create(string senderName, string text, ChatMessageType type, Character sender, Client client = null, PlayerConnectionChangeType changeType = PlayerConnectionChangeType.None, Color? textColor = null)
         {
-            return new ChatMessage(senderName, text, type, sender, client ?? GameMain.NetworkMember?.ConnectedClients?.Find(c => c.Character != null && c.Character == sender), changeType);
+            return new ChatMessage(senderName, text, type, sender, client ?? GameMain.NetworkMember?.ConnectedClients?.Find(c => c.Character != null && c.Character == sender), changeType, textColor);
         }
 
         public static string GetChatMessageCommand(string message, out string messageWithoutCommand)

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/NetworkMember.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/NetworkMember.cs
@@ -236,9 +236,9 @@ namespace Barotrauma.Networking
             return radioComponent.HasRequiredContainedItems(sender, addMessage: false);
         }
 
-        public void AddChatMessage(string message, ChatMessageType type, string senderName = "", Client senderClient = null, Character senderCharacter = null, PlayerConnectionChangeType changeType = PlayerConnectionChangeType.None)
+        public void AddChatMessage(string message, ChatMessageType type, string senderName = "", Client senderClient = null, Character senderCharacter = null, PlayerConnectionChangeType changeType = PlayerConnectionChangeType.None, Color? textColor = null)
         {
-            AddChatMessage(ChatMessage.Create(senderName, message, type, senderCharacter, senderClient, changeType: changeType));
+            AddChatMessage(ChatMessage.Create(senderName, message, type, senderCharacter, senderClient, changeType: changeType, textColor: textColor));
         }
 
         public virtual void AddChatMessage(ChatMessage message)
@@ -247,7 +247,7 @@ namespace Barotrauma.Networking
                         
             if (message.Sender != null && !message.Sender.IsDead)
             {
-                message.Sender.ShowSpeechBubble(2.0f, ChatMessage.MessageColor[(int)message.Type]);
+                message.Sender.ShowSpeechBubble(2.0f, message.Color);
             }
         }
 


### PR DESCRIPTION
This is a very simple addition, it allows servers to specify the color of a chat message when sending it to clients, this should make things a little bit more interesting with servers running modified versions of the game.

This also adds a debug console command: `sendchatmessage [sender] [message] [type] [r] [g] [b] [a]`, to help testing this.

I tested this in debug/release mode, and everything seems to work, nothing seems to break.

Feel free to ask for changes, many thanks!