### PR TITLE
Let quest items be found recursively (fix #10193)

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/CheckItemAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/CheckItemAction.cs
@@ -97,7 +97,7 @@ namespace Barotrauma
         {
             if (inventory == null) { return false; }
             int count = 0;
-            foreach (Item item in inventory.FindAllItems(it => itemTags.Any(it.HasTag) || itemIdentifierSplit.Contains(it.Prefab.Identifier)))
+            foreach (Item item in inventory.FindAllItems(it => itemTags.Any(it.HasTag) || itemIdentifierSplit.Contains(it.Prefab.Identifier), recursive: true))
             {
                 if (!ConditionalsMatch(item, character)) { continue; }
                 count++;


### PR DESCRIPTION
Let quest items be found recursively (inside toolbelts or held containers)

Tested and confirmed it fixes the issue described at #10193, but it may cause unintended behaviour elsewhere, so maybe it should be optional.
That said, I don't think it's an issue with the existing vanilla events that use CheckItemAction.

