### PR TITLE
Increase MaxValueInt of LevelObjectAmount in CaveGenerationParams.cs

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Levels/CaveGenerationParams.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Levels/CaveGenerationParams.cs
@@ -79,7 +79,7 @@ namespace Barotrauma
             set { maxBranchCount = Math.Max(value, minBranchCount); }
         }
 
-        [Serialize(50, IsPropertySaveable.Yes), Editable(MinValueInt = 0, MaxValueInt = 1000)]
+        [Serialize(50, IsPropertySaveable.Yes), Editable(MinValueInt = 0, MaxValueInt = 10000)]
         public int LevelObjectAmount
         {
             get;


### PR DESCRIPTION
Increases the maximum amount of objects in a cave from 1000 to 10000.

Useful for modders who want to make more detailed or less empty caves.

Only performace drawbacks are increased loading times while using mods that make use of this change.