### PR TITLE
Fix save decompression not working on .NET 6 with other platforms

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/SaveUtil.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/SaveUtil.cs
@@ -480,7 +480,7 @@ namespace Barotrauma
             int read = 0;
 
             // FIXME workaround for .NET6 causing save decompression to fail
-#if NET6_0 && LINUX
+#if NET6_0
             for (int i = 0; i < amount; i++)
             {
                 int result = zipStream.ReadByte();


### PR DESCRIPTION
Simply removes the LINUX preprocessor check, because the problem also happens on other platforms.