### PR TITLE
GoTo mission type enhancements

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Events/Missions/GoToMission.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Events/Missions/GoToMission.cs
@@ -3,6 +3,6 @@
     partial class GoToMission : Mission
     {
         public override bool DisplayAsCompleted => State >= Prefab.MaxProgressState;
-        public override bool DisplayAsFailed => false;
+        public override bool DisplayAsFailed => State == failState;
     }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/GoToMission.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/GoToMission.cs
@@ -4,9 +4,11 @@ namespace Barotrauma
 {
     partial class GoToMission : Mission
     {
+        private readonly bool maxProgressStateDeterminsCompleted;
         public GoToMission(MissionPrefab prefab, Location[] locations, Submarine sub)
             : base(prefab, locations, sub)
         {
+            maxProgressStateDeterminsCompleted = prefab.ConfigElement.GetAttributeBool("maxprogressdeterminescompleted", false);
         }
 
         protected override void UpdateMissionSpecific(float deltaTime)
@@ -19,6 +21,11 @@ namespace Barotrauma
 
         protected override bool DetermineCompleted()
         {
+            if (maxProgressStateDeterminsCompleted)
+            {
+                return Prefab.MaxProgressState == State;
+            }
+
             if (Level.Loaded?.Type == LevelData.LevelType.Outpost)
             {
                 return true;

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/GoToMission.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/GoToMission.cs
@@ -5,10 +5,12 @@ namespace Barotrauma
     partial class GoToMission : Mission
     {
         private readonly bool maxProgressStateDeterminsCompleted;
+        private readonly int failState;
         public GoToMission(MissionPrefab prefab, Location[] locations, Submarine sub)
             : base(prefab, locations, sub)
         {
             maxProgressStateDeterminsCompleted = prefab.ConfigElement.GetAttributeBool("maxprogressdeterminescompleted", false);
+            failState = prefab.ConfigElement.GetAttributeInt("failstate", -1);
         }
 
         protected override void UpdateMissionSpecific(float deltaTime)


### PR DESCRIPTION
Currently the GoTo mission type completes at the end of the round if either:
- The loaded level type is an outpost
- The sub is at the end exit of the level

There is no way to affect if the mission should count as completed through XML as it will always complete regardless of the state of the mission.

This is especially strange as if you look at the [client code](https://github.com/Regalis11/Barotrauma/blob/ca2c30edca3e0edf6ad69cf35ea62024793c4730/Barotrauma/BarotraumaClient/ClientSource/Events/Missions/GoToMission.cs#L5) that handles displaying if the mission is finished or not, it will only display as completed if the mission state is >= the MaxProgressState (which is defined in XML). This leads to an unintuitive situation where the mission will complete at the end of the round even though the MaxProgressState was not met. I believe in vanilla this only affects the clown haven mission.

This PR adds two new properties to the GoTo mission:  `maxprogressdeterminescompleted` (bool) * `failstate`(int)

If `maxprogressdeterminescompleted` is true (default false) it alters the `DetermineCompleted` logic of the GoTo mission to require the mission State to be >= to the MaxProgressState for the mission to count as completed at the end of the round (reflecting the logic for displaying as completed for the client).

 `failstate` (default -1) determines the state the GoTo mission must be in to display as failed for the client.

This shouldn't affect any existing vanilla or modded missions as the change to completion logic is locked behind setting `maxprogressdeterminescompleted` to true.
