### PR TITLE
Fix order of operations issue causing #7864

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/RelayComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/RelayComponent.cs
@@ -113,7 +113,7 @@ namespace Barotrauma.Items.Components
                 }
                 throttlePowerOutput = overloaded ?
 					MathHelper.Clamp(throttlePowerOutput, 0.0f, MaxPower): 					
-					Math.Max(throttlePowerOutput - MaxPower * 0.1f * deltaTime, 0.0f);
+					Math.Max((throttlePowerOutput - MaxPower) * 0.1f * deltaTime, 0.0f);
             }
 
             if (Math.Min(-currPowerConsumption, PowerLoad) > maxPower && CanBeOverloaded)


### PR DESCRIPTION
This fixes the order of operations issue that causes a long delay for power to reach relay components after the first in a chain. The delay was caused by the value of throttlePowerOutput being much higher than it should be because it was doing the subtraction last rather than first.