### PR TITLE
[Requires Localization] Add max level objects to graphics settings.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Map/Levels/LevelObjects/LevelObjectManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/Levels/LevelObjects/LevelObjectManager.cs
@@ -18,7 +18,7 @@ namespace Barotrauma
 
         //Maximum number of visible objects drawn at once. Should be large enough to not have an effect during normal gameplay, 
         //but small enough to prevent wrecking performance when zooming out very far
-        const int MaxVisibleObjects = 500;
+        private readonly int MaxVisibleObjects = GameSettings.CurrentConfig.Graphics.LevelObjectLimit;
 
         private Rectangle currentGridIndices;
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Settings/SettingsMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Settings/SettingsMenu.cs
@@ -289,6 +289,11 @@ namespace Barotrauma
             Label(right, TextManager.Get("ParticleLimit"), GUIStyle.SubHeadingFont);
             Slider(right, (100, 1500), 15, v => Round(v).ToString(), unsavedConfig.Graphics.ParticleLimit, v => unsavedConfig.Graphics.ParticleLimit = Round(v));
             Spacer(right);
+
+            Label(right, TextManager.Get("LevelObjectLimit"), GUIStyle.SubHeadingFont);
+            Slider(right, (250, 5250), 20, v => v > 5000 ? TextManager.Get("unlimited").Value : Round(v).ToString(), unsavedConfig.Graphics.LevelObjectLimit,  v => unsavedConfig.Graphics.LevelObjectLimit = v > 5000 ? int.MaxValue : Round(v),
+                TextManager.Get("LevelObjectLimitTooltip"));
+            Spacer(right);
         }
 
         private static string TrimAudioDeviceName(string name)

--- a/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
@@ -169,6 +169,7 @@ namespace Barotrauma
                         Specularity = true,
                         ChromaticAberration = true,
                         ParticleLimit = 1500,
+                        LevelObjectLimit = 500,
                         LosMode = LosMode.Transparent
                     };
                     gfxSettings.RadialDistortion = true;
@@ -197,6 +198,7 @@ namespace Barotrauma
                 public int FrameLimit;
                 public WindowMode DisplayMode;
                 public int ParticleLimit;
+                public int LevelObjectLimit;
                 public bool Specularity;
                 public bool ChromaticAberration;
                 public LosMode LosMode;


### PR DESCRIPTION
This commit adds a setting to the graphics settings menu that allows users to change the max amount of level objects.

Localization is required for the `LevelObjectLimit` and `LevelObjectLimitTooltip` tags.