### PR TITLE
Make the engine sound level scale with the output

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Engine.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Engine.cs
@@ -58,7 +58,7 @@ namespace Barotrauma.Items.Components
 
         public float CurrentVolume
         {
-            get { return Math.Abs((force / 100.0f) * (MinVoltage <= 0.0f ? 1.0f : Math.Min(prevVoltage / MinVoltage, 1.0f))); }
+            get { return Math.Abs(force * Math.Min(prevVoltage,MaxOverVoltageFactor) / 100.0f) ; }
         }
 
         public float CurrentBrokenVolume


### PR DESCRIPTION
Previously the level would depend on the minimum voltage configured in the editor, only altering the volume if the `prevVoltage` was less than the `MinVoltage`. But this would cause force to be 0 due to no power. Only if minimum voltage was configured higher than 1.0 would affect the equation.