### PR TITLE
Add the ability to inherit AND override a prefab

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Prefabs/PrefabSelector.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Prefabs/PrefabSelector.cs
@@ -35,7 +35,7 @@ namespace Barotrauma
                 lock (overrides)
                 {
                     var previous = previousPrefabInternal;
-                    if (previous != ActivePrefab)
+                    if (previous != activePrefabInternal)
                         return previous;
                     return null;
                 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Prefabs/PrefabSelector.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Prefabs/PrefabSelector.cs
@@ -24,6 +24,23 @@ namespace Barotrauma
                 lock (overrides) { return activePrefabInternal; }
             }
         }
+        
+        /// <summary>
+        /// Returns the first non-active prefab if exists, else null.
+        /// </summary>
+        public T? PreviousPrefab
+        {
+            get
+            {
+                lock (overrides)
+                {
+                    var previous = previousPrefabInternal;
+                    if (previous != ActivePrefab)
+                        return previous;
+                    return null;
+                }
+            }
+        }
 
         public void Add(T prefab, bool isOverride)
         {
@@ -74,6 +91,8 @@ namespace Barotrauma
         private readonly List<T> overrides = new List<T>();
 
         private T? activePrefabInternal => overrides.Any() ? overrides.First() : basePrefabInternal;
+        
+        private T? previousPrefabInternal => overrides.Count > 1 ? overrides.Skip(1).First() : basePrefabInternal;
 
         private void AddInternal(T prefab, bool isOverride)
         {


### PR DESCRIPTION
This modifies the prefab loading code to allow inheriting from a prefab while overriding it. This is useful for "patching" existing prefabs without having to duplicate them in their entirety. It also allows patching chains to exist where ModA modified an item from Vanilla and ModB can then modify it further without undoing what ModA did (assuming they are modifying different properties).

With this change the following is now a valid item that will override only the name, spritecolor and InventoryIconColor. All other properties are inherited from the parent version that is being overridden. It is now possible to create mods that tweak prefabs from other mods as long as you load them in the correct order.

```
<?xml version="1.0" encoding="utf-8"?>
<Items>
  <Override>
    <!-- Inherit and override to make harpoons orange -->
    <Item name="Spear Override" identifier="spear" inherit="spear" spritecolor="255,165,0,255" InventoryIconColor="255,165,0,255">
    </Item>
  </Override>
</Items>
```


I tested with the mods included in the zip as well as a number of my mods and mods I got from the workshop. You can use this order to chain patches over a few mods.

![mods](https://user-images.githubusercontent.com/2231937/172771515-0d6a7f81-e522-4d6e-9e8a-8640d49b376a.png)

I also included `inherit override self`, `inherit without override` and `inherit without override 2` that are all doing unsupported things that should prevent the mods from being activated with an error message.

[test-mods.zip](https://github.com/Regalis11/Barotrauma/files/8867148/test-mods.zip)

This relates to item #9237