### PR TITLE
[Feature Request] - Factor in submarine depth to the crush depth damage interval

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
@@ -40,7 +40,10 @@ namespace Barotrauma
             private set;
         }
 
-        private float depthDamageTimer = 10.0f;
+        // Defaults 0.1f, 10.0f, 0.05f -> min time (0.1 seconds) acheived at 200 m below crush depth
+        private float minDepthDamageTimer = 0.1f;
+        private float maxDepthDamageTimer = 10.0f;
+        private float depthToTimeRatio = 0.05f;
 
         private readonly Submarine submarine;
 
@@ -521,11 +524,6 @@ namespace Barotrauma
                     GameMain.GameScreen.Cam.Shake = Math.Max(GameMain.GameScreen.Cam.Shake, MathHelper.Clamp(pastCrushDepth * 0.001f, 1.0f, 50.0f));
                 }
             }
-
-            // Defaults 0.1f, 10.0f, 0.05f -> min time (0.1 seconds) acheived at 200 m below crush depth
-            float minDepthDamageTimer = 0.1f;
-            float maxDepthDamageTimer = 10.0f;
-            float depthToTimeRatio = 0.05f; 
 
             depthDamageTimer = Math.Clamp(maxDepthDamageTimer - (Submarine.RealWorldDepth - Submarine.RealWorldCrushDepth) * depthToTimeRatio, minDepthDamageTimer, maxDepthDamageTimer);
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
@@ -485,6 +485,7 @@ namespace Barotrauma
 
         private void UpdateDepthDamage(float deltaTime)
         {
+
 #if CLIENT
             if (GameMain.GameSession?.GameMode is TestGameMode) { return; }
 #endif
@@ -521,7 +522,12 @@ namespace Barotrauma
                 }
             }
 
-            depthDamageTimer = 10.0f;
+            // Defaults 0.1f, 10.0f, 0.05f -> min time (0.1 seconds) acheived at 200 m below crush depth
+            float minDepthDamageTimer = 0.1f;
+            float maxDepthDamageTimer = 10.0f;
+            float depthToTimeRatio = 0.05f; 
+
+            depthDamageTimer = Math.Clamp(maxDepthDamageTimer - (Submarine.RealWorldDepth - Submarine.RealWorldCrushDepth) * depthToTimeRatio, minDepthDamageTimer, maxDepthDamageTimer);
         }
 
         public void FlipX()

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
@@ -44,6 +44,7 @@ namespace Barotrauma
         private float minDepthDamageTimer = 0.1f;
         private float maxDepthDamageTimer = 10.0f;
         private float depthToTimeRatio = 0.05f;
+        private float depthDamageTimer = maxDepthDamageTimer;
 
         private readonly Submarine submarine;
 


### PR DESCRIPTION
Currently, a team of about ~3-5 players (depending on sub size) could weld walls faster than crush depth damaged them, making crush depth more of a nuisance than something to avoid.

With this change, crush depth would become more of a danger to the crew and something to avoid reaching (unless under some certain situations).