### PR TITLE
Unstable Power Rework Fixes

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
@@ -418,7 +418,7 @@ namespace Barotrauma.Items.Components
             {
                 float idealLoad = MaxPowerOutput / minMaxPower.ReactorMaxOutput * loadLeft;
                 float loadAdjust = MathHelper.Clamp((ratio - 0.5f) * 25 + idealLoad - (turbineOutput / 100 * MaxPowerOutput), -MaxPowerOutput / 100, MaxPowerOutput / 100);
-                newLoad = MathHelper.Clamp(loadLeft - (expectedPower + output) + loadAdjust, 0, loadLeft);
+                newLoad = MathHelper.Clamp(loadLeft - (expectedPower - output) + loadAdjust, 0, loadLeft);
             }
 
             if (float.IsNegative(newLoad))

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
@@ -176,23 +176,6 @@ namespace Barotrauma.Items.Components
         {
             RefreshConnections();
 
-            float powerReadingOut = 0;
-            float loadReadingOut = ExtraLoad;
-            if (powerLoad < 0)
-            {
-                powerReadingOut = -powerLoad;
-                loadReadingOut = 0;
-            }
-
-            if (powerOut != null && powerOut.Grid != null)
-            {
-                powerReadingOut = powerOut.Grid.Power;
-                loadReadingOut = powerOut.Grid.Load;
-            }
-
-            item.SendSignal(((int)Math.Round(powerReadingOut)).ToString(), "power_value_out");
-            item.SendSignal(((int)Math.Round(loadReadingOut)).ToString(), "load_value_out");
-
             if (Timing.TotalTime > extraLoadSetTime + 1.0)
             {
                 //Decay the extra load to 0 from either positive or negative
@@ -219,14 +202,28 @@ namespace Barotrauma.Items.Components
             //if the item can't be fixed, don't allow it to break
             if (!item.Repairables.Any() || !CanBeOverloaded) { return; }
 
-            if (prevSentPowerValue != (int)-CurrPowerConsumption || powerSignal == null)
+            float powerReadingOut = 0;
+            float loadReadingOut = ExtraLoad;
+            if (powerLoad < 0)
             {
-                prevSentPowerValue = (int)Math.Round(-CurrPowerConsumption);
+                powerReadingOut = -powerLoad;
+                loadReadingOut = 0;
+            }
+
+            if (powerOut != null && powerOut.Grid != null)
+            {
+                powerReadingOut = powerOut.Grid.Power;
+                loadReadingOut = powerOut.Grid.Load;
+            }
+
+            if (prevSentPowerValue != (int)powerReadingOut || powerSignal == null)
+            {
+                prevSentPowerValue = (int)Math.Round(powerReadingOut);
                 powerSignal = prevSentPowerValue.ToString();
             }
-            if (prevSentLoadValue != (int)powerLoad || loadSignal == null)
+            if (prevSentLoadValue != (int)loadReadingOut || loadSignal == null)
             {
-                prevSentLoadValue = (int)Math.Round(powerLoad);
+                prevSentLoadValue = (int)Math.Round(loadReadingOut);
                 loadSignal = prevSentLoadValue.ToString();
             }
             item.SendSignal(powerSignal, "power_value_out");

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/Powered.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/Powered.cs
@@ -238,7 +238,11 @@ namespace Barotrauma.Items.Components
                     else if (c.Name == "power_out")
                     {
                         powerOut = c;
-                        powerOut.Priority = Priority;
+                        // Connection takes the lowest priority
+                        if (Priority > powerOut.Priority)
+                        {
+                            powerOut.Priority = Priority;
+                        }
                     }
                     else if (c.Name == "power")
                     {
@@ -258,7 +262,11 @@ namespace Barotrauma.Items.Components
 #endif
                         }
                         powerOut = c;
-                        powerOut.Priority = Priority;
+                        // Connection takes the lowest priority
+                        if (Priority > powerOut.Priority)
+                        {
+                            powerOut.Priority = Priority;
+                        }
                     }
                     else
                     {

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
@@ -573,7 +573,7 @@ namespace Barotrauma
                     if (connections == null) { return; }                    
                     foreach (Connection c in connections.Values)
                     {
-                        if (c.IsPower && c.Grid != null)
+                        if (c.IsPower)
                         {
                             Powered.ChangedConnections.Add(c);
                             foreach (Connection conn in c.Recipients)


### PR DESCRIPTION
Fixes bugs relating to the power rework caused by refactoring. Most of the issues were very minor.
Also fixed batteries causing flickering which was actually from the original pr.

### Fixed
- Multi-reactor equations giving incorrect load
- Battery's equations outputting incorrectly and flickering if output power exceeded input power
- Broken devices being repaired not updating grid connections
- Junction box power_value_out and load_value_out outputting incorrect values
- Battery's power_value_out being negative
- Battery's dividing by zero causing nan errors
- Powerpriority of connections being incorrectly assigned

### Related issues
- #8386 
- #8387 
- #8388 