### PR TITLE
Allow Turrets to mine minerals (detach LevelResources)

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Projectile.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Projectile.cs
@@ -750,6 +750,22 @@ namespace Barotrauma.Items.Components
             else if (target.Body.UserData is Item item)
             {
                 if (item.Condition <= 0.0f) { return false; }
+
+                var levelResource = item.GetComponent<LevelResource>();
+                if (levelResource != null && levelResource.Attached && levelResource.requiredItems.Any() && Item.Tags.Any(tag => levelResource.requiredItems.Contains(tag)))
+                {
+                    float addedDetachTime = deltaTime * (1f + (User ?? Attacker).GetStatValue(StatTypes.RepairToolDeattachTimeMultiplier)) * (1f + Item.GetQualityModifier(Quality.StatType.RepairToolDeattachTimeMultiplier));
+                    levelResource.DeattachTimer += addedDetachTime;
+#if CLIENT
+                    (User ?? Attacker).Controlled?.UpdateHUDProgressBar(
+                        this,
+                        item.WorldPosition,
+                        levelResource.DeattachTimer / levelResource.DeattachDuration,
+                        GUIStyle.Red, GUIStyle.Green, "progressbar.deattaching");
+#endif
+                    FixItemProjSpecific(User, deltaTime, item, showProgressBar: false);
+                    return true;
+                }
             }
 
             //ignore character colliders (the projectile only hits limbs)


### PR DESCRIPTION
### TL;DR: enables modded **Turrets to mine minerals** by allowing Projectiles detach LevelResources.

A `LevelResource` is "mined" when its `deattachTimer` meets or exceeds its `DeattachDuration` (defined in its XML), causing it to detach and become pickable by players.

https://github.com/Regalis11/Barotrauma/blob/960835082a7c635b174af2edcf08203ed9dece55/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/LevelResource.cs#L40-L44

Currently only a `RepairTool` can increase the `DetachTimer` of a `LevelResource` (e.g. `uraniumore`). Players can also do this without an item equipped by just clicking on the `LevelResource` if it doesn't specify `RequiredItems`, as in the case of `aquaticpoppy`.

https://github.com/Regalis11/Barotrauma/blob/960835082a7c635b174af2edcf08203ed9dece55/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RepairTool.cs#L619-L635

This PR enables a `Projectile` to add to the `LevelResource`'s `deattachTimer` in the same way as a `RepairTool` currently can.

It's worth noting that merging this PR won't affect any _existing_ vanilla items or behaviors because only the `plasmacutter` has the `cuttingequipment` tag. For a modded `Turret` or `RangedWeapon` to be able to mine minerals, they'd have to be loaded with modded `Projectile` ammo that also has the `cuttingequipment` tag.