### PR TITLE
Make 4th 5th mouse buttons work on Linux

### DIFF
--- a/Libraries/MonoGame.Framework/Src/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/Libraries/MonoGame.Framework/Src/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             return PrimaryWindow.Handle;
         }
-        
+
         private static void PlatformSetWindowHandle(IntPtr windowHandle)
         {
         }
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             int x, y;
             var winFlags = Sdl.Window.GetWindowFlags(window.Handle);
-            var state = Sdl.Mouse.GetGlobalState(out x, out y);
+            var state = Sdl.Mouse.GetState(out x, out y);
 
             if ((winFlags & Sdl.Window.State.MouseFocus) != 0)
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             PrimaryWindow.MouseState.X = x;
             PrimaryWindow.MouseState.Y = y;
-            
+
             Sdl.Mouse.WarpInWindow(PrimaryWindow.Handle, x, y);
         }
 

--- a/Libraries/MonoGame.Framework/Src/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/Libraries/MonoGame.Framework/Src/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Xna.Framework.Input
         {
             PrimaryWindow.MouseState.X = x;
             PrimaryWindow.MouseState.Y = y;
-
             Sdl.Mouse.WarpInWindow(PrimaryWindow.Handle, x, y);
         }
 


### PR DESCRIPTION
I followed emmyposs's advice here #6305 to make the 4th and 5th mouse buttons work.

I tested it on my system (Ubuntu 20.04) and it works. I am able to assign the fourth and fifth mouse buttons to actions and they work in game. They also get labeled correctly in game which is nice as well. I didn't do extensive testing but I did not notice any negative side affects.