### PR TITLE
Add option in multiplayer lobby settings to disable the alive crew list

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
@@ -9,7 +9,6 @@ using System.Xml.Linq;
 using Barotrauma.IO;
 using Barotrauma.Items.Components;
 using System.Collections.Immutable;
-using System.Numerics;
 
 namespace Barotrauma
 {

--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
@@ -75,57 +75,66 @@ namespace Barotrauma
                 Stretch = true
             };
 
+            var CrewListDisabled = GameMain.NetworkMember.ServerSettings.DisableCrewList == false;
+
             Color? nameColor = null;
             if (Job != null) { nameColor = Job.Prefab.UIColor; }
 
-            GUITextBlock characterNameBlock = new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform), ToolBox.LimitString(Name, GUIStyle.Font, headerTextArea.Rect.Width), textColor: nameColor, font: GUIStyle.Font)
+            if (CrewListDisabled == false)
             {
-                ForceUpperCase = ForceUpperCase.Yes,
-                Padding = Vector4.Zero
-            };
-
-            if (permissionIcon != null)
-            {
-                Point iconSize = permissionIcon.SourceRect.Size;
-                int iconWidth = (int)((float)characterNameBlock.Rect.Height / iconSize.Y * iconSize.X);
-                new GUIImage(new RectTransform(new Point(iconWidth, characterNameBlock.Rect.Height), characterNameBlock.RectTransform) { AbsoluteOffset = new Point(-iconWidth - 2, 0) }, permissionIcon) { IgnoreLayoutGroups = true };
-            }
-
-            if (Job != null)
-            {
-                new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform), Job.Name, textColor: Job.Prefab.UIColor, font: font)
+                GUITextBlock characterNameBlock = new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform), ToolBox.LimitString(Name, GUIStyle.Font, headerTextArea.Rect.Width), textColor: nameColor, font: GUIStyle.Font)
                 {
+                    ForceUpperCase = ForceUpperCase.Yes,
                     Padding = Vector4.Zero
                 };
-            }
 
-            if (PersonalityTrait != null)
-            {
-                new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform),
-                    TextManager.AddPunctuation(':', TextManager.Get("PersonalityTrait"), PersonalityTrait.DisplayName),
-                    font: font)
+                if (permissionIcon != null)
                 {
-                    Padding = Vector4.Zero
-                };
-            }
+                    Point iconSize = permissionIcon.SourceRect.Size;
+                    int iconWidth = (int)((float)characterNameBlock.Rect.Height / iconSize.Y * iconSize.X);
+                    new GUIImage(new RectTransform(new Point(iconWidth, characterNameBlock.Rect.Height), characterNameBlock.RectTransform) { AbsoluteOffset = new Point(-iconWidth - 2, 0) }, permissionIcon) { IgnoreLayoutGroups = true };
+                }
 
-            GUIButton manageTalentButton = new GUIButton(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform),
-                text: TextManager.Get("ClientPermission.ManageBotTalents"), style: "GUIButtonSmall")
-            {
-                Enabled = false,
-                UserData = TalentMenu.ManageBotTalentsButtonUserData,
-                TextBlock =
+                if (Job != null)
+                {
+                    new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform), Job.Name, textColor: Job.Prefab.UIColor, font: font)
+                    {
+                        Padding = Vector4.Zero
+                    };
+                }
+
+                if (PersonalityTrait != null)
+                {
+                    new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform),
+                        TextManager.AddPunctuation(':', TextManager.Get("PersonalityTrait"), PersonalityTrait.DisplayName),
+                        font: font)
+                    {
+                        Padding = Vector4.Zero
+                    };
+                }
+
+                GUIButton manageTalentButton = new GUIButton(new RectTransform(new Vector2(1.0f, 0.25f), headerTextArea.RectTransform),
+                    text: TextManager.Get("ClientPermission.ManageBotTalents"), style: "GUIButtonSmall")
+                {
+                    Enabled = false,
+                    UserData = TalentMenu.ManageBotTalentsButtonUserData,
+                    TextBlock =
                 {
                     AutoScaleHorizontal = true
                 }
-            };
+                };
 
-            if (TalentMenu.CanManageTalents(this))
+                if (TalentMenu.CanManageTalents(this))
+                {
+                    manageTalentButton.Enabled = true;
+                }
+            }
+            else
             {
-                manageTalentButton.Enabled = true;
+                nameColor = Color.White;
             }
 
-            if (Job != null && Character is not { IsDead: true })
+            if (Job != null && Character is not { IsDead: true } && CrewListDisabled == false)
             {
                 var skillsArea = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.63f), paddedFrame.RectTransform, Anchor.BottomCenter, Pivot.BottomCenter))
                 {
@@ -160,7 +169,7 @@ namespace Barotrauma
                     }
                 }
             }
-            else if (Character is { IsDead: true })
+            else if (Character is { IsDead: true } && CrewListDisabled == false)
             {
                 var deadArea = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.63f), paddedFrame.RectTransform, Anchor.BottomCenter, Pivot.BottomCenter))
                 {
@@ -478,7 +487,7 @@ namespace Barotrauma
         {
             if (evaluateDisguise && IsDisguised) return;
             var icon = !IsDisguisedAsAnother || !evaluateDisguise ? Job?.Prefab?.Icon : disguisedJobIcon;
-            if (icon == null) { return; }
+            if (icon == null || GameMain.NetworkMember.ServerSettings.DisableCrewList == true) { return; }
             Color iconColor = !IsDisguisedAsAnother || !evaluateDisguise ? Job.Prefab.UIColor : disguisedJobColor;
 
             icon.Draw(spriteBatch, area.Center.ToVector2(), iconColor, scale: Math.Min(area.Width / (float)icon.SourceRect.Width, area.Height / (float)icon.SourceRect.Height));

--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
@@ -484,7 +484,7 @@ namespace Barotrauma
         {
             if (evaluateDisguise && IsDisguised) return;
             var icon = !IsDisguisedAsAnother || !evaluateDisguise ? Job?.Prefab?.Icon : disguisedJobIcon;
-            if (icon == null || GameMain.NetworkMember.ServerSettings.DisableCrewList == true) { return; }
+            if (icon == null) { return; }
             Color iconColor = !IsDisguisedAsAnother || !evaluateDisguise ? Job.Prefab.UIColor : disguisedJobColor;
 
             icon.Draw(spriteBatch, area.Center.ToVector2(), iconColor, scale: Math.Min(area.Width / (float)icon.SourceRect.Width, area.Height / (float)icon.SourceRect.Height));

--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
@@ -128,59 +128,55 @@ namespace Barotrauma
                 {
                     manageTalentButton.Enabled = true;
                 }
-            }
-            else
-            {
-                nameColor = Color.White;
-            }
 
-            if (Job != null && Character is not { IsDead: true } && CrewListDisabled == false)
-            {
-                var skillsArea = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.63f), paddedFrame.RectTransform, Anchor.BottomCenter, Pivot.BottomCenter))
+                if (Job != null && Character is not { IsDead: true })
                 {
-                    Stretch = true
-                };
-
-                var skills = Job.GetSkills().ToList();
-                skills.Sort((s1, s2) => -s1.Level.CompareTo(s2.Level));
-
-                new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.0f), skillsArea.RectTransform), TextManager.AddPunctuation(':', TextManager.Get("skills"), string.Empty), font: font) { Padding = Vector4.Zero };
-
-                foreach (Skill skill in skills)
-                {
-                    Color textColor = Color.White * (0.5f + skill.Level / 200.0f);
-
-                    var skillName = new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.0f), skillsArea.RectTransform), TextManager.Get("SkillName." + skill.Identifier), textColor: textColor, font: font) { Padding = Vector4.Zero };
-
-                    float modifiedSkillLevel = skill.Level;
-                    if (Character != null)
+                    var skillsArea = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.63f), paddedFrame.RectTransform, Anchor.BottomCenter, Pivot.BottomCenter))
                     {
-                        modifiedSkillLevel = Character.GetSkillLevel(skill.Identifier);
-                    }
-                    if (!MathUtils.NearlyEqual(MathF.Round(modifiedSkillLevel), MathF.Round(skill.Level)))
+                        Stretch = true
+                    };
+
+                    var skills = Job.GetSkills().ToList();
+                    skills.Sort((s1, s2) => -s1.Level.CompareTo(s2.Level));
+
+                    new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.0f), skillsArea.RectTransform), TextManager.AddPunctuation(':', TextManager.Get("skills"), string.Empty), font: font) { Padding = Vector4.Zero };
+
+                    foreach (Skill skill in skills)
                     {
-                        int skillChange = (int)MathF.Round(modifiedSkillLevel - skill.Level);
-                        string changeText = $"{(skillChange > 0 ? "+" : "") + skillChange}";
-                        new GUITextBlock(new RectTransform(new Vector2(1.0f, 1.0f), skillName.RectTransform), $"{(int)skill.Level} ({changeText})", textColor: textColor, font: font, textAlignment: Alignment.CenterRight);
-                    }
-                    else
-                    {
-                        new GUITextBlock(new RectTransform(new Vector2(1.0f, 1.0f), skillName.RectTransform), ((int)skill.Level).ToString(), textColor: textColor, font: font, textAlignment: Alignment.CenterRight);
+                        Color textColor = Color.White * (0.5f + skill.Level / 200.0f);
+
+                        var skillName = new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.0f), skillsArea.RectTransform), TextManager.Get("SkillName." + skill.Identifier), textColor: textColor, font: font) { Padding = Vector4.Zero };
+
+                        float modifiedSkillLevel = skill.Level;
+                        if (Character != null)
+                        {
+                            modifiedSkillLevel = Character.GetSkillLevel(skill.Identifier);
+                        }
+                        if (!MathUtils.NearlyEqual(MathF.Round(modifiedSkillLevel), MathF.Round(skill.Level)))
+                        {
+                            int skillChange = (int)MathF.Round(modifiedSkillLevel - skill.Level);
+                            string changeText = $"{(skillChange > 0 ? "+" : "") + skillChange}";
+                            new GUITextBlock(new RectTransform(new Vector2(1.0f, 1.0f), skillName.RectTransform), $"{(int)skill.Level} ({changeText})", textColor: textColor, font: font, textAlignment: Alignment.CenterRight);
+                        }
+                        else
+                        {
+                            new GUITextBlock(new RectTransform(new Vector2(1.0f, 1.0f), skillName.RectTransform), ((int)skill.Level).ToString(), textColor: textColor, font: font, textAlignment: Alignment.CenterRight);
+                        }
                     }
                 }
-            }
-            else if (Character is { IsDead: true } && CrewListDisabled == false)
-            {
-                var deadArea = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.63f), paddedFrame.RectTransform, Anchor.BottomCenter, Pivot.BottomCenter))
+                else if (Character is { IsDead: true })
                 {
-                    Stretch = true
-                };
+                    var deadArea = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.63f), paddedFrame.RectTransform, Anchor.BottomCenter, Pivot.BottomCenter))
+                    {
+                        Stretch = true
+                    };
 
-                LocalizedString deadDescription = 
-                    TextManager.Get("deceased") + "\n" + 
-                   (Character.CauseOfDeath.Affliction?.CauseOfDeathDescription ?? TextManager.Get("CauseOfDeath." + Character.CauseOfDeath.Type.ToString()));
+                    LocalizedString deadDescription =
+                        TextManager.Get("deceased") + "\n" +
+                       (Character.CauseOfDeath.Affliction?.CauseOfDeathDescription ?? TextManager.Get("CauseOfDeath." + Character.CauseOfDeath.Type.ToString()));
 
-                new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.0f), deadArea.RectTransform), deadDescription, textColor: GUIStyle.Red, font: font, textAlignment: Alignment.TopLeft) { Padding = Vector4.Zero };
+                    new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.0f), deadArea.RectTransform), deadDescription, textColor: GUIStyle.Red, font: font, textAlignment: Alignment.TopLeft) { Padding = Vector4.Zero };
+                }
             }
 
             if (returnParent)

--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
@@ -75,7 +75,7 @@ namespace Barotrauma
                 Stretch = true
             };
 
-            var CrewListDisabled = GameMain.NetworkMember.ServerSettings.DisableCrewList == false;
+            var CrewListDisabled = GameMain.NetworkMember.ServerSettings.DisableCrewList;
 
             Color? nameColor = null;
             if (Job != null) { nameColor = Job.Prefab.UIColor; }

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
@@ -45,6 +45,7 @@ namespace Barotrauma
         private bool transferMenuStateCompleted;
         private readonly HashSet<Identifier> registeredEvents = new HashSet<Identifier>();
         private readonly TalentMenu talentMenu = new TalentMenu();
+        public bool CrewListIsDisabled = GameMain.NetworkMember.ServerSettings.DisableCrewList;
 
         private class LinkedGUI
         {
@@ -626,7 +627,6 @@ namespace Barotrauma
             linkedGUIList = new List<LinkedGUI>();
 
             var connectedClients = GameMain.Client.ConnectedClients;
-            var CrewListIsDisabled = GameMain.NetworkMember.ServerSettings.DisableCrewList;
             if (CrewListIsDisabled == false)
             {
                 for (int i = 0; i < teamIDs.Count; i++)
@@ -743,7 +743,7 @@ namespace Barotrauma
                 new GUITextBlock(new RectTransform(new Point(pingColumnWidth, paddedFrame.Rect.Height), paddedFrame.RectTransform), client.Ping.ToString(), textAlignment: Alignment.Center),
                 permissionIcon));
 
-            if (client.Character is { } character && GameMain.NetworkMember.ServerSettings.DisableCrewList == false)
+            if (client.Character is { } character && CrewListIsDisabled == false)
             {
                 CreateWalletCrewFrame(character, paddedFrame);
             }
@@ -878,6 +878,9 @@ namespace Barotrauma
             GUITextBlock characterNameBlock;
             Sprite permissionIconSprite = GetPermissionIcon(client);
             JobPrefab prefab = client.Character?.Info?.Job?.Prefab;
+
+            if (CrewListIsDisabled == true) { prefab = null; } // Set prefab to null if crew list is disabled, we don't want to show their job. Only the client.
+
             Color nameColor = prefab != null ? prefab.UIColor : Color.White;
 
             Point iconSize = new Point((int)(paddedFrame.Rect.Height * 0.8f));

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
@@ -743,7 +743,7 @@ namespace Barotrauma
                 new GUITextBlock(new RectTransform(new Point(pingColumnWidth, paddedFrame.Rect.Height), paddedFrame.RectTransform), client.Ping.ToString(), textAlignment: Alignment.Center),
                 permissionIcon));
 
-            if (client.Character is { } character)
+            if (client.Character is { } character && GameMain.NetworkMember.ServerSettings.DisableCrewList == false)
             {
                 CreateWalletCrewFrame(character, paddedFrame);
             }

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
@@ -894,7 +894,7 @@ namespace Barotrauma
             permissionIcon = new GUIImage(new RectTransform(new Vector2(iconWidth, 1f), paddedFrame.RectTransform) { AbsoluteOffset = new Point(xOffset + 2, 0) }, permissionIconSprite) { IgnoreLayoutGroups = true };
        
 
-            if (client.Character != null && client.Character.IsDead)
+            if (client.Character != null && client.Character.IsDead && CrewListIsDisabled == false)
             {
                 characterNameBlock.Strikethrough = new GUITextBlock.StrikethroughSettings(null, GUI.IntScale(1f), GUI.IntScale(5f));
             }

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
@@ -920,7 +920,7 @@ namespace Barotrauma
             {
                 spectateIcon.Draw(spriteBatch, area, Color.White);
             }
-            else if (client.Character != null && client.Character.IsDead)
+            else if (client.Character != null && client.Character.IsDead && CrewListIsDisabled == false)
             {
                 if (client.Character.Info != null)
                 {

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
@@ -626,8 +626,8 @@ namespace Barotrauma
             linkedGUIList = new List<LinkedGUI>();
 
             var connectedClients = GameMain.Client.ConnectedClients;
-            var CrewListIsEnabled = !GameMain.NetworkMember.ServerSettings.DisableCrewList;
-            if (CrewListIsEnabled == true)
+            var CrewListIsDisabled = GameMain.NetworkMember.ServerSettings.DisableCrewList;
+            if (CrewListIsDisabled == false)
             {
                 for (int i = 0; i < teamIDs.Count; i++)
                 {
@@ -642,7 +642,7 @@ namespace Barotrauma
             for (int j = 0; j < connectedClients.Count; j++)
             {
                 Client client = connectedClients[j];
-                if (!client.InGame || client.Character == null || client.Character.IsDead || CrewListIsEnabled == false)
+                if (!client.InGame || client.Character == null || client.Character.IsDead || CrewListIsDisabled == true)
                 {
                     CreateMultiPlayerClientElement(client);
                 }

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
@@ -626,20 +626,23 @@ namespace Barotrauma
             linkedGUIList = new List<LinkedGUI>();
 
             var connectedClients = GameMain.Client.ConnectedClients;
-
-            for (int i = 0; i < teamIDs.Count; i++)
+            var CrewListIsEnabled = !GameMain.NetworkMember.ServerSettings.DisableCrewList;
+            if (CrewListIsEnabled == true)
             {
-                foreach (Character character in crew.Where(c => c.TeamID == teamIDs[i]))
+                for (int i = 0; i < teamIDs.Count; i++)
                 {
-                    if (!(character is AICharacter) && connectedClients.Any(c => c.Character == null && c.Name == character.Name)) { continue; }
-                    CreateMultiPlayerCharacterElement(character, GameMain.Client.PreviouslyConnectedClients.FirstOrDefault(c => c.Character == character), i);
+                    foreach (Character character in crew.Where(c => c.TeamID == teamIDs[i]))
+                    {
+                        if (!(character is AICharacter) && connectedClients.Any(c => c.Character == null && c.Name == character.Name)) { continue; }
+                        CreateMultiPlayerCharacterElement(character, GameMain.Client.PreviouslyConnectedClients.FirstOrDefault(c => c.Character == character), i);
+                    }
                 }
             }
 
             for (int j = 0; j < connectedClients.Count; j++)
             {
                 Client client = connectedClients[j];
-                if (!client.InGame || client.Character == null || client.Character.IsDead)
+                if (!client.InGame || client.Character == null || client.Character.IsDead || CrewListIsEnabled == false)
                 {
                     CreateMultiPlayerClientElement(client);
                 }

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
@@ -108,8 +108,10 @@ namespace Barotrauma
                 OnSelected = (component, userData) => false,
                 SelectMultiple = false,
                 Spacing = (int)(GUI.Scale * 10),
-                OnRearranged = OnCrewListRearranged
+                OnRearranged = OnCrewListRearranged,
             };
+
+            if (CrewListDisabled == true) { AutoHideCrewList(); }
 
             jobIndicatorBackground = new Sprite("Content/UI/CommandUIAtlas.png", new Rectangle(0, 512, 128, 128));
             previousOrderArrow = new Sprite("Content/UI/CommandUIAtlas.png", new Rectangle(128, 512, 128, 128));

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
@@ -101,6 +101,7 @@ namespace Barotrauma
             // AbsoluteOffset is set in UpdateProjectSpecific based on crewListOpenState
             crewList = new GUIListBox(new RectTransform(Vector2.One, crewArea.RectTransform), style: null, isScrollBarOnDefaultSide: false)
             {
+                Visible = !CrewListDisabled,
                 AutoHideScrollBar = false,
                 CanBeFocused = false,
                 CurrentDragMode = GUIListBox.DragMode.DragWithinBox,
@@ -110,8 +111,6 @@ namespace Barotrauma
                 Spacing = (int)(GUI.Scale * 10),
                 OnRearranged = OnCrewListRearranged,
             };
-
-            if (CrewListDisabled == true) { AutoHideCrewList(); }
 
             jobIndicatorBackground = new Sprite("Content/UI/CommandUIAtlas.png", new Rectangle(0, 512, 128, 128));
             previousOrderArrow = new Sprite("Content/UI/CommandUIAtlas.png", new Rectangle(128, 512, 128, 128));

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
@@ -57,6 +57,7 @@ namespace Barotrauma
                 PreferCrewMenuOpen = value;
             }
         }
+        public bool CrewListDisabled = GameMain.NetworkMember.ServerSettings.DisableCrewList;
 
         public static bool PreferCrewMenuOpen = true;
 
@@ -1642,7 +1643,7 @@ namespace Barotrauma
                     Math.Min(crewListOpenState + deltaTime * 2.0f, 1.0f) :
                     Math.Max(crewListOpenState - deltaTime * 2.0f, 0.0f);
 
-                if (GUI.KeyboardDispatcher.Subscriber == null && PlayerInput.KeyHit(InputType.CrewOrders))
+                if (GUI.KeyboardDispatcher.Subscriber == null && CrewListDisabled == false && PlayerInput.KeyHit(InputType.CrewOrders))
                 {
                     SoundPlayer.PlayUISound(GUISoundType.PopupMenu);
                     IsCrewMenuOpen = !IsCrewMenuOpen;

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
@@ -75,8 +75,15 @@ namespace Barotrauma
                 ToolTip = TextManager.GetWithVariable("hudbutton.crewlist", "[key]", GameSettings.CurrentConfig.KeyMap.KeyBindText(InputType.CrewOrders)),
                 OnClicked = (GUIButton btn, object userdata) =>
                 {
-                    if (CrewManager == null || CrewManager.CrewListDisabled == false) { return false; }
-                    CrewManager.IsCrewMenuOpen = !CrewManager.IsCrewMenuOpen;
+                    if (CrewManager == null) { return false; }
+                    if (CrewManager.CrewListDisabled == false)
+                    {
+                        CrewManager.IsCrewMenuOpen = false;
+                    }
+                    else
+                    {
+                        CrewManager.IsCrewMenuOpen = !CrewManager.IsCrewMenuOpen;
+                    }
                     return true;
                 }
             };

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
@@ -72,6 +72,7 @@ namespace Barotrauma
             Point buttonSize = new Point(buttonWidth, buttonHeight);
             crewListButton = new GUIButton(new RectTransform(buttonSize, parent: topLeftButtonGroup.RectTransform), style: "CrewListToggleButton")
             {
+                Visible = !CrewManager.CrewListDisabled,
                 ToolTip = TextManager.GetWithVariable("hudbutton.crewlist", "[key]", GameSettings.CurrentConfig.KeyMap.KeyBindText(InputType.CrewOrders)),
                 OnClicked = (GUIButton btn, object userdata) =>
                 {

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
@@ -75,7 +75,7 @@ namespace Barotrauma
                 ToolTip = TextManager.GetWithVariable("hudbutton.crewlist", "[key]", GameSettings.CurrentConfig.KeyMap.KeyBindText(InputType.CrewOrders)),
                 OnClicked = (GUIButton btn, object userdata) =>
                 {
-                    if (CrewManager == null) { return false; }
+                    if (CrewManager == null || CrewManager.CrewListDisabled == false) { return false; }
                     CrewManager.IsCrewMenuOpen = !CrewManager.IsCrewMenuOpen;
                     return true;
                 }

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
@@ -75,15 +75,8 @@ namespace Barotrauma
                 ToolTip = TextManager.GetWithVariable("hudbutton.crewlist", "[key]", GameSettings.CurrentConfig.KeyMap.KeyBindText(InputType.CrewOrders)),
                 OnClicked = (GUIButton btn, object userdata) =>
                 {
-                    if (CrewManager == null) { return false; }
-                    if (CrewManager.CrewListDisabled == false)
-                    {
-                        CrewManager.IsCrewMenuOpen = false;
-                    }
-                    else
-                    {
-                        CrewManager.IsCrewMenuOpen = !CrewManager.IsCrewMenuOpen;
-                    }
+                    if (CrewManager == null || CrewManager.CrewListDisabled == true) { return false; }
+                    CrewManager.IsCrewMenuOpen = !CrewManager.IsCrewMenuOpen;
                     return true;
                 }
             };

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
@@ -1373,6 +1373,7 @@ namespace Barotrauma.Networking
             ServerSettings.AllowFriendlyFire = inc.ReadBoolean();
             ServerSettings.LockAllDefaultWires = inc.ReadBoolean();
             ServerSettings.AllowRagdollButton = inc.ReadBoolean();
+            ServerSettings.DisableCrewList = inc.ReadBoolean();
             ServerSettings.AllowLinkingWifiToChat = inc.ReadBoolean();
             ServerSettings.MaximumMoneyTransferRequest = inc.ReadInt32();
             bool usingShuttle = GameMain.NetLobbyScreen.UsingShuttle = inc.ReadBoolean();

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerSettings.cs
@@ -707,6 +707,9 @@ namespace Barotrauma.Networking
             var disableBotConversationsBox = new GUITickBox(new RectTransform(new Vector2(1.0f, 0.05f), numberLayout.RectTransform), TextManager.Get("ServerSettingsDisableBotConversations"));
             GetPropertyData(nameof(DisableBotConversations)).AssignGUIComponent(disableBotConversationsBox);
 
+            var disableCrewListBox = new GUITickBox(new RectTransform(new Vector2(1.0f, 0.05f), numberLayout.RectTransform), TextManager.Get("ServerSettingsDisableCrewList"));
+            GetPropertyData(nameof(DisableCrewList)).AssignGUIComponent(disableCrewListBox);
+
             GUILayoutGroup buttonHolder = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.1f), roundsContent.RectTransform), isHorizontal: true)
             {
                 Stretch = true,

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
@@ -2275,6 +2275,7 @@ namespace Barotrauma
             options.Add(new ContextMenuOption("Rank", isEnabled: canManagePermissions, options: rankOptions.ToArray()));
 
             Color clientColor = client.Character?.Info?.Job.Prefab.UIColor ?? Color.White;
+            if (GameMain.NetworkMember.ServerSettings.DisableCrewList == true) { clientColor = Color.White; }
 
             if (GameMain.Client.ConnectedClients.Contains(client))
             {

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -2563,6 +2563,7 @@ namespace Barotrauma.Networking
             msg.WriteBoolean(ServerSettings.AllowFriendlyFire);
             msg.WriteBoolean(ServerSettings.LockAllDefaultWires);
             msg.WriteBoolean(ServerSettings.AllowRagdollButton);
+            msg.WriteBoolean(ServerSettings.DisableCrewList);
             msg.WriteBoolean(ServerSettings.AllowLinkingWifiToChat);
             msg.WriteInt32(ServerSettings.MaximumMoneyTransferRequest);
             msg.WriteBoolean(IsUsingRespawnShuttle());

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
@@ -626,6 +626,13 @@ namespace Barotrauma.Networking
             set;
         }
 
+        [Serialize(false, IsPropertySaveable.Yes)]
+        public bool DisableCrewList
+        {
+            get;
+            set;
+        }
+
         public float SelectedLevelDifficulty
         {
             get { return selectedLevelDifficulty; }
@@ -954,6 +961,8 @@ namespace Barotrauma.Networking
         }
 
         private bool allowModeVoting;
+        private bool disableCrewList;
+
         //Don't serialize: the value is set based on ModeSelectionMode
         public bool AllowModeVoting
         {


### PR DESCRIPTION
### What this PR does
Adds an option in the lobby settings under gameplay section to disable the crew list

### Why
Roleplay purposes, you may not want to have a list that tells you everyone in the game and if they're alive
traitor mode, disabling the crew list will add more mystery to the mode if someone dies

https://github.com/Regalis11/Barotrauma/assets/45323883/e6a8c290-fbc7-44c3-af94-1b18feef385f

![image](https://github.com/Regalis11/Barotrauma/assets/45323883/6b80648b-6585-4366-845a-69b8e7251498)

The crew list is enabled by default