### PR TITLE
Make AI calculate target visibility from the turret muzzle.

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Turret.cs
@@ -1401,8 +1401,12 @@ namespace Barotrauma.Items.Components
 
             if (canShoot)
             {
-                Vector2 start = ConvertUnits.ToSimUnits(item.WorldPosition);
+                Vector2 turretBase = ConvertUnits.ToSimUnits(item.WorldPosition);
+                Vector2 start = ConvertUnits.ToSimUnits(GetRelativeFiringPosition());
                 Vector2 end = ConvertUnits.ToSimUnits(targetPos.Value);
+
+                // Check that the target is not closer to us than the muzzle
+                if (Vector2.DistanceSquared(turretBase, start) > Vector2.DistanceSquared(turretBase, end)) { return false; }
                 // Check that there's not other entities that shouldn't be targeted (like a friendly sub) between us and the target.
                 Body worldTarget = CheckLineOfSight(start, end);
                 bool shoot;


### PR DESCRIPTION
Make AI calculate target visibility from the turret muzzle, and add a check that the target is not closer than the muzzle of the turret.

Helps the AI to use turrets with more intimate placement (custom subs).

A good test case is the [U-42C](https://steamcommunity.com/sharedfiles/filedetails/?id=2880175190) from the workshop, which has a rear flak cannon placement that doesn't work well with AI. (Note that a bot-friendly variant is included, but use the default one for testing).

AI seems to work very well with my changes, and I tested a few vanilla subs as well, using freecam and spawning in crawlers and hammerheads.
Probably needs more thorough testing still, as any regression in AI shooting things would be pretty catastrophic.