### PR TITLE
Fix unkillable ballast flora bug

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Creatures/BallastFloraBehavior.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Creatures/BallastFloraBehavior.cs
@@ -457,7 +457,7 @@ namespace Barotrauma.MapCreatures.Behavior
                 int parentBranchId = branchElement.GetAttributeInt("parentbranch", -1);
 
                 BallastFloraBranch? parentBranch = null;
-                if (parentBranchId > -1)
+                if (parentBranchId > -1 && parentBranchId < Branches.Count)
                 {
                     parentBranch = Branches[parentBranchId];
                 }


### PR DESCRIPTION
This fixes https://github.com/Regalis11/Barotrauma/issues/8947

After making this change and building locally, I was able to kill the ballast flora after loading my save: 
![image](https://user-images.githubusercontent.com/2903742/164989748-074bcc30-2bd3-4a27-8173-bdc508673d78.png)
