### PR TITLE
Fix power indicator not rotating with battery.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/GUI.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/GUI.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Barotrauma.IO;
 using System.Linq;
-using System.Xml.Linq;
 using Barotrauma.CharacterEditor;
 using Barotrauma.Extensions;
 using Barotrauma.Items.Components;
@@ -50,6 +49,14 @@ namespace Barotrauma
 
     static class GUI
     {
+        // Controls where a line is drawn for given coords.
+        public enum OutlinePosition
+        {
+            Default = 0, // Thickness is inside of top left and outside of bottom right coord
+            Inside = 1, // Thickness is subtracted from the inside
+            Centered = 2, // Thickness is centered on given coords
+            Outside = 3, // Tickness is added to the outside
+        }
         public static GUICanvas Canvas => GUICanvas.Instance;
         public static CursorState MouseCursor = CursorState.Default;
 
@@ -1603,6 +1610,54 @@ namespace Barotrauma
                 sb.Draw(solidWhiteTexture, new Vector2(rect.X + thickness, rect.Bottom - thickness), srcRect, clr, 0.0f, Vector2.Zero, new Vector2(rect.Width - thickness, thickness), SpriteEffects.None, depth);
                 sb.Draw(solidWhiteTexture, new Vector2(rect.Right - thickness, rect.Y + thickness), srcRect, clr, 0.0f, Vector2.Zero, new Vector2(thickness, rect.Height - thickness * 2f), SpriteEffects.None, depth);
             }
+        }
+
+        public static void DrawRectangle(SpriteBatch sb, Vector2 position, Vector2 size, Vector2 pivot, float rotation, Color clr, float depth = 0.0f, float thickness = 1, OutlinePosition outlinePos = OutlinePosition.Centered)
+        {
+            Vector2 topLeft = new Vector2(-pivot.X, -pivot.Y);
+            Vector2 topRight = new Vector2(-pivot.X + size.X, -pivot.Y);
+            Vector2 bottomLeft = new Vector2(-pivot.X, -pivot.Y + size.Y);
+            Vector2 actualSize = size;
+
+            switch(outlinePos)
+            {
+                case OutlinePosition.Default:
+                    actualSize += new Vector2(thickness);
+                    break;
+                case OutlinePosition.Centered:
+                    topLeft -= new Vector2(thickness * 0.5f);
+                    topRight -= new Vector2(thickness * 0.5f);
+                    bottomLeft -= new Vector2(thickness * 0.5f);
+                    actualSize += new Vector2(thickness);
+                    break;
+                case OutlinePosition.Inside:
+                    topRight -= new Vector2(thickness, 0.0f);
+                    bottomLeft -= new Vector2(0.0f, thickness);
+                    break;
+                case OutlinePosition.Outside:
+                    topLeft -= new Vector2(thickness);
+                    topRight -= new Vector2(0.0f, thickness);
+                    bottomLeft -= new Vector2(thickness, 0.0f);
+                    actualSize += new Vector2(thickness * 2.0f);
+                    break;
+            }
+
+            Matrix rotate = Matrix.CreateRotationZ(rotation);
+            topLeft = Vector2.Transform(topLeft, rotate) + position;
+            topRight = Vector2.Transform(topRight, rotate) + position;
+            bottomLeft = Vector2.Transform(bottomLeft, rotate) + position;
+
+            Rectangle srcRect = new Rectangle(0, 0, 1, 1);
+            sb.Draw(solidWhiteTexture, topLeft, srcRect, clr, rotation, Vector2.Zero, new Vector2(thickness, actualSize.Y), SpriteEffects.None, depth);
+            sb.Draw(solidWhiteTexture, topLeft, srcRect, clr, rotation, Vector2.Zero, new Vector2(actualSize.X, thickness), SpriteEffects.None, depth);
+            sb.Draw(solidWhiteTexture, topRight, srcRect, clr, rotation, Vector2.Zero, new Vector2(thickness, actualSize.Y), SpriteEffects.None, depth);
+            sb.Draw(solidWhiteTexture, bottomLeft, srcRect, clr, rotation, Vector2.Zero, new Vector2(actualSize.X, thickness), SpriteEffects.None, depth);
+        }
+
+        public static void DrawFilledRectangle(SpriteBatch sb, Vector2 position, Vector2 size, Vector2 pivot, float rotation, Color clr, float depth = 0.0f)
+        {
+            Rectangle srcRect = new Rectangle(0, 0, 1, 1);
+            sb.Draw(solidWhiteTexture, position, srcRect, clr, rotation, (pivot/size), size, SpriteEffects.None, depth);
         }
 
         public static void DrawFilledRectangle(SpriteBatch sb, RectangleF rect, Color clr, float depth = 0.0f)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Power/PowerContainer.cs
@@ -125,6 +125,14 @@ namespace Barotrauma.Items.Components
             set { efficiency = MathHelper.Clamp(value, 0.0f, 1.0f); }
         }
 
+        private bool flipIndicator;
+        [Editable, Serialize(false, IsPropertySaveable.Yes, description: "Should the progress bar indicating the charge be flipped to fill from the other side.")]
+        public bool FlipIndicator
+        {
+            get { return flipIndicator; }
+            set { flipIndicator = value; }
+        }
+
         public float RechargeRatio => RechargeSpeed / MaxRechargeSpeed;
 
         public const float aiRechargeTargetRatio = 0.5f;


### PR DESCRIPTION
PR for issue #9848

Drawing the charge indicator did not take into account the rotation of the parent container. This fixes this by adding two functions for drawing rotated rectangles, one for an outline and one for filled. The function for drawing the outlined rectangle has been written to accept the desired position for the outline for increased ease of use.

Behavior maintained from previous implementation:
- Mirroring the parent X or Y does not mirror the indicator.

Behavior changed/added:
- The outline is now drawn on the inside of the given coords, so that the overall drawn size matches the size provided.
- The charge indicator accounts for the thickness of the outline so that very small charge levels are still visible and not covered by the outline.
- Added a 'FlipIndicator' property to the power container so that it is possible to truely mirror the object if desired.

Before changes:
![BeforeChange](https://user-images.githubusercontent.com/1829181/193914683-87878e78-2355-4d55-8bf7-da72a98d5a60.png)

After changes:
![AfterChange](https://user-images.githubusercontent.com/1829181/193914715-af520adc-7c9a-46b0-a70e-1c7ed89a9d47.png)

Test sub:
[PowerIndicatorTests.zip](https://github.com/Regalis11/Barotrauma/files/9710214/PowerIndicatorTests.zip)
