### PR TITLE
Allow characters to switch attacks without snapping ropes from previous attacks

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
@@ -87,11 +87,11 @@ namespace Barotrauma
                 if (_attackLimb != value)
                 {
                     _previousAttackLimb = _attackLimb;
-                    _previousAttackLimb?.AttachedRope?.Snap();
+                    if (_previousAttackLimb != null && _previousAttackLimb.attack.SnapRopeOnNewAttack) { _previousAttackLimb?.AttachedRope?.Snap(); }
                 }
                 else if (_attackLimb != null && _attackLimb.attack.CoolDownTimer <= 0)
                 {
-                    _attackLimb.AttachedRope?.Snap();
+                    if (_attackLimb != null && _attackLimb.attack.SnapRopeOnNewAttack) { _attackLimb?.AttachedRope?.Snap(); }
                 }
                 _attackLimb = value;
                 attackVector = null;

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
@@ -100,6 +100,9 @@ namespace Barotrauma
         [Serialize(false, IsPropertySaveable.Yes, description: "Should the AI try to turn around when aiming with this attack?"), Editable]
         public bool Reverse { get; private set; }
 
+        [Serialize(true, IsPropertySaveable.Yes, description: "Should the rope attached to this limb snap upon choosing a new attack?"), Editable]
+        public bool SnapRopeOnNewAttack { get; private set; }
+
         [Serialize(false, IsPropertySaveable.Yes, description: "Should the AI try to steer away from the target when aiming with this attack? Best combined with PassiveAggressive behavior."), Editable]
         public bool Retreat { get; private set; }
 


### PR DESCRIPTION
This PR adds a way to "get around" one of the most recent changes introduced in the "Urban Expanses" update:
` Ropes attached to limbs now automatically snap when another attack is chosen.`
The abovementioned is pretty a pretty useful QoL improvement which makes it very easy to make a character drag another character towards itself and immediately release it after attacking. However it makes it _impossible_ to make a character drag another character towards itself and NOT immediately release it without taking more complicated steps.

```
Adds a new parameter to attacks: "SnapRopeOnNewAttack", set to true by default.
If true, when a new attack is picked to be used next by a character, any rope created by a previous attack will automatically snap.
If false, when a new attack is picked to be used next by a character, ropes will be left intact.
```

This would allow, for example, to create a monster which drags a crewmember towards itself and periodically attacks it while holding onto it and also swimming away.