### PR TITLE
Switch physics timers from ElapsedTicks to Elapsed.Ticks See #9045

### DIFF
--- a/Libraries/Farseer Physics Engine 3.5/Dynamics/World.cs
+++ b/Libraries/Farseer Physics Engine 3.5/Dynamics/World.cs
@@ -1414,7 +1414,7 @@ namespace FarseerPhysics.Dynamics
 
             ProcessChanges();
             if (Settings.EnableDiagnostics)
-                AddRemoveTime = TimeSpan.FromTicks(_watch.ElapsedTicks);
+                AddRemoveTime = TimeSpan.FromTicks(_watch.Elapsed.Ticks);
 
             // If new fixtures were added, we need to find the new contacts.
             if (_worldHasNewFixture)
@@ -1423,7 +1423,7 @@ namespace FarseerPhysics.Dynamics
                 _worldHasNewFixture = false;
             }
             if (Settings.EnableDiagnostics)
-                NewContactsTime = TimeSpan.FromTicks(_watch.ElapsedTicks) - AddRemoveTime;
+                NewContactsTime = TimeSpan.FromTicks(_watch.Elapsed.Ticks) - AddRemoveTime;
 
             //FPE only: moved position and velocity iterations into Settings.cs
             TimeStep step;
@@ -1443,12 +1443,12 @@ namespace FarseerPhysics.Dynamics
                     ControllerList[i].Update(dt);
                 }
                 if (Settings.EnableDiagnostics)
-                    ControllersUpdateTime = TimeSpan.FromTicks(_watch.ElapsedTicks) - (AddRemoveTime + NewContactsTime);
+                    ControllersUpdateTime = TimeSpan.FromTicks(_watch.Elapsed.Ticks) - (AddRemoveTime + NewContactsTime);
 
                 // Update contacts. This is where some contacts are destroyed.
                 ContactManager.Collide();
                 if (Settings.EnableDiagnostics)
-                    ContactsUpdateTime = TimeSpan.FromTicks(_watch.ElapsedTicks) - (AddRemoveTime + NewContactsTime + ControllersUpdateTime);
+                    ContactsUpdateTime = TimeSpan.FromTicks(_watch.Elapsed.Ticks) - (AddRemoveTime + NewContactsTime + ControllersUpdateTime);
 
                 // Integrate velocities, solve velocity constraints, and integrate positions.
                 if (_stepComplete && step.dt > 0.0f)
@@ -1456,7 +1456,7 @@ namespace FarseerPhysics.Dynamics
                     Solve(ref step);
                 }
                 if (Settings.EnableDiagnostics)
-                    SolveUpdateTime = TimeSpan.FromTicks(_watch.ElapsedTicks) - (AddRemoveTime + NewContactsTime + ControllersUpdateTime + ContactsUpdateTime);
+                    SolveUpdateTime = TimeSpan.FromTicks(_watch.Elapsed.Ticks) - (AddRemoveTime + NewContactsTime + ControllersUpdateTime + ContactsUpdateTime);
 
                 // Handle TOI events.
                 if (Settings.ContinuousPhysics && step.dt > 0.0f)
@@ -1464,7 +1464,7 @@ namespace FarseerPhysics.Dynamics
                     SolveTOI(ref step, ref iterations);
                 }
                 if (Settings.EnableDiagnostics)
-                    ContinuousPhysicsTime = TimeSpan.FromTicks(_watch.ElapsedTicks) - (AddRemoveTime + NewContactsTime + ControllersUpdateTime + ContactsUpdateTime + SolveUpdateTime);
+                    ContinuousPhysicsTime = TimeSpan.FromTicks(_watch.Elapsed.Ticks) - (AddRemoveTime + NewContactsTime + ControllersUpdateTime + ContactsUpdateTime + SolveUpdateTime);
 
                 if (step.dt > 0.0f)
                     Fluid.Update(dt);


### PR DESCRIPTION
The following performance counters are off by what appears to be a factor of 100 on linux. See #9045
ContinuousPhysicsTime
ControllersUpdateTime
AddRemoveTime
NewContactsTime
ContactsUpdateTime
SolveUpdateTime