### PR TITLE
Fix multiple dedicated servers running on same IP Address not working properly

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/ServerListScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/ServerListScreen.cs
@@ -1764,7 +1764,7 @@ namespace Barotrauma
             if (serverInfo.OwnerVerified)
             {
                 var childrenToRemove = serverList.Content.FindChildren(c => (c.UserData is ServerInfo info) && info != serverInfo &&
-                                                                            (serverInfo.OwnerID != 0 ? info.OwnerID == serverInfo.OwnerID : info.IP == serverInfo.IP)).ToList();
+                                                                            (serverInfo.OwnerID != 0 ? info.OwnerID == serverInfo.OwnerID : info.IP == serverInfo.IP && info.Port == serverInfo.Port)).ToList();
                 foreach (var child in childrenToRemove)
                 {
                     serverList.Content.RemoveChild(child);


### PR DESCRIPTION
This PR fixes two bugs:

1) Multiple servers on same IP wouldn't show up on the server browser, this is fixed by adding the port value check that was left out here:
https://github.com/Regalis11/Barotrauma/blob/master/Barotrauma/BarotraumaClient/ClientSource/Screens/ServerListScreen.cs#L1766-L1767

2) Multiple servers on same IP would have "?" as ping, this is fixed by changing activePings so it uses a ServerInfo object instead of a string IP Address

Related to #6412