### PR TITLE
Fix Issue #11136 - "[Factions] Hostile faction vessels are either incredibly rare or don't spawn"

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/GameSession/GameModes/CampaignMode.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSession/GameModes/CampaignMode.cs
@@ -428,11 +428,7 @@ namespace Barotrauma
                             var missionPrefabs = MissionPrefab.Prefabs.Where(m => m.Tags.Any(t => t == automaticMission.MissionTag)).OrderBy(m => m.UintIdentifier);
                             if (missionPrefabs.Any())
                             {
-                                var missionPrefab = ToolBox.SelectWeightedRandom(missionPrefabs, p => (float)p.Commonness, rand);     
-                                if (missionPrefab.Type == MissionType.Pirate && Missions.Any(m => m.Prefab.Type == MissionType.Pirate))
-                                {
-                                    continue;                                    
-                                }
+                                var missionPrefab = ToolBox.SelectWeightedRandom(missionPrefabs, p => (float)p.Commonness, rand);
                                 if (automaticMission.LevelType == LevelData.LevelType.Outpost)
                                 {
                                     extraMissions.Add(missionPrefab.Instantiate(new Location[] { currentLocation, currentLocation }, Submarine.MainSub));


### PR DESCRIPTION
This PR fixes issue #11136 by removing an unnecessary(?) check for mission prefabs of type "Pirate" in the AddExtraMissions method.