### PR TITLE
[BugFix] JB ExtraLoad negative power

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerTransfer.cs
@@ -273,7 +273,7 @@ namespace Barotrauma.Items.Components
 
         public override float GetConnectionPowerOut(Connection conn, float power, PowerRange minMaxPower, float load)
         {
-            return conn == powerOut ? PowerConsumption + ExtraLoad : 0;
+            return conn == powerOut ? MathHelper.Max(-(PowerConsumption + ExtraLoad), 0) : 0;
         }
 
         public override bool Pick(Character picker)


### PR DESCRIPTION
Extraload when set to negative would push negative power onto the grid instead of adding power to the grid.
Simply a +- mistake during implementation.