### PR TITLE
Alter AttackResult ctor

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
@@ -72,7 +72,7 @@ namespace Barotrauma
         {
             Damage = damage;
             HitLimb = null;
-            Afflictions = null;
+            Afflictions = new List<Affliction>();
             AppliedDamageModifiers = appliedDamageModifiers;
         }
     }


### PR DESCRIPTION
Make Afflictions an empty list rather than null. Reason: Causes a potential NRE with HumanAIController, rather than altering that logic and leaving other avenues for potential NREs I think it's better to just make AttackResult.Afflictions not null. This generally shouldn't cause an issue because it's just an empty enumerable.