### PR TITLE
Unstable Power fixes

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/Powered.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/Powered.cs
@@ -151,6 +151,8 @@ namespace Barotrauma.Items.Components
             }
             set
             {
+                /*
+                 * Removed as setting Voltage in most cases shouldn't set the voltage for the grid as a whole, only for the device.
                 if (powerIn != null)
                 {
                     if (powerIn.Grid != null)
@@ -165,6 +167,7 @@ namespace Barotrauma.Items.Components
                         powerOut.Grid.Voltage = Math.Max(0.0f, value);
                     }
                 }
+                */
                 voltage = Math.Max(0.0f, value);
             }
         }
@@ -213,7 +216,7 @@ namespace Barotrauma.Items.Components
                 powerOnSoundPlayed = false;
             }
 #endif
-            if (powerIn == null)
+            if (powerIn == null && powerOut == null)
             {
                 //power down the device here if it has no power connection (= receives power from contained battery cells instead of the "normal" power logic)
                 Voltage -= deltaTime;
@@ -500,7 +503,7 @@ namespace Barotrauma.Items.Components
                     }
                     else
                     {
-                        powered.CurrPowerConsumption = powered.GetConnectionPowerOut(powered.powerIn, 0, powered.MinMaxPowerOut(powered.powerIn, 0), 0);
+                        powered.CurrPowerConsumption = -powered.GetConnectionPowerOut(powered.powerIn, 0, powered.MinMaxPowerOut(powered.powerIn, 0), 0);
                         powered.GridResolved(powered.powerIn);
                     }
                 }
@@ -541,7 +544,7 @@ namespace Barotrauma.Items.Components
                     else
                     {
                         //Perform power calculations for the singular connection
-                        float loadOut = powered.GetConnectionPowerOut(powered.powerOut, 0, powered.MinMaxPowerOut(powered.powerOut, 0), 0);
+                        float loadOut = -powered.GetConnectionPowerOut(powered.powerOut, 0, powered.MinMaxPowerOut(powered.powerOut, 0), 0);
                         if (powered is PowerTransfer pt2)
                         {
                             pt2.PowerLoad = loadOut;
@@ -667,7 +670,7 @@ namespace Barotrauma.Items.Components
 
         public static bool ValidPowerConnection(Connection conn1, Connection conn2)
         {
-            return conn1.IsPower && conn2.IsPower && (conn1.Item.HasTag("junctionbox") || conn2.Item.HasTag("junctionbox") || conn1.IsOutput != conn2.IsOutput || (conn1.Item.HasTag("dock") && conn2.Item.HasTag("dock")));
+            return conn1.IsPower && conn2.IsPower && (conn1.Item.HasTag("junctionbox") || conn2.Item.HasTag("junctionbox") || conn1.Item.HasTag("dock") || conn2.Item.HasTag("dock") || conn1.IsOutput != conn2.IsOutput);
         }
 
         /// <summary>

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/Powered.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/Powered.cs
@@ -216,7 +216,7 @@ namespace Barotrauma.Items.Components
                 powerOnSoundPlayed = false;
             }
 #endif
-            if (powerIn == null && powerOut == null)
+            if (powerIn == null)
             {
                 //power down the device here if it has no power connection (= receives power from contained battery cells instead of the "normal" power logic)
                 Voltage -= deltaTime;


### PR DESCRIPTION
### Fixes

- Power incorrectly displayed in reactor when unwired
- Power being incorrectly stored in their class (Cause of above issue)
- Some docking connections being considered invalid (Relay output to docking port)
- Removed Voltage property from setting voltage of the grid. Caused confusion and in many cases is not needed or wanted.

I think I got all the power related bug, hopefully this is the last of it. 