### PR TITLE
#8473 No output on POWER/LOAD_VALUE_OUT on JB overload off

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
@@ -183,9 +183,6 @@ namespace Barotrauma.Items.Components
 
             ApplyStatusEffects(ActionType.OnActive, deltaTime, null);
 
-            //if the item can't be fixed, don't allow it to break
-            if (!item.Repairables.Any() || !CanBeOverloaded) { return; }
-
             if (prevSentPowerValue != (int)-CurrPowerConsumption || powerSignal == null)
             {
                 prevSentPowerValue = (int)Math.Round(-CurrPowerConsumption);
@@ -198,6 +195,9 @@ namespace Barotrauma.Items.Components
             }
             item.SendSignal(powerSignal, "power_value_out");
             item.SendSignal(loadSignal, "load_value_out");
+
+            //if the item can't be fixed, don't allow it to break
+            if (!item.Repairables.Any() || !CanBeOverloaded) { return; }
 
             float maxOverVoltage = Math.Max(OverloadVoltage, 1.0f);
             Overload = -currPowerConsumption > Math.Max(powerLoad, 200.0f) * maxOverVoltage;


### PR DESCRIPTION
It was not reaching the code that set power_value_out and load_value_out when can be overloaded was false.
