### PR TITLE
Simple wireable creature/item Spawner 

### DIFF
--- a/spawner.xml
+++ b/spawner.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+
+  <Item name="Spawner" nameidentifier="spawner" identifier="spawner" description="" width="128" height="192" texturescale="0.5,0.5" scale="0.5" category="Alien" noninteractable="true" spritecolor="255,255,150,255" >
+    <sprite texture="Content/Map/MapAtlas.png" sourcerect="784,526,100,100" depth="0.975" premultiplyalpha="false" origin="0.5,0.5" />
+    <EntitySpawnerComponent />
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="trigger_in" displayname="connection.turrettriggerin" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />      
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+    </ConnectionPanel> 
+    <CustomInterface canbeselected="true" pickkey="Use" drawhudwhenequipped="true" allowuioverlap="false">
+      <GuiFrame style="ItemUI" absoluteoffset="0,0" anchor="BottomCenter" relativesize="0.2,0.13" />
+      <TextBox text="Item Identifier" propertyname="ItemIdentifier" maxtextlength="50"/>
+      <TextBox text="Species Name" propertyname="Speciesname" maxtextlength="50"/> 
+    </CustomInterface>    
+  </Item>
+  
+</Items>

--- a/spawner.xml
+++ b/spawner.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
 
-  <Item name="Spawner" nameidentifier="spawner" identifier="spawner" description="" width="128" height="192" texturescale="0.5,0.5" scale="0.5" category="Alien" noninteractable="true" spritecolor="255,255,150,255" >
+  <Item name="Spawner" nameidentifier="spawner" identifier="spawner" description="" width="128" height="192" texturescale="0.5,0.5" scale="0.5" category="Electrical" noninteractable="true" spritecolor="255,255,150,255" >
     <sprite texture="Content/Map/MapAtlas.png" sourcerect="784,526,100,100" depth="0.975" premultiplyalpha="false" origin="0.5,0.5" />
     <EntitySpawnerComponent />
     <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">


### PR DESCRIPTION
Adds a simple spawner that can be placed in sub editor, can be triggered by signals and editer via UI
Very useful for "scenario" maps

Initially wanted to update the ruin vent but made it a standalone item because "Ruin Vent" isnt intuitive.
Added the missing xml supported code
Added a GUI field for choosing what can be spawned in-game

Sprite pending


![spawner](https://github.com/Regalis11/Barotrauma/assets/73229309/b4a09b93-78ac-4aca-b607-601dcfb68796)
![spawnerwires](https://github.com/Regalis11/Barotrauma/assets/73229309/c00c56ac-1a08-42c3-9db2-2a955c81797f)


In case you want to update the Ruin Vent itself instead of creating a new item, you might want to update noninteractable="false" so the UI/Wiring isnt accessible

Here's a list of all ruins room that have a ruin vent:

```
alien_chambers2
alien_chambers4way
alien_chasm
alien_chasm2
alien_chasm3
alien_entrance1
alien_entrance2
alien_geneticstorage1L
alien_maintenancepassages
alien_maintenancepassages2
alien_maintenancetunnels1
alien_offices
```

