### PR TITLE
Reactor fuel percent left fix

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
@@ -336,6 +336,7 @@ namespace Barotrauma.Items.Components
             var containedItems = item.OwnInventory?.AllItems;
             if (containedItems != null)
             {
+                int num_rods = 0;
                 foreach (Item item in containedItems)
                 {
                     if (!item.HasTag("reactorfuel")) { continue; }
@@ -350,8 +351,10 @@ namespace Barotrauma.Items.Components
                             item.Condition -= fissionRate / 100.0f * GetFuelConsumption() * deltaTime;
                         }
                     }
+                    num_rods += 1;
                     fuelLeft += item.ConditionPercentage;
                 }
+                fuelLeft /= num_rods;
             }
 
             if (fissionRate > 0.0f)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
@@ -354,7 +354,10 @@ namespace Barotrauma.Items.Components
                     num_rods += 1;
                     fuelLeft += item.ConditionPercentage;
                 }
-                fuelLeft /= num_rods;
+                if (num_rods > 0)
+                {
+                    fuelLeft /= num_rods;
+                }
             }
 
             if (fissionRate > 0.0f)


### PR DESCRIPTION
Right now the reactor output signal "fuel percentage left" outputs a nonsensical range from 0-400%, it probably should be from 0-100%, so fix this. This makes measuring fuel efficiency of the reactor possible because you can then sample the fuel usage as (% fuel left) * (total fuel). With the current bug you can not do this because there is no way to make sense of how many rods are in the reactor, since for example two fulgarium fuel rods has the same "fuel out" as three thorium fuel rods, so there is no way to measure fuel effieciency, even with very complex circuits to try to calculate how many rods are in the reactor. With this bug fix, you would not even need the number of rods because you can know the actual fuel percentage left and compare it to the total fuel_out which is a unit of heat, in order to calculate what one single percent of fuel means, as opposed to the 0-400% range in which one single percent of fuel could mean anything.