### PR TITLE
Add a low oxygen pin

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OxygenDetector.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/OxygenDetector.cs
@@ -4,6 +4,8 @@ namespace Barotrauma.Items.Components
 {
     class OxygenDetector : ItemComponent
     {
+        public const int LowOxygenPercentage = 35;
+
         public OxygenDetector(Item item, XElement element)
             : base (item, element)
         {
@@ -14,7 +16,9 @@ namespace Barotrauma.Items.Components
         {
             if (item.CurrentHull == null) return;
 
-            item.SendSignal(((int)item.CurrentHull.OxygenPercentage).ToString(), "signal_out");            
+            int oxygenPercentage = (int)item.CurrentHull.OxygenPercentage;
+            item.SendSignal((oxygenPercentage).ToString(), "signal_out");
+            item.SendSignal((oxygenPercentage <= LowOxygenPercentage ? "1" : "0"), "low_oxygen");
         }
 
     }


### PR DESCRIPTION
- [x] I have searched the issue tracker to check if the issue has already been reported.

**Description**
This is a feature request
Oxygen generators only put out a percentage of oxygen in the current hull. This makes creating circuits that toggle on and off the oxygen generator a complete abomination that likely impacts performance. This seems to be getting more popular (maybe I am just noticing people do it more).
See;
https://steamcommunity.com/sharedfiles/filedetails/?id=2732232801
https://steamcommunity.com/sharedfiles/filedetails/?id=2732422820
https://steamcommunity.com/sharedfiles/filedetails/?id=2419010949

This is easily resolved by adding a low_oxygen pin to the oxygen generator similar to how the Water Detector has a high_pressure pin. Adding this pin would also make creating an alarm for low oxygen work in a similar manor to how fire and flood alarms work in vanilla subs.

**Steps To Reproduce**
Attempt to create a circuit that will toggle on and off the oxygen generator if the oxygen is low in any hull without using a ridiculous number of components.

**Version**
v0.15.23.0 (Windows/Linux).
I play on Linux, but develop/debug on windows because I use Visual Studio.

**Additional information**

Add an low_oxygen pin to the Oxygen Detector. 
This change requires xml changes as well. I can't add those to the PR because they are not in this repo.

This needs to be added to the oxygendetector ConnectionPanel in the signalitems.xml
`<output name="low_oxygen" displayname="connection.lowoxygenout" />`

This needs to be added to the EnglishVanilla.xml. I don't know other languages so I am no help with translation.
`<connection.lowoxygenout>low_oxygen</connection.lowoxygenout>`