### PR TITLE
Captive souls event rework

### DIFF
--- a/OutpostEvents.xml
+++ b/OutpostEvents.xml
@@ -1,0 +1,3435 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Randomevents>
+  
+  <!-- Define flavor sprites that appear top left of the message box here, identifier is required -->
+  <EventSprites>
+    <Sprite identifier="gambler" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="559,6,165,240" origin="0.5,0.5"/>
+    <Sprite identifier="cultist" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="37,507,182,249" origin="0.5,0.5"/>
+    <Sprite identifier="mediator" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="267,5,225,242" origin="0.5,0.5"/>
+    <Sprite identifier="huskinvite" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="555,775,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="map" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="259,521,249,240" origin="0.5,0.5"/>
+    <Sprite identifier="vent" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="507,0,249,252" origin="0.5,0.5"/>
+    <Sprite identifier="brokenterminal" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="768,0,244,251" origin="0.5,0.5"/>    
+    <Sprite identifier="ambush" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="261,542,248,174" origin="0.5,0.5"/>
+    <Sprite identifier="trashcan" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="771,15,244,241" origin="0.5,0.5"/>
+    <Sprite identifier="clown" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="544,259,182,249" origin="0.5,0.5"/>
+    <Sprite identifier="unconscious" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="770,321,241,152" origin="0.5,0.5"/>
+    <Sprite identifier="noticeboard" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="263,523,243,231" origin="0.5,0.5"/>
+    <Sprite identifier="ventinside" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="510,520,248,242" origin="0.5,0.5"/>
+    <Sprite identifier="redbluebottles" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="549,516,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="redyellowbottles" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="764,520,243,232" origin="0.5,0.5"/>
+    <Sprite identifier="dorm" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="267,269,231,237" origin="0.5,0.5"/>
+    <Sprite identifier="cleaner" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="34,1,182,242" origin="0.5,0.5"/>
+    <Sprite identifier="note" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="808,768,182,247" origin="0.5,0.5"/>
+    <Sprite identifier="noteopened" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="812,514,182,247" origin="0.5,0.5"/>
+    <Sprite identifier="group" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="37,772,182,247" origin="0.5,0.5"/>
+    <Sprite identifier="mechanic" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="553,775,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="crowd" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="1,293,248,174" origin="0.5,0.5"/>
+    <Sprite identifier="clownambush" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="519,280,241,219" origin="0.5,0.5"/>
+    <Sprite identifier="office" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="34,256,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="mines" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="760,772,246,245" origin="0.5,0.5"/>
+    <Sprite identifier="oldman" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="28,516,202,249" origin="0.5,0.5"/>
+    <Sprite identifier="security" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="294,775,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="captain" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="34,0,182,251" origin="0.5,0.5"/>
+    <Sprite identifier="officeinside" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="766,264,245,230" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra3" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra4" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Infiltration1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Infiltration2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Terrorism1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Terrorism2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stuckinthemiddle1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Censorship1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BadVibration1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BadVibration2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BombScare1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BombScare2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stowaway1A" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stowaway1B" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stowaway2" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="0,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="ShockJock" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="256,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="HeartOfGold" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="512,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="ManAndHisRaptor" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="768,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Receptiondude" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="0,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Instructor" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="256,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Ancient1" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="512,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Ancient2" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="768,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="engineer" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="0,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Separatists" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="256,512,256,256" origin="0.5,0.5"/> 
+    <Sprite identifier="Coalition" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="256,0,256,256" origin="0.5,0.5"/> 
+    <Sprite identifier="Ecclesiast" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="256,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Jestmaster" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="256,768,256,256" origin="0.5,0.5"/>
+  </EventSprites>
+
+
+
+  <!-- Events defined in <EventPrefabs> can only be triggered via a console command or with a TriggerEventAction -->
+  <EventPrefabs>
+    <!-- test event -->
+    <ScriptedEvent identifier="testevent">
+      <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="cultist">
+        <Option text="Next">
+          <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="huskinvite">
+            <Option text="Next">
+              <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="cultist">
+                <Option text="Next">
+                  <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="mediator" closedialog="true" />
+                </Option>
+                <Option text="End" endconversation="true">
+                  <TagAction criteria="player" tag="player"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="End"/>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="forcebeaconmission" requirebeaconstation="True">
+      <MissionAction missionidentifier="beacon" />
+    </ScriptedEvent>
+
+    <!--"Giving directions"-->
+    <ScriptedEvent identifier="givingdirections" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="captain" targettag="givingdirections_captain" spawnlocation="Outpost" spawnpointtype="Path" targetmoduletags="crewmodule" />
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="givingdirections_captain" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <NPCWaitAction npctag="givingdirections_captain" wait="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.c1" eventsprite="captain">
+        <Option text="EventText.givingdirections.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o1.c1">
+            <Option text="EventText.givingdirections.o1.o1">
+              <SkillCheckAction requiredskill="Helm" requiredlevel="50" targettag="triggerer_player">
+                <Success>
+                  <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o1.o1.c1">
+                    <Option text="EventText.givingdirections.o1.o1.o1" />
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o1.o1.c2">
+                    <Option text="EventText.givingdirections.o1.o1.o2" />
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.givingdirections.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.givingdirections.o2">
+          <RNGAction chance="0.15">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o2.c1">
+                <Option text="EventText.givingdirections.o2.o1" endconversation="true">
+                  <SpawnAction itemidentifier="revolver" targettag="prizerevolver" targetinventory="triggerer_player" />
+                  <SpawnAction itemidentifier="revolverround" targetinventory="prizerevolver" />
+                  <SpawnAction itemidentifier="revolverround" targetinventory="prizerevolver" />
+                  <SpawnAction itemidentifier="revolverround" targetinventory="prizerevolver" />
+                </Option>
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o2.c2">
+                <Option text="EventText.givingdirections.o2.o2" />
+              </ConversationAction>
+              <CombatAction combatmode="Offensive" npctag="givingdirections_captain" enemytag="triggerer_player" isinstigator="false" guardreaction="none" witnessreaction="retreat"/>
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.givingdirections.o3" />
+      </ConversationAction>
+      <NPCWaitAction npctag="givingdirections_captain" wait="false" />
+    </ScriptedEvent>
+    <!--"A sound in the vent"
+    TODO:
+    -follow-up event?-->
+    <ScriptedEvent identifier="soundinthevent" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:mudraptorspawnvent" tag="mudraptorspawnvent" />
+      <TriggerAction target1tag="mudraptorspawnvent" target2tag="player" applytotarget1="selectedmudraptorspawnvent" applytotarget2="triggerer_player" radius="50"/>
+      <StatusEffectAction targettag="selectedmudraptorspawnvent">
+        <StatusEffect>
+          <Sound file="Content/Sounds/Damage/Creak1.ogg" range="500" />
+        </StatusEffect>
+      </StatusEffectAction>
+      <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.c1" eventsprite="vent">
+        <Option text="EventText.soundinthevent.o1">
+          <SkillCheckAction targettag="triggerer_player" requiredskill="Mechanical" requiredlevel="60">
+            <Success>
+              <GiveSkillEXPAction skill="mechanical" amount="5" targettag="triggerer_player" />
+              <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o1.c1" />
+              <MoneyAction amount="1000" />
+            </Success>
+            <Failure>
+              <AfflictionAction affliction="lacerations" strength="15" limbtype="LeftHand" targettag="triggerer_player" />
+              <StatusEffectAction targettag="selectedmudraptorspawnvent">
+                <StatusEffect>
+                  <Explosion range="200.0" stun="0.2" force="5.0" flames="false" flash="false" shockwave="false" sparks="false" underwaterbubble="false" />
+                  <Sound file="Content/Sounds/Damage/StructureCrunch2.ogg" range="500" />
+                </StatusEffect>
+              </StatusEffectAction>
+              <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o1.c2" />
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+        <Option text="EventText.soundinthevent.o2">
+          <SkillCheckAction targettag="triggerer_player" requiredskill="weapons" requiredlevel="70">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o2.c1" eventsprite="ambush"/>
+              <WaitAction time="1.5" />
+              <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="selectedmudraptorspawnvent" />
+              <StatusEffectAction targettag="selectedmudraptorspawnvent">
+                <StatusEffect>
+                  <Explosion range="200.0" stun="0.5" force="5.0" flash="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" />
+                  <Sound file="Content/Items/Door/DoorBreak1.ogg" range="500" />
+                </StatusEffect>
+              </StatusEffectAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o2.c2" eventsprite="ambush"/>
+              <StatusEffectAction targettag="selectedmudraptorspawnvent">
+                <StatusEffect>
+                  <Explosion range="200.0" stun="0.5" force="5.0" flash="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" />
+                  <Sound file="Content/Items/Door/DoorBreak1.ogg" range="500" />
+                </StatusEffect>
+              </StatusEffectAction>
+              <WaitAction time="1.5" />
+              <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="selectedmudraptorspawnvent" />
+              <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="selectedmudraptorspawnvent" />
+              <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="selectedmudraptorspawnvent" />
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+        <Option text="EventText.soundinthevent.o3">
+          <RNGAction chance="0.33">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o3.c1">
+                <Option text="EventText.soundinthevent.o3.o1" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <SkillCheckAction requiredskill="Helm" requiredlevel="70" targettag="triggerer_player">
+                <Success>
+                  <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o3.c2">
+                    <Option text="EventText.soundinthevent.o3.o2" />
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o3.c3">
+                    <Option text="EventText.soundinthevent.o3.o3" />
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Failure>
+          </RNGAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Impromptu engineering"-->
+    <ScriptedEvent identifier="impromptuengineering" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <!--<TagAction criteria="itemidentifier:opdeco_computer" tag="potentialresearchterminal" submarinetype="outpost" />-->
+      <!--<TagAction criteria="itemidentifier:opdeco_desk" tag="potentialresearchterminal" submarinetype="outpost" />-->
+      <TagAction criteria="itemidentifier:op_researchtable" tag="potentialresearchterminal" submarinetype="outpost" />
+      <TagAction criteria="itemidentifier:op_researchterminal" tag="potentialresearchterminal" submarinetype="outpost" />
+      <TriggerAction target1tag="potentialresearchterminal" target2tag="player" applytotarget1="selectedresearchterminal" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <StatusEffectAction targettag="selectedresearchterminal">
+        <StatusEffect indestructible="false" condition="0" setvalue="true" />
+      </StatusEffectAction>
+      <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.c1" eventsprite="brokenterminal">
+        <Option text="EventText.impromptuengineering.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.c1">
+            <Option text="EventText.impromptuengineering.o1.o1">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="Mechanical" requiredlevel="40">
+                <Success>
+                  <GiveSkillEXPAction skill="mechanical" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o1.c1">
+                    <Option text="EventText.impromptuengineering.o1.o1.o1" endconversation="true">
+                      <SpawnAction itemidentifier="redwire" targetinventory="triggerer_player" />
+                      <SpawnAction itemidentifier="copper" targetinventory="triggerer_player" />
+                      <SpawnAction itemidentifier="fpgacircuit" targetinventory="triggerer_player" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o1.c2">
+                    <Option text="EventText.impromptuengineering.o1.o1.o2" endconversation="true">
+                      <SpawnAction itemidentifier="redwire" targetinventory="triggerer_player" />
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.impromptuengineering.o1.o2">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="electrical" requiredlevel="50">
+                <Success>
+                  <StatusEffectAction targettag="selectedresearchterminal">
+                    <StatusEffect condition="100" indestructible="true" setvalue="true" />
+                  </StatusEffectAction>
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.c1">
+                    <Option text="EventText.impromptuengineering.o1.o2.o1">
+                      <SpawnAction itemidentifier="coilgunammobox" spawnlocation="MainSub" />
+                      <SpawnAction itemidentifier="coilgunammobox" spawnlocation="MainSub" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.o1.c1">
+                        <Option text="EventText.impromptuengineering.o1.o2.o1.o1" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.impromptuengineering.o1.o2.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.o2.c1">
+                        <Option text="EventText.impromptuengineering.o1.o2.o2.o1" endconversation="true">
+                          <GiveSkillEXPAction skill="electrical" amount="5" targettag="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.c2">
+                    <Option text="EventText.impromptuengineering.o1.o2.o3" endconversation="true">
+                      <AfflictionAction targettag="triggerer_player" affliction="burn" strength="15" limbtype="lefthand" />
+                      <StatusEffectAction targettag="triggerer_player">
+                        <StatusEffect targetlimbs="LeftHand,RightHand">
+                          <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+                          <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+                          <Affliction identifier="stun" strength="4" />
+                          <Affliction identifier="burn" strength="5" />
+                        </StatusEffect>
+                      </StatusEffectAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.impromptuengineering.o1.o3"></Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.impromptuengineering.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Good samaritan"-->
+    <ScriptedEvent identifier="goodsamaritan" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="patient" spawnlocation="Outpost" spawnpointtype="Path" />
+      <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="60" />
+      <GodModeAction targettag="patient" enabled="true" />
+      <TriggerAction target1tag="patient" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="150" waitforinteraction="true"/>      
+      <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.c1" eventsprite="unconscious">
+        <Option text="EventText.goodsamaritan.o1">
+          <SkillCheckAction targettag="triggerer_player" requiredskill="Medical" requiredlevel="30">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.c1">
+                <Option text="EventText.goodsamaritan.o1.o1">
+                  <CheckItemAction targettag="triggerer_player" itemidentifiers="antinarc">
+                    <Success>
+                      <RemoveItemAction targettag="triggerer_player" itemidentifiers="antinarc" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.o1.c1" />
+                      <ReputationAction targettype="Location" increase="2" />
+                      <GodModeAction targettag="patient" enabled="false" />
+                      <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="-50" />
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.o1.c2" />
+                      <ReputationAction targettype="Location" increase="2" />
+                      <GodModeAction targettag="patient" enabled="false" />
+                    </Failure>
+                  </CheckItemAction>
+                </Option>
+                <Option text="EventText.goodsamaritan.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.o2.c1">
+                    <Option text="EventText.goodsamaritan.o1.o2.o1" />
+                  </ConversationAction>
+                  <GiveSkillEXPAction targettag="triggerer_player" skill="Medical" amount="5" />
+                  <GodModeAction targettag="patient" enabled="false" />
+                </Option>
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.c2">
+                <Option text="EventText.goodsamaritan.o1.o3" />
+              </ConversationAction>
+              <GodModeAction targettag="patient" enabled="false" />
+              <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="50" />
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+        <Option text="EventText.goodsamaritan.o2" endconversation="true">
+          <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o2.c1" />
+          <ReputationAction targettype="Location" increase="-2" />
+          <MoneyAction amount="14" targettag="player" />
+          <GodModeAction targettag="patient" enabled="false" />
+          <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="50" />
+        </Option>
+        <Option text="EventText.goodsamaritan.o3" endconversation="true">
+          <GodModeAction targettag="patient" enabled="false" />
+          <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="50" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Propaganda"-->
+    <ScriptedEvent identifier="propaganda" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_hrflyers" tag="potentialflyers" submarinetype="outpost" />
+      <!--<TagAction criteria="structureidentifier:opdeco_propagandaposter1" tag="potentialflyers" submarinetype="outpost" />
+      <TagAction criteria="structureidentifier:opdeco_propagandaposter2" tag="potentialflyers" submarinetype="outpost" />
+      <TagAction criteria="structureidentifier:opdeco_propagandaposter3" tag="potentialflyers" submarinetype="outpost" />
+      <TagAction criteria="structureidentifier:opdeco_propagandaposter4" tag="potentialflyers" submarinetype="outpost" />
+      <TagAction criteria="structureidentifier:opdeco_propagandaposter5" tag="potentialflyers" submarinetype="outpost" />
+      <TagAction criteria="structureidentifier:opdeco_propagandaposter6" tag="potentialflyers" submarinetype="outpost" />
+      <TagAction criteria="structureidentifier:opdeco_propagandaposter7" tag="potentialflyers" submarinetype="outpost" />-->
+      <TriggerAction target1tag="potentialflyers" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.propaganda.c1" eventsprite="noticeboard">
+        <Option text="EventText.propaganda.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.propaganda.o1.c1">
+            <Option text="EventText.propaganda.o1.o1">
+              <ReputationAction targettype="Faction" identifier="separatists" increase="3" />
+              <ReputationAction targettype="Faction" identifier="coalition" increase="-2" />
+              <ConversationAction targettag="triggerer_player" text="EventText.propaganda.o1.o1.c1">
+                <Option text="EventText.propaganda.o1.o1.o1" />
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.propaganda.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.propaganda.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Goblin cooking"-->
+    <ScriptedEvent identifier="goblincooking1" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:mudraptorspawnvent" tag="psychosisvent" />
+      <TriggerAction target1tag="psychosisvent" target2tag="player" applytotarget1="selectedpsychosisvent" applytotarget2="triggerer_player" radius="50" />
+      <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.c1" eventsprite="officeinside">
+        <Option text="EventText.goblincooking1.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.c1">
+            <Option text="EventText.goblincooking1.o1.o1">
+              <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="5" />
+              <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.c1" eventsprite="vent">
+                <Option text="EventText.goblincooking1.o1.o1.o1">
+                  <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="25" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.c1" fadetoblack="true" eventsprite="ventinside">
+                    <Option text="EventText.goblincooking1.o1.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.o1.c1" fadetoblack="true">
+                        <Option text="EventText.goblincooking1.o1.o1.o1.o1.o1">
+                          <AfflictionAction targettag="triggerer_player" affliction="stun" strength="2" />
+                          <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="25" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.o1.o1.c1" />
+                          <MoneyAction amount="-500" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.goblincooking1.o1.o1.o1.o2" fadetoblack="true">
+                      <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="25" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.o2.c1">
+                        <Option text="EventText.goblincooking1.o1.o1.o1.o2.o1" />
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.goblincooking1.o1.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o2.c1">
+                    <Option text="EventText.goblincooking1.o1.o1.o2.o1" />
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.goblincooking1.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.goblincooking1.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Crawler outbreak"-->
+    <ScriptedEvent identifier="crawleroutbreak" commonness="250">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="player" targetmoduletype="researchmodule" radius="200" applytotarget1="triggerer_player" />
+      <SpawnAction speciesname="crawler" spawnlocation="Outpost" targetmoduletags="researchmodule" />
+      <SpawnAction speciesname="crawler" spawnlocation="Outpost" targetmoduletags="researchmodule" />
+      <SpawnAction speciesname="crawler" spawnlocation="Outpost" targetmoduletags="researchmodule" />
+      <ConversationAction targettag="triggerer_player" text="EventText.crawleroutbreak.c1" eventsprite="ambush"/>
+    </ScriptedEvent>
+    <!--"Taste test"-->
+    <ScriptedEvent identifier="tastetest" commonness="150">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_trashcan" tag="potentialtrashcan" submarinetype="outpost" />
+      <TriggerAction target1tag="potentialtrashcan" target2tag="player" applytotarget1="selectedtrashcan" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <ConversationAction text="EventText.tastetest.c1" targettag="triggerer_player" eventsprite="redbluebottles">
+        <Option text="EventText.tastetest.o1">
+          <SkillCheckAction requiredskill="Medical" requiredlevel="40" targettag="triggerer_player">
+            <Success>
+              <GiveSkillEXPAction skill="medical" amount="5" targettag="triggerer_player" />
+              <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.c1">
+                <Option text="EventText.tastetest.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o1.c1">
+                    <Option text="EventText.tastetest.o1.o1.o1" endconversation="true">
+                      <WaitAction time="20" />
+                      <AfflictionAction targettag="triggerer_player" affliction="internaldamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="lacerations" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="blunttrauma" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="bitewounds" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="gunshotwound" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="organdamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="explosiondamage" strength="-50" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o1.o1.c1">
+                        <Option text="EventText.tastetest.o1.o1.o1.o1" endconversation="true">
+                          <TriggerAction target1tag="selectedtrashcan" target2tag="triggerer_player" radius="100" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o1.o1.o1.c1" eventsprite="redyellowbottles"/>
+                          <SpawnAction itemidentifier="hyperzine" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="steroids" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="sulphuricacid" targetinventory="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.tastetest.o1.o2" endconversation="true" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.c2">
+                <Option text="EventText.tastetest.o1.o3">
+                  <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o3.c1">
+                    <Option text="EventText.tastetest.o1.o3.o1" endconversation="true">
+                      <WaitAction time="20" />
+                      <AfflictionAction targettag="triggerer_player" affliction="internaldamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="lacerations" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="blunttrauma" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="bitewounds" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="gunshotwound" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="organdamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="explosiondamage" strength="-50" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o3.o1.c1" eventsprite="redbluebottles">
+                        <Option text="EventText.tastetest.o1.o3.o1.o1" endconversation="true">
+                          <TriggerAction target1tag="selectedtrashcan" target2tag="triggerer_player" radius="100" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o3.o1.o1.c1" />
+                          <SpawnAction itemidentifier="hyperzine" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="steroids" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="sulphuricacid" targetinventory="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.tastetest.o1.o4">
+                  <AfflictionAction targettag="triggerer_player" affliction="organdamage" limbtype="torso" strength="50" />
+                  <AfflictionAction targettag="triggerer_player" affliction="stun" strength="6" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o4.c1">
+                    <Option text="EventText.tastetest.o1.o4.o1" />
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.tastetest.o1.o5" />
+              </ConversationAction>
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+        <Option text="EventText.tastetest.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Outbreak"
+    TODO:
+    -spawn correct npc-->
+    <ScriptedEvent identifier="outbreak" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="infectednpc" spawnlocation="Outpost" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="outbreaknpc" spawnlocation="Outpost" />
+      <TriggerAction target1tag="outbreaknpc" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <AfflictionAction targettag="infectednpc" affliction="huskinfection" strength="40" />
+      <ConversationAction targettag="triggerer_player" text="EventText.outbreak.c1" eventsprite="cultist">
+        <Option text="EventText.outbreak.o1" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Mike the Idiot 1"-->
+    <ScriptedEvent identifier="miketheidiot1" commonness="25">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="player" targetmoduletype="crewmodule" radius="200" applytotarget1="triggerer_player" />
+      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.c1" eventsprite="dorm">
+        <Option text="EventText.miketheidiot1.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.c1">
+            <Option text="EventText.miketheidiot1.o1.o1">
+              <CheckMoneyAction Amount="5">
+                <Success>
+                  <MoneyAction amount="-5" />
+                  <SetDataAction identifier="timesmikefound" value="1" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.o1.c1">
+                    <Option text="EventText.miketheidiot1.o1.o1.o1">
+                      <ConversationAction text="EventText.miketheidiot1.o1.o1.o1.c1">
+                        <Option text="EventText.miketheidiot1.o1.o1.o1.o1" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.miketheidiot1.o1.o1.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.o1.o2.c1">
+                        <Option text="EventText.miketheidiot1.o1.o1.o2.o1" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.miketheidiot1.o1.o1.o3">
+                      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.o1.o3.c1">
+                        <Option text="EventText.miketheidiot1.o1.o1.o3.o1" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="eventtext.miketheidiot.nomoney"/>                  
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.miketheidiot1.o1.o2" endconversation="true" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.miketheidiot1.o2" endconversation="true" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Mike the Idiot 2"-->
+    <ScriptedEvent identifier="miketheidiot2" commonness="25">
+      <CheckDataAction identifier="timesmikefound" condition="eq 1">
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <TriggerAction target1tag="player" targetmoduletype="crewmodule" radius="200" applytotarget1="triggerer_player" />
+          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.c1" eventsprite="cleaner">
+            <Option text="EventText.miketheidiot2.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.c1">
+                <Option text="EventText.miketheidiot2.o1.o1">
+                  <CheckMoneyAction Amount="5">
+                    <Success>
+                      <MoneyAction amount="-5" />
+                      <SetDataAction identifier="timesmikefound" value="2" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.c1">
+                        <Option text="EventText.miketheidiot2.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.o1.c1">
+                            <Option text="EventText.miketheidiot2.o1.o1.o1.o1" endconversation="true" />
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.miketheidiot2.o1.o1.o2">
+                          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.o2.c1">
+                            <Option text="EventText.miketheidiot2.o1.o1.o2.o1" endconversation="true" />
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.miketheidiot2.o1.o1.o3">
+                          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.o3.c1">
+                            <Option text="EventText.miketheidiot2.o1.o1.o3.o1" endconversation="true" />
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="eventtext.miketheidiot.nomoney"/>
+                    </Failure>
+                  </CheckMoneyAction>                  
+                </Option>
+                <Option text="EventText.miketheidiot2.o1.o2" endconversation="true" />
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.miketheidiot2.o2" endconversation="true" />
+          </ConversationAction>
+        </Success>
+        <Failure>
+          <!--Do nothing-->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--"Firefighting"-->
+    <ScriptedEvent identifier="firefighting" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_trashcan" tag="potentialtrashcan" submarinetype="outpost" />
+      <TriggerAction target1tag="potentialtrashcan" target2tag="player" applytotarget1="selectedtrashcan" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.firefighting.c1" eventsprite="trashcan">
+        <Option text="EventText.firefighting.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.firefighting.o1.c1">
+            <Option text="EventText.firefighting.o1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.firefighting.o1.o1.c1" />
+              <AfflictionAction targettag="triggerer_player" affliction="burn" strength="5" limbtype="rightarm" />
+            </Option>
+            <Option text="EventText.firefighting.o1.o2" endconversation="true">
+              <WaitAction time="30" />
+              <FireAction size="10" targettag="selectedtrashcan" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.firefighting.o2" endconversation="true">
+          <WaitAction time="30" />
+          <FireAction size="10" targettag="selectedtrashcan" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Sleight of Hand"-->
+    <ScriptedEvent identifier="sleightofhand" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="gambler" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="gambler" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="gamblingsecurity" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <!--<NPCFollowAction npctag="gambler" targettag="gamblingsecurity" follow="true" />
+      <NPCFollowAction npctag="gamblingsecurity" targettag="gambler" follow="true" />-->
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="gambler" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.c1" eventsprite="gambler">
+        <Option text="EventText.sleightofhand.o1">
+          <RNGAction chance="0.125">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o1.c1"/>
+              <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o1.c2"></ConversationAction>
+              <MoneyAction amount="-500" />
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.sleightofhand.o2">
+          <RNGAction chance="0.25">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o2.c1"/>
+              <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o2.c2" />
+              <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" />
+              <CombatAction combatmode="defensive" npctag="gamblingsecurity" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+              <ReputationAction targettype="Location" increase="-2" />
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.sleightofhand.o3" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Foreshadowing"-->
+    <!--NOTE: disabled in event lists-->
+    <ScriptedEvent identifier="foreshadowing" commonness="25">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="bot" tag="potentialnotegiver" />
+      <TriggerAction target1tag="potentialnotegiver" target2tag="player" applytotarget1="notegiver" applytotarget2="triggerer_player" radius="100" waitforinteraction="false"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.foreshadowing.c1" eventsprite="note">
+        <Option text="EventText.foreshadowing.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.foreshadowing.o1.c1" eventsprite="noteopened"></ConversationAction>
+        </Option>
+        <Option text="EventText.foreshadowing.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Engineers are special"-->
+    <ScriptedEvent identifier="Engineers_are_special" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="humanprefabidentifier:reactoroperator" tag="repairnpc" />
+      <TriggerAction target1tag="repairnpc" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <NPCWaitAction npctag="repairnpc" wait="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1" eventsprite="mechanic" continueconversation="true" _npos="2839.201,261.54736" />
+      <SkillCheckAction targettag="triggerer_player" requiredskill="mechanical" requiredlevel="50" _npos="3262.4575,261.54736">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.c1" continueconversation="true" _npos="3700.167,125.27942">
+            <Option text="EventText.Engineers_are_special.c1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.o1.c1" _npos="4287.3125,-70.810974" />
+            </Option>
+            <Option text="EventText.Engineers_are_special.c1.o2">
+              <RNGAction chance="0.6" _npos="4285.822,189.16768">
+                <Success>
+                  <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.o2.c1" _npos="4714.9326,97.9465" />
+                  <ReputationAction targettype="Location" increase="2" />
+                  <GiveSkillEXPAction skill="mechanical" amount="5" targettag="triggerer_player" />
+                  <SetPriceMultiplierAction multiplier="0.85" operation="Multiply" targetmultiplier="Mechanical"/>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.o2.c2" _npos="4714.8335,315.59344" />
+                </Failure>
+              </RNGAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.c2" _npos="3700.1667,325.55194" />
+        </Failure>
+      </SkillCheckAction>
+      <NPCWaitAction npctag="repairnpc" wait="false" />
+    </ScriptedEvent>
+    <!--"Mediator"-->
+    <ScriptedEvent identifier="mediator" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="troublemaker1" spawnlocation="Outpost" spawnpointtype="Path" lootingisstealing="false"/>
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="troublemaker2" spawnlocation="Outpost" spawnpointtype="Path" lootingisstealing="false"/>
+      <!-- make sure the npcs have something to fight with -->
+      <SpawnAction itemidentifier="wrench" targetinventory="troublemaker1" />
+      <SpawnAction itemidentifier="wrench" targetinventory="troublemaker2" />
+      <NPCFollowAction npctag="troublemaker1" targettag="troublemaker2" follow="true" />
+      <NPCFollowAction npctag="troublemaker2" targettag="troublemaker1" follow="true" />
+      <TriggerAction target1tag="troublemaker1" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.mediator.c1" eventsprite="mediator">
+        <Option text="EventText.mediator.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.c1">
+            <Option text="EventText.mediator.o1.o1">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="Helm" requiredlevel="70">
+                <Success>
+                  <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o1.c1" />
+                  <ReputationAction targettype="Location" increase="1" />
+                  <NPCFollowAction npctag="troublemaker1" targettag="troublemaker2" follow="false" />
+                  <NPCFollowAction npctag="troublemaker2" targettag="troublemaker1" follow="false" />
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o1.c2" />
+                  <ReputationAction targettype="Location" increase="-2" />
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.mediator.o1.o2">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="weapons" requiredlevel="50">
+                <Success>
+                  <GiveSkillEXPAction skill="weapons" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.c1" />
+                  <ReputationAction targettype="Location" increase="2" />
+                  <NPCFollowAction npctag="troublemaker1" targettag="troublemaker2" follow="false" />
+                  <NPCFollowAction npctag="troublemaker2" targettag="troublemaker1" follow="false" />
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.c2">
+                    <Option text="EventText.mediator.o1.o2.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.o1.c1">
+                        <Option text="EventText.mediator.o1.o2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.o1.o1.c1" />
+                          <CombatAction combatmode="Offensive" npctag="troublemaker1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+                          <CombatAction combatmode="Offensive" npctag="troublemaker2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.mediator.o2">
+          <ConversationAction targettag="triggerer_player" text="EventText.mediator.o2.c1" />
+          <ReputationAction targettype="Location" increase="-2" />
+          <CombatAction combatmode="Offensive" npctag="troublemaker1" enemytag="troublemaker2" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+          <CombatAction combatmode="Offensive" npctag="troublemaker2" enemytag="troublemaker1" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.mediator.o3" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Black market"-->
+    <ScriptedEvent identifier="blackmarket" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="smuggler" spawnlocation="Outpost" spawnpointtype="Path" />
+      <TriggerAction target1tag="smuggler" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <NPCFollowAction npctag="smuggler" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.c1" eventsprite="cultist">
+        <Option text="EventText.blackmarket.o1">
+          <RNGAction chance="0.5">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1" continueconversation="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1.c1">
+                <Option text="EventText.blackmarket.o1.c1.o1">
+                  <CheckMoneyAction amount="1000">
+                    <Success>
+                      <MoneyAction amount="-1000" />
+                      <RNGAction chance="0.33">
+                        <Success>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1.o1.c1" />
+                          <SpawnAction itemidentifier="alienpistol" targettag="boughtpistol" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="alienpowercell" targetinventory="boughtpistol" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1.o1.c2" />
+                        </Failure>
+                      </RNGAction>                      
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="eventtext.blackmarket.nomoney" />
+                    </Failure>
+                  </CheckMoneyAction>
+                </Option>
+                <Option text="EventText.blackmarket.o1.c1.o2" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2" />
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2.c2">                
+                <Option text="EventText.blackmarket.o1.c2.o1">
+                  <CheckMoneyAction amount="500">
+                    <Success>
+                      <MoneyAction amount="-500" />
+                      <RNGAction chance="0.33">
+                        <Success>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2.o1.c1" />
+                          <SpawnAction itemidentifier="smallmudraptoregg" targetinventory="triggerer_player" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2.o1.c2" />
+                          <SpawnAction itemidentifier="huskeggsbasic" targetinventory="triggerer_player" />
+                        </Failure>
+                      </RNGAction>                      
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="eventtext.blackmarket.nomoney" />
+                    </Failure>                    
+                  </CheckMoneyAction>
+                </Option>
+                <Option text="EventText.blackmarket.o1.c2.o2" />
+              </ConversationAction>
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.blackmarket.o2" />
+      </ConversationAction>
+      <NPCFollowAction npctag="smuggler" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Fan club"-->
+    <ScriptedEvent identifier="fanclub" commonness="75">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="fan" spawnlocation="Outpost" targetmoduletags="airlock" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="fan" spawnlocation="Outpost" targetmoduletags="airlock" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="fan" spawnlocation="Outpost" targetmoduletags="airlock" />
+      <TriggerAction target1tag="fan" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <NPCFollowAction npctag="fan" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.fanclub.c1" eventsprite="crowd">
+        <Option text="EventText.fanclub.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.fanclub.o1.c1" />
+          <ReputationAction targettype="Location" increase="2" />
+          <NPCFollowAction npctag="fan" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.fanclub.o2" endconversation="true">
+          <WaitAction time="10" />
+          <NPCFollowAction npctag="fan" targettag="triggerer_player" follow="false" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"At Wit's End"-->
+    <ScriptedEvent identifier="atwitsend" commonness="70">
+      <CheckDataAction identifier="atwitsend_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat event-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="artiedolittle" targettag="artie" spawnlocation="Outpost" targetmoduletags="airlock" />
+          <TriggerAction target1tag="artie" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.c1" eventsprite="crowd">
+            <Option text="EventText.atwitsend.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o1.c1">
+                <Option text="EventText.atwitsend.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o1.o1.c1" />
+                  <NPCChangeTeamAction npctag="artie" teamid="Team1" addtocrew="true" />
+                  <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="false" />
+                </Option>
+                <Option text="EventText.atwitsend.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o1.o2.c1" />
+                  <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="false" />
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.atwitsend.o2">
+              <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o2.c1" />
+              <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="false" />
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="atwitsend_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    
+    <!--"Consultant"
+      TODO: correct mine module tag-->
+    <ScriptedEvent identifier="consultant" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="mineowner" spawnlocation="Outpost" targetmoduletags="adminmodule" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="miner" targettag="foreman" spawnlocation="Outpost" targetmoduletags="tempmine" />
+      <TriggerAction target1tag="mineowner" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <NPCWaitAction npctag="mineowner" wait="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.consultant.c1" eventsprite="office">
+        <Option text="EventText.consultant.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.c1">
+            <Option text="EventText.consultant.o1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1" />
+              <TriggerAction target1tag="foreman" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+              <NPCWaitAction npctag="foreman" wait="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.c1" eventsprite="mines">
+                <Option text="EventText.consultant.o1.o1.c1.o1">
+                  <SkillCheckAction requiredskill="Helm" requiredlevel="60" targettag="triggerer_player">
+                    <Success>
+                      <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o1.c1" />
+                      <MoneyAction amount="2000" />
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o1.c2" />
+                    </Failure>
+                  </SkillCheckAction>
+                </Option>
+                <Option text="EventText.consultant.o1.o1.c1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.c1">
+                    <Option text="EventText.consultant.o1.o1.c1.o2.o1">
+                      <SkillCheckAction requiredskill="Medical" requiredlevel="50" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="medical" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o1.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o1.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                    <Option text="EventText.consultant.o1.o1.c1.o2.o2">
+                      <SkillCheckAction requiredskill="Helm" requiredlevel="60" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o2.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o2.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.consultant.o1.o1.c1.o3">
+                  <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.c1">
+                    <Option text="EventText.consultant.o1.o1.c1.o3.o1">
+                      <SkillCheckAction requiredskill="Medical" requiredlevel="50" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="medical" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o1.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o1.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                    <Option text="EventText.consultant.o1.o1.c1.o3.o2">
+                      <SkillCheckAction requiredskill="Helm" requiredlevel="60" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o2.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o2.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+              <NPCWaitAction npctag="foreman" wait="false" />
+            </Option>
+            <Option text="EventText.consultant.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.consultant.o2" />
+      </ConversationAction>
+      <NPCWaitAction npctag="mineowner" wait="false" />
+    </ScriptedEvent>
+    <!--Big brother-->
+    <ScriptedEvent identifier="bigbrother" commonness="150">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="securitychief" spawnlocation="Outpost" targetmoduletags="adminmodule" />
+      <NPCWaitAction npctag="securitychief" wait="true" />
+      <WaitAction time="5" />
+      <ConversationAction text="EventText.bigbrother.c1" dialogtype="Small" eventsprite="officeinside"/>
+      <TriggerAction target1tag="player" target2tag="securitychief" radius="150" applytotarget1="triggerer_player"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1" speakertag="securitychief" eventsprite="officeinside" waitforinteraction="true">
+        <Option text="EventText.bigbrother.c1.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.o1.c1">
+            <Option text="EventText.bigbrother.c1.o1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.o1.o1.c1">
+                <Option text="EventText.bigbrother.c1.o1.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.o1.o1.o1.c1" />
+                </Option>
+                <Option text="EventText.bigbrother.c1.o1.o1.o2" endconversation="true">
+                  <GoTo name="end" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.bigbrother.c1.o2" endconversation="true">
+          <GoTo name="end" />
+        </Option>
+      </ConversationAction>
+      <NPCWaitAction npctag="securitychief" wait="false" />
+      <TriggerAction target1tag="triggerer_player" targetmoduletype="seccrewmodule" radius="10" applytotarget1="triggerer_player" />
+      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.c1" eventsprite="dorm">
+        <Option text="EventText.bigbrother.c1.c1.o1">
+          <RNGAction chance="0.2">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.c1" dialogtype="Small" />
+              <ConversationAction text="EventText.bigbrother.c1.c1.o1.c1.c1" speakertag="securitychief" dialogtype="Small"/>
+              <MoneyAction amount="2000" />
+            </Success>
+            <Failure>
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="guard" spawnlocation="Outpost" spawnpointtag="triggerer_player" />
+              <NPCWaitAction npctag="guard" wait="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.c2" eventsprite="security">
+                <Option text="EventText.bigbrother.c1.c1.o1.o1">
+                  <SkillCheckAction requiredskill="weapons" requiredlevel="40" targettag="triggerer_player">
+                    <Success>
+                      <GiveSkillEXPAction skill="weapons" amount="5" targettag="triggerer_player" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o1.c1" dialogtype="Small" />
+                      <ConversationAction text="EventText.bigbrother.c1.c1.o1.o1.c1.c1" speakertag="securitychief" dialogtype="Small" />
+                      <MoneyAction amount="2000" />
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o1.c2"/>
+                      <WaitAction time="20" />
+                      <TriggerAction target1tag="triggerer_player" target2tag="guard" radius="250" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o1.c2.c2" eventsprite="security" dialogtype="Small"/>
+                      <WaitAction time="10" />
+                      <CombatAction combatmode="Offensive" npctag="guard" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+                    </Failure>
+                  </SkillCheckAction>
+                </Option>
+                <Option text="EventText.bigbrother.c1.c1.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o2.c1" eventsprite="security" />
+                  <WaitAction time="20" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="guard" radius="250" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o2.c1.c1" eventsprite="security" dialogtype="Small"/>
+                  <WaitAction time="10" />
+                  <CombatAction combatmode="Offensive" npctag="guard" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+                </Option>
+              </ConversationAction>
+              <NPCWaitAction npctag="guard" wait="false" />
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.bigbrother.c1.c1.o2">
+          <SkillCheckAction requiredskill="Electrical" requiredlevel="30" targettag="triggerer_player">
+            <Success>
+              <GiveSkillEXPAction skill="electrical" amount="5" targettag="triggerer_player" />
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.c1" dialogtype="Small" />
+              <ConversationAction text="EventText.bigbrother.c1.c1.o2.c1.c1" speakertag="securitychief" dialogtype="Small" />
+              <MoneyAction amount="2000" />
+            </Success>
+            <Failure>
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="guard" spawnlocation="Outpost" spawnpointtag="triggerer_player" />
+              <NPCWaitAction npctag="guard" wait="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.c2" eventsprite="security">
+                <Option text="EventText.bigbrother.c1.c1.o2.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.o1.c1" dialogtype="Small" />
+                  <ConversationAction text="EventText.bigbrother.c1.c1.o2.o1.c1.c1" speakertag="securitychief" dialogtype="Small" />
+                  <MoneyAction amount="2000" />
+                </Option>
+                <Option text="EventText.bigbrother.c1.c1.o2.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.o2.c1" />
+                  <WaitAction time="20" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="guard" radius="250" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.o2.c1.c1" eventsprite="security" dialogtype="Small"/>
+                  <WaitAction time="10" />
+                  <CombatAction combatmode="Offensive" npctag="guard" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+                </Option>
+              </ConversationAction>
+              <NPCWaitAction npctag="guard" wait="false" />
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+      </ConversationAction>
+      <Label name="end"/>
+    </ScriptedEvent> 
+    <!--Stowaway 1-->
+    <!--TODO:
+    -remove toolbox after event-->
+    <ScriptedEvent identifier="stowaway1" commonness="50">
+      <TagAction criteria="player" tag="player"/>
+      <SpawnAction itemidentifier="metalcrate" targettag="stowawaytoolbox" spawnlocation="MainSub" ignorebyai="true" />
+      <Label name="stowawayreturn"/>
+      <TriggerAction target1tag="stowawaytoolbox" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <ConversationAction text="EventText.stowaway1.c1" dialogtype="Regular" eventsprite="Stowaway1A" targettag="triggerer_player">
+        <Option text="EventText.stowaway1.o1">
+          <ConversationAction text="EventText.stowaway1.o1.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway1A">
+            <Option text="EventText.stowaway1.o1.o1">
+              <ConversationAction text="EventText.stowaway1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                <Option text="EventText.stowaway1.o1.o1.o1">
+                  <ConversationAction text="EventText.stowaway1.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                    <Option text="EventText.stowaway1.o1.o1.o1.o1">
+                      <RNGAction chance="0.66">
+                        <Success>
+                          <ConversationAction text="EventText.stowaway1.o1.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway1B"/>
+                          <SpawnAction speciesname="Crawler_hatchling" spawnpointtag="triggerer_player" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction text="EventText.stowaway1.o1.o1.o1.o1.c2" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway1B"/>
+                          <RNGAction chance="0.5">
+                            <Success>
+                              <SpawnAction speciesname="psilotoad" spawnpointtag="triggerer_player" />
+                            </Success>
+                            <Failure>
+                              <SpawnAction speciesname="orangeboy" spawnpointtag="triggerer_player" />
+                            </Failure>
+                          </RNGAction>  
+                        </Failure>
+                      </RNGAction>
+                    </Option>
+                    <Option text="EventText.generic.walkaway" endconversation="true">
+                      <!--Return-->
+                      <GoTo name="stowawayreturn" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.generic.walkaway" endconversation="true">
+                  <!--Return-->
+                  <GoTo name="stowawayreturn" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          </Option>
+        <Option text="EventText.generic.walkaway" endconversation="true">
+          <!--Return-->
+          <GoTo name="stowawayreturn" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+   <!--Stowaway 2-->
+    <ScriptedEvent identifier="stowaway2" commonness="50">
+      <CheckDataAction identifier="stowaway2_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat event-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <TagAction criteria="itemidentifier:steelcabinet" tag="potentialcabinet" submarinetype="player" />
+          <TagAction criteria="itemidentifier:mediumwindowedsteelcabinet" tag="potentialcabinet" submarinetype="player"/>
+          <TagAction criteria="itemidentifier:mediumsteelcabinet" tag="potentialcabinet" submarinetype="player" />
+          <!--disabled return label for now-->
+          <Label name="stowawayreturn"/>
+          <TriggerAction target1tag="potentialcabinet" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+          <ConversationAction text="EventText.stowaway2.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway2">
+            <Option text="EventText.stowaway2.o1">
+              <!--disabled clown part for now-->
+              <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 200">
+                <Success>
+                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="clownmessenger" targettag="messenger" spawnpointtag="triggerer_player"/>
+                    <ConversationAction text="EventText.stowaway2.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                      <Option text="EventText.stowaway2.o1.o1">
+                        <ConversationAction text="EventText.stowaway2.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                        <MissionAction missiontag="salvageclownwreck" minlocationdistance="2" unlockfurtheronmap="true"/>
+                      </Option>
+                    </ConversationAction>
+                  </Success>
+                  <Failure>
+                    <ConversationAction text="EventText.stowaway2.o1.c2" dialogtype="Regular" targettag="triggerer_player">
+                      <Option text="EventText.stowaway2.o1.o2">
+                        <ConversationAction text="EventText.stowaway2.o1.o2.c1" dialogtype="Regular" targettag="triggerer_player">
+                          <Option text="EventText.stowaway2.o1.o2.o1">
+                            <ConversationAction text="EventText.stowaway2.o1.o2.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                              <Option text="EventText.stowaway2.o1.o2.o1.o1">
+                                <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                                  <Option text="EventText.stowaway2.o1.o2.o1.o1.o1">
+                                    <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                    <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                    <MissionAction missiontag="escortstowaway" />
+                                  </Option>
+                                  <Option text="EventText.stowaway2.o1.o2.o1.o1.o2">
+                                    <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                    <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                    <MissionAction missiontag="escortstowaway" />
+                                  </Option>
+                                  <Option text="EventText.stowaway2.o1.o2.o1.o1.o3">
+                                    <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                    <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o3.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                    <NPCChangeTeamAction npctag="stowaway" teamid="Team1" addtocrew="true" />
+                                  </Option>
+                                </ConversationAction>
+                              </Option>
+                            </ConversationAction>
+                          </Option>
+                          <Option text="EventText.stowaway2.o1.o2.o2" endconversation="true">
+                            <GoTo name="stowawayreturn" />
+                          </Option>
+                        </ConversationAction>
+                      </Option>
+                      <Option text="EventText.stowaway2.o1.o2.o1">
+                        <ConversationAction text="EventText.stowaway2.o1.o2.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                          <Option text="EventText.stowaway2.o1.o2.o1.o1">
+                            <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                              <Option text="EventText.stowaway2.o1.o2.o1.o1.o1">
+                                <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                <MissionAction missiontag="escortstowaway" />
+                              </Option>
+                              <Option text="EventText.stowaway2.o1.o2.o1.o1.o2">
+                                <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                <MissionAction missiontag="escortstowaway" />
+                              </Option>
+                              <Option text="EventText.stowaway2.o1.o2.o1.o1.o3">
+                                <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o3.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                <NPCChangeTeamAction npctag="stowaway" teamid="Team1" addtocrew="true" />
+                              </Option>
+                            </ConversationAction>
+                          </Option>
+                        </ConversationAction>
+                      </Option>
+                      <Option text="EventText.stowaway2.o1.o2.o2" endconversation="true">
+                        <GoTo name="stowawayreturn" />
+                      </Option>
+                    </ConversationAction>
+                  </Failure>
+                </CheckReputationAction>
+              </Option>
+              <Option text="EventText.generic.walkaway" endconversation="true">
+                <GoTo name="stowawayreturn" />
+              </Option>
+          </ConversationAction>
+          <SetDataAction identifier="stowaway2_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Shock jock-->
+    <ScriptedEvent identifier="shockjock" commonness="50">
+      <CheckDataAction identifier="shockjock_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat this event if the continuation event is complete-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="passerby" spawnlocation="outpost"/>
+          <TriggerAction target1tag="player" target2tag="passerby" applytotarget1="triggerer_player" radius="150" waitforinteraction="false"/>
+          <ConversationAction text="EventText.shockjock.c1" targettag="triggerer_player" dialogtype="Regular" eventsprite="ShockJock">
+            <Option text="EventText.shockjock.o1">
+              <RNGAction chance="0.66">
+                <Success>
+                  <RNGAction chance="0.5">
+                    <Success>
+                      <ConversationAction text="EventText.shockjock.o1.c1" targettag="triggerer_player" dialogtype="Regular">
+                        <Option text="EventText.generic.continue">
+                          <ConversationAction text="EventText.shockjock.o1.o1.c1" targettag="triggerer_player" dialogtype="Regular">
+                            <Option text="EventText.generic.continue">
+                              <ConversationAction text="EventText.shockjock.signoff" targettag="triggerer_player" dialogtype="Regular" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                    <Failure>
+                      <ConversationAction text="EventText.shockjock.o1.c2" targettag="triggerer_player" dialogtype="Regular">
+                        <Option text="EventText.generic.continue">
+                          <ConversationAction text="EventText.shockjock.o1.o2.c1" targettag="triggerer_player" dialogtype="Regular">
+                            <Option text="EventText.generic.continue">
+                              <ConversationAction text="EventText.shockjock.signoff" targettag="triggerer_player" dialogtype="Regular" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Failure>
+                  </RNGAction>
+                </Success>
+                <Failure>
+                  <ConversationAction text="EventText.shockjock.o1.c3" targettag="triggerer_player" dialogtype="Regular">
+                    <Option text="EventText.generic.continue">
+                      <ConversationAction text="EventText.shockjock.o1.o3.c1" targettag="triggerer_player" dialogtype="Regular">
+                        <Option text="EventText.generic.continue">
+                          <ConversationAction text="EventText.shockjock.signoff" targettag="triggerer_player" dialogtype="Regular" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </RNGAction>
+              <ConversationAction text="EventText.shockjock.o1.c4" targettag="triggerer_player" dialogtype="Regular">
+                <Option text="EventText.shockjock.o1.o4">
+                  <ConversationAction text="EventText.shockjock.o1.o4.c1" targettag="triggerer_player" dialogtype="Regular" />
+                  <SetDataAction identifier="heardbroadcast" value="true" />
+                </Option>
+                <Option text="EventText.generic.walkaway">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.generic.ignore">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Shock jock continuation-->
+    <ScriptedEvent identifier="shockjock2" commonness="50">
+      <TagAction criteria="player" tag="player"/>
+      <CheckDataAction identifier="shockjock_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat event-->
+        </Success>
+        <Failure>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="shockjock" targettag="okelly" spawnpointtag="saferoom" spawnlocation="beaconstation" requirespawnpointtag="true"/>
+          <SpawnAction speciesname="orangeboy" spawnpointtag="saferoom" targettag="maurice" spawnlocation="beaconstation" requirespawnpointtag="true"/>
+          <SpawnAction itemidentifier="petnametag" targetinventory="maurice" targettag="mauricenametag"/>
+          <StatusEffectAction targettag="mauricenametag">
+            <StatusEffect writtenname="Maurice"/>
+          </StatusEffectAction>
+          <TriggerAction target1tag="player" target2tag="okelly" applytotarget1="triggerer_player" radius="200" />
+          <CombatAction combatmode="Offensive" npctag="okelly" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+          <SetDataAction identifier="shockjock_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Assassination of Jacov Subra-->
+    <!--PART 1-->
+    <ScriptedEvent identifier="assassinationofjacovsubra1" commonness="50">
+      <CheckDataAction identifier="waytoascension" condition="gt 3">
+        <Success>
+          <!-- Don't give the assassination mission after joining the Church of Husk -->
+        </Success>
+        <Failure>
+          <CheckDataAction identifier="subraevent_state" condition="gt 0">
+            <Success>
+              <!--Don't repeat event-->
+            </Success>
+            <Failure>
+              <TagAction criteria="player" tag="player"/>
+              <TagAction criteria="itemidentifier:steelcabinet" tag="potentialcabinet" submarinetype="outpost" />
+              <TagAction criteria="itemidentifier:mediumwindowedsteelcabinet" tag="potentialcabinet" submarinetype="outpost"/>
+              <TagAction criteria="itemidentifier:mediumsteelcabinet" tag="potentialcabinet" submarinetype="outpost" />
+              <SpawnAction itemidentifier="idcard" spawnlocation="outpost" targettag="subraid" targetinventory="potentialcabinet" ignorebyai="true" />
+              <!--<TriggerAction target1tag="potentialcabinet" target2tag="player" applytotarget1="selectedcabinet" applytotarget2="triggerer_player" radius="50" />-->
+              <TriggerAction target1tag="subraid" target2tag="player" applytotarget1="selectedcabinet" applytotarget2="triggerer_player" radius="50" waitforinteraction="true"/>
+              <SetDataAction identifier="subraevent_state" value="1"/>
+              <ConversationAction text="EventText.assassinationofjacovsubra1.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="JacovSubra1">
+                <Option text="EventText.assassinationofjacovsubra1.o1">
+                  <ConversationAction text="EventText.assassinationofjacovsubra1.o1.c1" targettag="triggerer_player"/>
+                </Option>
+                <Option text="EventText.assassinationofjacovsubra1.o2">
+                  <!--Do nothing for now-->
+                </Option>
+              </ConversationAction>
+            </Failure>
+          </CheckDataAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 2-->
+    <ScriptedEvent identifier="assassinationofjacovsubra2" commonness="0">
+      <CheckDataAction identifier="subraevent_state" condition="eq 1">
+        <Success>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="workeronbreak" spawnpointtype="Path" spawnlocation="Outpost" targetmoduletags="airlock"/>
+          <TriggerAction target1tag="workeronbreak" target2tag="player" applytotarget2="triggerer_player" radius="500" waitforinteraction="true"/>
+          <NPCWaitAction npctag="workeronbreak" wait="true" />
+          <ConversationAction text="EventText.assassinationofjacovsubra2.c1" targettag="triggerer_player">
+            <Option text="EventText.assassinationofjacovsubra2.o1">
+              <ConversationAction text="EventText.assassinationofjacovsubra2.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra2">
+                <Option text="EventText.generic.continue">
+                <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.c1" targettag="triggerer_player">
+                  <Option text="EventText.assassinationofjacovsubra2.o1.o1.o1">
+                    <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.o1.c1" targettag="triggerer_player"/>
+                    <SetDataAction identifier="subraevent_state" value="2"/>
+                  </Option>
+                </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option >
+            <Option text="EventText.assassinationofjacovsubra2.o2">
+              <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra2">
+                <Option text="EventText.assassinationofjacovsubra2.o1.o1.o1">
+                  <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.o1.c1" targettag="triggerer_player"/>
+                  <SetDataAction identifier="subraevent_state" value="2"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.assassinationofjacovsubra2.o3">
+              <!--Rude, but set data anyway.-->
+              <SetDataAction identifier="subraevent_state" value="2"/>
+            </Option>
+          </ConversationAction>
+        <NPCWaitAction npctag="workeronbreak" wait="false" />
+        </Success>
+        <Failure>
+          <!--Do nothing before the ID card is found-->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 3-->
+    <!--TODO:
+    -trigger interact-->
+    <ScriptedEvent identifier="assassinationofjacovsubra3" commonness="0">
+      <CheckDataAction identifier="waytoascension" condition="gt 3">
+        <Success>
+          <!-- Don't progress the assassination mission after joining the Church of Husk -->
+        </Success>
+        <Failure>
+          <CheckDataAction identifier="subraevent_state" condition="eq 2">
+            <Success>
+              <TagAction criteria="player" tag="player"/>
+              <TagAction criteria="itemidentifier:opdeco_hrflyers" tag="potentialflyers" submarinetype="outpost" />
+              <TriggerAction target1tag="potentialflyers" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+              <ConversationAction text="EventText.assassinationofjacovsubra3.c1" targettag="triggerer_player" eventsprite="JacovSubra3">
+                <Option text="EventText.assassinationofjacovsubra3.o1" endconversation="true">
+                  <MissionAction missionidentifier="gotosubra" locationtype="Abandoned" unlockfurtheronmap="true"/>
+                </Option >
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <!--Do nothing-->
+            </Failure>
+          </CheckDataAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 4-->
+    <ScriptedEvent identifier="assassinationofjacovsubra4" commonness="0">
+      <CheckDataAction identifier="waytoascension" condition="gt 3">
+        <Success>
+          <!-- Don't progress the assassination mission after joining the Church of Husk -->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jacovsubra" targettag="jacovsubra" spawnlocation="Outpost"/>
+          <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <NPCWaitAction npctag="jacovsubra" wait="true" />
+          <ConversationAction text="EventText.assassinationofjacovsubra4.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.assassinationofjacovsubra4.o1">
+              <ConversationAction text="EventText.assassinationofjacovsubra4.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.assassinationofjacovsubra4.o1.o1">
+                  <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.assassinationofjacovsubra4.o1.o1.o1">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.assassinationofjacovsubra4.deal">
+                          <ConversationAction text="EventText.assassinationofjacovsubra4.neversaw" targettag="triggerer_player"/>
+                          <MoneyAction amount="3000" />
+                        </Option>
+                        <Option text="EventText.assassinationofjacovsubra4.nodeal">
+                          <ConversationAction text="EventText.assassinationofjacovsubra4.run" targettag="triggerer_player"/>
+                          <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                          <SetDataAction identifier="subraevent_state" value="3"/>
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.assassinationofjacovsubra4.o1.o1.o2">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.o2.c1" targettag="triggerer_player">
+                        <Option text="EventText.assassinationofjacovsubra4.o1.o1.o2.o1" endconversation="true">
+                          <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                          <SetDataAction identifier="subraevent_state" value="3"/>
+                          <!--END-->
+                        </Option>
+                        <Option text="EventText.assassinationofjacovsubra4.o1.o1.o2.o2">
+                          <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.o2.o2.c1" targettag="triggerer_player"/>
+                          <MissionAction missionidentifier="subraescort"/>
+                          <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.assassinationofjacovsubra4.o1.o2">
+                  <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.assassinationofjacovsubra4.deal">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.neversaw" targettag="triggerer_player"/>
+                      <MoneyAction amount="3000" />
+                    </Option>
+                    <Option text="EventText.assassinationofjacovsubra4.nodeal">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.run" targettag="triggerer_player"/>
+                      <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                      <SetDataAction identifier="subraevent_state" value="3"/>
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.assassinationofjacovsubra4.o2" endconversation="true">
+              <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+              <SetDataAction identifier="subraevent_state" value="3"/>
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <NPCWaitAction npctag="jacovsubra" wait="false" />
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Bad vibrations-->
+    <!--PART 1-->
+    <ScriptedEvent identifier="badvibrations1" commonness="50">
+      <CheckDataAction identifier="badvibrations_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="artifactvictim" targettag="victim" spawnlocation="Outpost" />
+          <NPCWaitAction npctag="artifactvictim" wait="true" />
+          <TriggerAction target1tag="player" target2tag="victim" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.badvibrations1.c1" targettag="triggerer_player" eventsprite="BadVibration1">
+            <Option text="EventText.badvibrations1.o1">
+              <ConversationAction text="EventText.badvibrations1.o1.c1" targettag="triggerer_player" eventsprite="BadVibration2">
+                <Option text="EventText.badvibrations1.o1.o1">
+                  <ConversationAction text="EventText.badvibrations1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.badvibrations1.o1.o1.o1">
+                      <ConversationAction text="EventText.badvibrations1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.badvibrations1.stepback">
+                          <ConversationAction text="EventText.badvibrations1.raving" targettag="triggerer_player"/>
+                          <MissionAction missionidentifier="badvibrationsartifactruins"/>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.badvibrations1.stepback">
+                      <ConversationAction text="EventText.badvibrations1.raving" targettag="triggerer_player"/>
+                      <MissionAction missionidentifier="badvibrationsartifactruins"/>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.badvibrations1.notmyproblem">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.badvibrations1.notmyproblem">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="badvibrations_missionreceived" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 2-->
+    <ScriptedEvent identifier="badvibrations2" commonness="0">
+      <TagAction criteria="player" tag="player"/>
+      <TagAction criteria="itemidentifier:psychosisartifact_event" tag="artifact"/>
+      <TriggerAction target1tag="player" target2tag="artifact" applytotarget1="triggerer_player" waitforinteraction="true"/>
+      <AfflictionAction affliction="psychosis" strength="10" targettag="triggerer_player" />
+      <ConversationAction text="EventText.badvibrations2.c1" targettag="triggerer_player">
+        <Option text="EventText.badvibrations2.o1">
+          <AfflictionAction affliction="psychosis" strength="20" targettag="triggerer_player" />
+          <ConversationAction text="EventText.badvibrations2.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.badvibrations2.o1.o1">
+              <AfflictionAction affliction="psychosis" strength="30" targettag="triggerer_player" />
+              <ConversationAction text="EventText.badvibrations2.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.badvibrations2.o1.o1.o1">
+                  <AfflictionAction affliction="paralysis" strength="100" targettag="triggerer_player" />
+                  <ConversationAction text="EventText.badvibrations2.o1.o1.o1.c1" targettag="triggerer_player"/>
+                  <!--END-->
+                </Option>
+                <Option text="EventText.badvibrations2.inspect">
+                  <AfflictionAction affliction="psychosis" strength="-100" targettag="triggerer_player" />
+                  <SetDataAction identifier="badvibrations_state" value="1" />
+                  <ConversationAction text="EventText.badvibrations2.protrusion" targettag="triggerer_player"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.badvibrations2.inspect">
+              <AfflictionAction affliction="psychosis" strength="-100" targettag="triggerer_player" />
+              <SetDataAction identifier="badvibrations_state" value="1" />
+              <ConversationAction text="EventText.badvibrations2.protrusion" targettag="triggerer_player"/>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.badvibrations2.inspect">
+          <AfflictionAction affliction="psychosis" strength="-100" targettag="triggerer_player" />
+          <SetDataAction identifier="badvibrations_state" value="1" />
+          <ConversationAction text="EventText.badvibrations2.protrusion" targettag="triggerer_player"/>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--PART 3-->
+    <ScriptedEvent identifier="badvibrations3" commonness="0">
+      <CheckDataAction identifier="badvibrations_state" condition="eq 1">
+        <Success>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="artifactvictim" targettag="artifactvictim" spawnlocation="Outpost" />
+          <NPCWaitAction npctag="artifactvictim" wait="true" />
+          <TriggerAction target1tag="player" target2tag="artifactvictim" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.badvibrations3.c1" targettag="triggerer_player">
+            <Option text="EventText.badvibrations3.o1">
+              <ConversationAction text="EventText.badvibrations3.gotbetter" targettag="triggerer_player">
+                <Option text="EventText.badvibrations3.welcome">
+                  <ConversationAction text="EventText.badvibrations3.anotherthing" targettag="triggerer_player">
+                    <Option text="EventText.badvibrations3.merrier">
+                      <ConversationAction text="EventText.badvibrations3.seeyouonboard" targettag="triggerer_player"/>
+                      <NPCChangeTeamAction npctag="artifactvictim" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="badvibrations_state" value="2" />
+                      <!--END-->
+                    </Option>
+                    <Option text="EventText.badvibrations3.full">
+                      <ConversationAction text="EventText.badvibrations3.hangout" targettag="triggerer_player"/>
+                      <SetDataAction identifier="badvibrations_state" value="2" />
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.badvibrations3.reward">
+                  <ConversationAction text="EventText.badvibrations3.scrounge" targettag="triggerer_player"/>
+                  <MoneyAction amount="350" />
+                  <SetDataAction identifier="badvibrations_state" value="2" />
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.badvibrations3.o2">
+              <ConversationAction text="EventText.badvibrations3.o2.c1" targettag="triggerer_player">
+                <Option text="EventText.badvibrations3.o2.o1">
+                  <ConversationAction text="EventText.badvibrations3.gotbetter" targettag="triggerer_player">
+                    <Option text="EventText.badvibrations3.welcome">
+                      <ConversationAction text="EventText.badvibrations3.anotherthing" targettag="triggerer_player">
+                        <Option text="EventText.badvibrations3.merrier">
+                          <ConversationAction text="EventText.badvibrations3.seeyouonboard" targettag="triggerer_player"/>
+                          <NPCChangeTeamAction npctag="artifactvictim" teamid="Team1" addtocrew="true" />
+                          <SetDataAction identifier="badvibrations_state" value="2" />
+                          <!--END-->
+                        </Option>
+                        <Option text="EventText.badvibrations3.full">
+                          <ConversationAction text="EventText.badvibrations3.hangout" targettag="triggerer_player"/>
+                          <SetDataAction identifier="badvibrations_state" value="2" />
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.badvibrations3.reward">
+                      <ConversationAction text="EventText.badvibrations3.scrounge" targettag="triggerer_player"/>
+                      <MoneyAction amount="350" />
+                      <SetDataAction identifier="badvibrations_state" value="2" />
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+        <Failure>
+          <!--Do nothing-->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--A man and his raptor-->
+    <!--PART 1-->
+    <ScriptedEvent identifier="manandhisraptor1" commonness="50">
+      <CheckDataAction identifier="manandhisraptor_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="raptorowner" targettag="raptorowner" spawnlocation="Outpost" />
+          <NPCWaitAction npctag="raptorowner" wait="true" />
+          <TriggerAction target1tag="player" target2tag="raptorowner" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.manandhisraptor1.c1" targettag="triggerer_player" eventsprite="ManAndHisRaptor">
+            <Option text="EventText.manandhisraptor1.o1">
+              <ConversationAction text="EventText.manandhisraptor1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.manandhisraptor1.o1.o1">
+                  <ConversationAction text="EventText.manandhisraptor1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.manandhisraptor1.takeonboard">
+                      <MissionAction missionidentifier="raptorescort"/>
+                      <MoneyAction amount="1000" />
+                      <ConversationAction text="EventText.manandhisraptor1.great" targettag="triggerer_player"/>
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.manandhisraptor1.takeonboard">
+                  <MissionAction missionidentifier="raptorescort"/>
+                  <ConversationAction text="EventText.manandhisraptor1.great" targettag="triggerer_player"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.manandhisraptor1.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="manandhisraptor_missionreceived" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 2-->
+    <ScriptedEvent identifier="manandhisraptor2" commonness="0">
+      <TagAction criteria="player" tag="player"/>
+      <TagAction criteria="humanprefabidentifier:raptorowner" tag="raptorowner"/>
+      <TriggerAction target1tag="player" target2tag="raptorowner" applytotarget1="triggerer_player" waitforinteraction="true"/>
+      <ConversationAction text="EventText.manandhisraptor2.c1" targettag="triggerer_player">
+        <Option text="EventText.manandhisraptor2.o1">
+          <SpawnAction speciesname="mudraptor_passive" spawnpointtag="raptorowner" targettag="rex"/>
+          <SpawnAction itemidentifier="petnametag" targetinventory="rex" targettag="rexnametag"/>
+          <StatusEffectAction targettag="rexnametag">
+            <StatusEffect writtenname="Rex"/>
+          </StatusEffectAction>
+          <ConversationAction text="EventText.manandhisraptor2.o1.c1" targettag="triggerer_player"/>
+        </Option>
+      </ConversationAction>
+      <ConversationAction text="EventText.manandhisraptor2.c1.c1" speakertag="rex" endeventifinterrupted="false" dialogtype="Small" />
+    </ScriptedEvent>
+    <!--Heart of gold-->
+    <ScriptedEvent identifier="heartofgold" commonness="50">
+      <CheckDataAction identifier="heartofgold_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="drugdealer" targettag="drugdealer" spawnlocation="outpost"/>
+          <NPCWaitAction npctag="drugdealer" wait="true" />
+          <TriggerAction target1tag="player" target2tag="drugdealer" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.heartofgold.c1" targettag="triggerer_player" eventsprite="HeartOfGold">
+            <Option text="EventText.heartofgold.o1">
+              <ConversationAction text="EventText.heartofgold.o1.c1" targettag="triggerer_player"/>
+              <CombatAction combatmode="Offensive" npctag="drugdealer" enemytag="triggerer_player" isinstigator="false" guardreaction="none" witnessreaction="retreat"/>
+              <!--END-->
+            </Option>
+            <Option text="EventText.heartofgold.o2">
+              <ConversationAction text="EventText.heartofgold.o2.c1" targettag="triggerer_player">
+                <Option text="EventText.heartofgold.goodluck">
+                  <ConversationAction text="EventText.heartofgold.wait" targettag="triggerer_player">
+                    <Option text="EventText.heartofgold.okay">
+                      <ConversationAction text="EventText.heartofgold.signingbonus" targettag="triggerer_player"/>
+                      <NPCChangeTeamAction npctag="drugdealer" teamid="Team1" addtocrew="true" />
+                      <!--END-->
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <ConversationAction text="EventText.heartofgold.whatamigonnado" targettag="triggerer_player">
+                        <Option text="EventText.heartofgold.onyourown">
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.heartofgold.o2.o2">
+                  <ConversationAction text="EventText.heartofgold.o2.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.heartofgold.o2.o2.o1">
+                      <ConversationAction text="EventText.heartofgold.o2.o2.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.heartofgold.goodluck">
+                          <ConversationAction text="EventText.heartofgold.wait" targettag="triggerer_player">
+                            <Option text="EventText.heartofgold.okay">
+                              <ConversationAction text="EventText.heartofgold.signingbonus" targettag="triggerer_player"/>
+                              <NPCChangeTeamAction npctag="drugdealer" teamid="Team1" addtocrew="true" />
+                              <!--END-->
+                            </Option>
+                            <Option text="EventText.generic.refuse">
+                              <ConversationAction text="EventText.heartofgold.whatamigonnado" targettag="triggerer_player">
+                                <Option text="EventText.heartofgold.onyourown">
+                                  <!--END-->
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="heartofgold_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+
+    <!-- radiation escapee -->
+    <ScriptedEvent identifier="radiationescapee" commonness="50">
+      <CheckDataAction identifier="radiationescapee_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="radiationescapee" targettag="radiationescapee" spawnlocation="Outpost" />
+          <TriggerAction target1tag="radiationescapee" target2tag="player" applytotarget2="triggerer_player" radius="500" waitforinteraction="false"/>
+          <NPCFollowAction npctag="radiationescapee" targettag="triggerer_player" follow="true" />
+          <TriggerAction target1tag="radiationescapee" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="false"/>
+          <ConversationAction text="EventText.radiationescapee.c1" targettag="triggerer_player" eventsprite="ManAndHisRaptor">
+            <Option text="EventText.radiationescapee.o1">
+              <ConversationAction text="EventText.radiationescapee.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.radiationescapee.o1.o1">                  
+                  <ConversationAction text="EventText.radiationescapee.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="eventtext.manandhisraptor1.takeonboard">
+                      <MissionAction missionidentifier="radiationescapeeescort" unlockfurtheronmap="true"/>
+                      <ConversationAction text="EventText.radiationescapee.great" targettag="triggerer_player"/>
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>                  
+                </Option>
+                <Option text="EventText.radiationescapee.o1.o2">
+                  <ConversationAction text="EventText.radiationescapee.o1.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.manandhisraptor1.takeonboard">
+                      <MissionAction missionidentifier="radiationescapeeescort" unlockfurtheronmap="true"/>
+                      <ConversationAction text="EventText.radiationescapee.great" targettag="triggerer_player"/>
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="radiationescapee_missionreceived" value="true"/>
+          <NPCFollowAction npctag="radiationescapee" targettag="triggerer_player" follow="false" />
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- researcher escort -->
+    <ScriptedEvent identifier="researcherescort" commonness="50">
+      <CheckDataAction identifier="researcherescort_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="eyeresearcher" targettag="eyeresearcher" spawnlocation="Outpost" />
+          <TriggerAction target1tag="player" target2tag="eyeresearcher" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.researcherescort.c1" targettag="triggerer_player" eventsprite="BombScare1">
+            <Option text="EventText.researcherescort.o1">
+              <ConversationAction text="EventText.researcherescort.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.researcherescort.o1.o1">
+                  <ConversationAction text="EventText.researcherescort.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.researcherescort.o1.o1.o1">
+                      <ConversationAction text="EventText.researcherescort.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="eventtext.manandhisraptor1.takeonboard">
+                          <MissionAction missionidentifier="researcherescort" unlockfurtheronmap="true"/>
+                          <ConversationAction text="EventText.researcherescort.great" targettag="triggerer_player"/>
+                          <SetDataAction identifier="researcherescort_missionreceived" value="true"/>
+                        </Option>
+                        <Option text="EventText.generic.refuse">
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>                    
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- returner -->
+    <ScriptedEvent identifier="returner" commonness="50">
+      <CheckDataAction identifier="returner" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="returner" spawnlocation="Outpost" />
+          <TriggerAction target1tag="player" target2tag="returner" applytotarget1="triggerer_player" radius="150" waitforinteraction="false"/>
+          <ConversationAction text="EventText.returner.c1" targettag="triggerer_player" eventsprite="BadVibration2">
+            <Option text="EventText.returner.o1">
+              <ConversationAction text="EventText.returner.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.returner.o1.o1">
+                  <ConversationAction text="EventText.returner.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.returner.o1.o1.o1">
+                      <ConversationAction text="EventText.returner.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.returner.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.returner.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="returner" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Captive souls-->
+    <ScriptedEvent identifier="captivesouls" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="researcher" targettag="captivesouls_scientist" targetmoduletags="airlock" spawnlocation="Outpost" />
+      <NPCWaitAction npctag="captivesouls_scientist" wait="true" />
+      <TriggerAction target1tag="player" target2tag="captivesouls_scientist" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.captivesouls.c1" targettag="triggerer_player" eventsprite="mediator">
+        <Option text="EventText.captivesouls.o1">
+          <ConversationAction text="EventText.captivesouls.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.generic.continue">
+              <ConversationAction text="EventText.captivesouls.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.generic.continue">
+                  <ConversationAction text="EventText.captivesouls.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" >
+                    <Option text="EventText.generic.continue">
+                      <ConversationAction text="EventText.captivesouls.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+      <!--Trigger at research module-->
+      <TriggerAction target1tag="triggerer_player" targetmoduletype="researchmodule" radius="100" />
+      <ConversationAction text="EventText.captivesouls.c1.c1" targettag="triggerer_player">
+        <Option text="EventText.captivesouls.c1.o1">
+          <ConversationAction text="EventText.captivesouls.c1.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.captivesouls.c1.o1.o1">
+              <ConversationAction text="EventText.captivesouls.c1.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.captivesouls.c1.o1.o1.o1">
+                  <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.captivesouls.c1.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.generic.continue">
+                              <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1">
+                                  <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                                  <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" />
+                                </Option>
+                                <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2">
+                                  <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2.c1" targettag="triggerer_player" endconversation="true" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o2">
+                          <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o2.c1" targettag="triggerer_player" endconversation="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.captivesouls.c1.o1.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.captivesouls.c1.o2">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--Explosive Mishap-->
+    <ScriptedEvent identifier="explosivemishap" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="player" targetmoduletype="armorymodule" applytotarget1="triggerer_player" />
+      <ConversationAction text="EventText.explosivemishap.c1" targettag="triggerer_player" eventsprite="Stowaway2">
+        <Option text="EventText.explosivemishap.o1">
+          <ConversationAction text="EventText.explosivemishap.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.generic.continue">
+              <ConversationAction text="EventText.explosivemishap.o1.o1.c1" targettag="triggerer_player" endconversation="true"/>
+              <StatusEffectAction targettag="triggerer_player">
+                <StatusEffect>
+                  <Explosion range="200.0" stun="1.0" force="15.0" flames="true" flash="true" shockwave="true" sparks="true" underwaterbubble="true" />
+                  <Sound file="Content/Sounds/Damage/StructureCrunch2.ogg" range="500" />
+                </StatusEffect>
+              </StatusEffectAction>
+              <ConversationAction text="EventText.explosivemishap.o1.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.explosivemishap.o1.o1.o1.o1">
+                  <ConversationAction text="EventText.explosivemishap.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.explosivemishap.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1">
+                              <RNGAction chance="0.25">
+                                <Success>
+                                  <ConversationAction targettag="triggerer_player" text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c1">
+                                    <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o1" endconversation="true">
+                                      <SpawnAction itemidentifier="ancientweapon" targettag="ancientweapon" targetinventory="triggerer_player" />
+                                      <SpawnAction itemidentifier="alienpowercell" targetinventory="ancientweapon" />
+                                    </Option>
+                                    <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2">
+                                      <ConversationAction targettag="triggerer_player" text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2.c1" endconversation="true" />
+                                      <ReputationAction targettype="Location" increase="3" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Success>
+                                <Failure>
+                                  <ConversationAction targettag="triggerer_player" text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c2" endconversation="true" />
+                                  <SpawnAction itemidentifier="ancientweapon" targettag="ancientweapon" targetinventory="triggerer_player" />
+                                </Failure>
+                              </RNGAction>
+                            </Option>
+                            <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o2" endconversation="true">
+                              <SpawnAction itemidentifier="ancientweapon" targettag="ancientweapon" targetinventory="triggerer_player" />
+                            </Option>
+                            <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2.c1" endconversation="true" />
+                              <ReputationAction targettype="Location" increase="3" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.explosivemishap.o1.o1.o1.o1.o2">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--Occupational Hazards-->
+    <ScriptedEvent identifier="occupationalhazards" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="player" targetmoduletype="crewmodule" applytotarget1="triggerer_player" />
+      <ConversationAction text="EventText.occupationalhazards.c1" targettag="triggerer_player" eventsprite="engineer">
+        <Option text="EventText.occupationalhazards.o1">
+          <ConversationAction text="EventText.occupationalhazards.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.occupationalhazards.o1.o1">
+              <ConversationAction text="EventText.occupationalhazards.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.occupationalhazards.o1.o1.o1">
+                  <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.occupationalhazards.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1">
+                                  <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                    <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1">
+                                      <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                                      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="raptorvictim" targettag="occupationalhazards_miner" spawnlocation="Outpost" spawnpointtype="Path" targetmoduletags="minemodule" />
+                                      <SpawnAction itemidentifier="smallmudraptoregg" spawnlocation="Outpost" targetmoduletags="minemodule"/>
+                                      <SpawnAction itemidentifier="smallmudraptoregg" spawnlocation="Outpost" targetmoduletags="minemodule"/>
+                                      <AfflictionAction targettag="occupationalhazards_miner" affliction="bitewounds" strength="1000" />
+                                      <TriggerAction target1tag="occupationalhazards_miner" target2tag="triggerer_player" radius="100" disableiftargetincapacitated="false"/>
+                                      <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1" targettag="triggerer_player" eventsprite="unconscious">
+                                        <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1">
+                                          <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1.c1" targettag="triggerer_player" endconversation="true"/>
+                                          <MoneyAction amount="904" />
+                                        </Option>
+                                        <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o2"/>
+                                      </ConversationAction>
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--Hognose-->
+    <ScriptedEvent identifier="hognose" commonness="50">
+      <CheckDataAction identifier="hognose_accepted" condition="eq true">
+        <Success>
+          <!--Do nothing-->
+        </Success>
+        <Failure>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="hognose" targettag="hognose" spawnlocation="Outpost" spawnpointtype="Path" />
+          <NPCWaitAction npctag="hognose" wait="true" />
+          <TagAction criteria="player" tag="player" />
+          <TriggerAction target1tag="hognose" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+          <ConversationAction text="EventText.hognose.c1" targettag="triggerer_player" eventsprite="Stowaway2">
+            <Option text="EventText.hognose.o1">
+              <ConversationAction text="EventText.hognose.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.hognose.o1.o1">
+                  <ConversationAction text="EventText.hognose.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.hognose.o1.o1.o1">
+                      <ConversationAction text="EventText.hognose.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.hognose.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.hognose.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.hognose.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.hognose.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                <Option text="EventText.generic.continue">
+                                  <ConversationAction text="EventText.hognose.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                    <Option text="EventText.hognose.o1.o1.o1.o1.o1.o1.o1">
+                                      <ConversationAction text="EventText.hognose.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                                      <MissionAction missionidentifier="killmopingjack" />
+                                      <SetDataAction identifier="hognose_accepted" value="true" />
+                                    </Option>
+                                    <Option text="EventText.hognose.o1.o1.o1.o1.o1.o1.o2">
+                                      <!--END-->
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.hognose.o1.o1.o2" />
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.hognose.o1.o2">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.hognose.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="hognose2" commonness="50">
+      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="hognose" targettag="hognose" spawnlocation="MainSub" spawnpointtype="Path" allowduplicates="false" />
+      <NPCChangeTeamAction npctag="hognose" teamid="Team1" addtocrew="true" />
+    </ScriptedEvent>
+
+    <!--Prophet of Sierpinsk-->
+    <ScriptedEvent identifier="prophetofsierpinsk" commonness="0">
+      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="prophetofsierpinsk" targettag="prophet" spawnpointtag="saferoom" spawnlocation="beaconstation" requirespawnpointtag="true" />
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="prophet" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" eventsprite="officeinside" />
+      <ConversationAction text="EventText.prophetofsierpinsk.c1" targettag="triggerer_player">
+        <Option text="EventText.prophetofsierpinsk.o1">
+          <ConversationAction text="EventText.prophetofsierpinsk.o1.c1" targettag="triggerer_player" />
+          <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.c1" targettag="triggerer_player">
+            <Option text="EventText.prophetofsierpinsk.o1.c1.o1">
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.prophetofsierpinsk.o1.c1.o1.o1">
+                  <GoTo name="explain" />
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.prophetofsierpinsk.o1.c1.o2">
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o2.c1" targettag="triggerer_player">
+                <Option text="EventText.prophetofsierpinsk.o1.c1.o2.o1">
+                  <GoTo name="explain" />
+                </Option>
+              </ConversationAction>
+              <Label name="explain" />
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o2.c1.c1" targettag="triggerer_player" />
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o2.c1.c1.c1" targettag="triggerer_player" endconversation="true" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.prophetofsierpinsk.o2">
+          <ConversationAction text="EventText.prophetofsierpinsk.o2.c1" targettag="triggerer_player">
+            <Option text="EventText.prophetofsierpinsk.o2.o1">
+              <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.prophetofsierpinsk.o2.o1.o1">
+                  <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.prophetofsierpinsk.o2.o1.o1.o1">
+                      <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.prophetofsierpinsk.o2.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--"Alien writing 1"-->
+    <ScriptedEvent identifier="alienwriting1" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienwriting1" tag="alienwriting1" />
+      <Label name="writingstart" />
+      <TriggerAction target1tag="alienwriting1" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <CheckItemAction targettag="triggerer_player" itemidentifiers="alientranslator">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start">
+            <Option text="eventtext.alienwriting.listen">
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.writingstart"/>
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.1_1"/>
+            </Option>
+            <Option text="eventtext.alienwriting.dontlisten" endconversation="true">
+              <GoTo name="writingstart" />
+            </Option>
+          </ConversationAction>
+          <GoTo name="writingstart" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start_alt" endconversation="true"/>
+          <GoTo name="writingstart" />
+        </Failure>
+      </CheckItemAction>
+    </ScriptedEvent>
+    
+    <!--"Alien writing 2"-->
+    <ScriptedEvent identifier="alienwriting2" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienwriting2" tag="alienwriting2" />
+      <Label name="writingstart" />
+      <TriggerAction target1tag="alienwriting2" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <CheckItemAction targettag="triggerer_player" itemidentifiers="alientranslator">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start">
+            <Option text="eventtext.alienwriting.listen">
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.writingstart"/>
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.2_1"/>
+            </Option>
+            <Option text="eventtext.alienwriting.dontlisten" endconversation="true">
+              <GoTo name="writingstart" />
+            </Option>
+          </ConversationAction>
+          <GoTo name="writingstart" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start_alt" endconversation="true"/>
+          <GoTo name="writingstart" />
+        </Failure>
+      </CheckItemAction>
+    </ScriptedEvent>
+
+    <!--"Alien writing 3"-->
+    <ScriptedEvent identifier="alienwriting3" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienwriting3" tag="alienwriting3" />
+      <Label name="writingstart" />
+      <TriggerAction target1tag="alienwriting3" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <CheckItemAction targettag="triggerer_player" itemidentifiers="alientranslator">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start">
+            <Option text="eventtext.alienwriting.listen">
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.writingstart"/>
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.3_1"/>
+            </Option>
+            <Option text="eventtext.alienwriting.dontlisten" endconversation="true">
+              <GoTo name="writingstart" />
+            </Option>
+          </ConversationAction>
+          <GoTo name="writingstart" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start_alt" endconversation="true"/>
+          <GoTo name="writingstart" />
+        </Failure>
+      </CheckItemAction>
+    </ScriptedEvent>
+
+    <!--"Ancient encounter"-->
+    <ScriptedEvent identifier="ancientencounter" commonness="100">
+      <WaitAction time="10" />
+      <ConversationAction text="EventText.ancientencounter.c1" eventsprite="Ancient1">
+        <Option text="EventText.ancientencounter.o1">
+          <ConversationAction text="EventText.ancientencounter.o1.c1" eventsprite="Ancient2">
+            <Option text="EventText.ancientencounter.o1.o1">
+              <ConversationAction text="EventText.ancientencounter.o1.o1.c1" eventsprite="Ancient2">
+                <Option text="EventText.ancientencounter.o1.o1.o1">
+                  <ConversationAction text="EventText.ancientencounter.o1.o1.o1.c1" eventsprite="Ancient2">
+                    <Option text="EventText.ancientencounter.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                        <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                            <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                                <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.o1" endconversation="true" />
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.ancientencounter.o1.o1.o2">
+                  <ConversationAction text="EventText.ancientencounter.o1.o1.o2.c1" eventsprite="Ancient2">
+                    <Option text="EventText.ancientencounter.o1.o1.o1">
+                      <ConversationAction text="EventText.ancientencounter.o1.o1.o1.c1" eventsprite="Ancient2">
+                        <Option text="EventText.ancientencounter.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                            <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                                <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1">
+                                  <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                                    <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.o1" endconversation="true" />
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="ancientencounterfinal" commonness="0">
+      <ConversationAction text="EventText.ancientencounterfinal" dialogtype="Regular" endconversation="true" eventsprite="Ancient2"/>
+    </ScriptedEvent>
+    
+    <ScriptedEvent identifier="buttonpressed1" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienentrancebutton" tag="alienentrancebutton" />
+      <TagAction criteria="itemtag:anomalydoor" tag="door" />
+      <TriggerAction target1tag="alienentrancebutton" target2tag="player" applytotarget2="triggerer_player" radius="500"/>
+      <Label name="retry" />
+      <WaitAction time="1" />
+      <CheckConditionalAction targettag="door" targetitemcomponent="Door" IsOpen="true" >
+        <Success>
+          <ConversationAction text="EventText.buttonpressed1.c1" dialogtype="Regular" endconversation="true"/>
+        </Success>
+        <Failure>
+          <Goto name="retry"/>
+        </Failure>
+      </CheckConditionalAction>
+    </ScriptedEvent>
+
+    <!--"Unlock Path"-->
+    <ScriptedEvent identifier="unlockpathgeneric" commonness="0" unlockpathevent="true">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 30">
+        <Success>
+          <ConversationAction text="EventText.unlockpathgeneric.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathgeneric.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathgeneric.o1">
+              <CheckMoneyAction amount="2000">
+                <Success>
+                  <MoneyAction amount="-2000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgeneric.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgeneric.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpathgeneric.o2">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgeneric.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathcoldcaverns" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="30" faction="coalition" biome="coldcaverns">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 30">
+        <Success>
+          <ConversationAction text="EventText.unlockpathcoldcaverns.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathcoldcaverns.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathcoldcaverns.o1">
+              <CheckMoneyAction amount="2000">
+                <Success>
+                  <MoneyAction amount="-2000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathcoldcaverns.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathcoldcaverns.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathcoldcaverns.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpatheuropanridge" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="40" faction="coalition" biome="europanridge">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 40">
+        <Success>
+          <ConversationAction text="EventText.unlockpatheuropanridge.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpatheuropanridge.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpatheuropanridge.o1">
+              <CheckMoneyAction amount="4000">
+                <Success>
+                  <MoneyAction amount="-4000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathaphoticplateau" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="50" faction="coalition" biome="theaphoticplateau">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 50">
+        <Success>
+          <ConversationAction text="EventText.unlockpathaphoticplateau.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathaphoticplateau.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathaphoticplateau.o1">
+              <CheckMoneyAction amount="8000">
+                <Success>
+                  <MoneyAction amount="-8000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathgreatsea" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="75" faction="coalition" biome="thegreatsea">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 75">
+        <Success>
+          <ConversationAction text="EventText.unlockpathgreatsea.c1" speakertag="unlockpathnpc" dialogtype="Regular" eventsprite="captain"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathgreatsea.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathgreatsea.o1">
+              <CheckMoneyAction amount="16000">
+                <Success>
+                  <MoneyAction amount="-16000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathcoldcavernsseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="30" faction="separatists" biome="coldcaverns">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Success>
+          <ConversationAction text="EventText.unlockpathcoldcavernsseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="eventtext.unlockpathcoldcavernsseparatists.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathcoldcaverns.o1">
+              <CheckMoneyAction amount="2000">
+                <Success>
+                  <MoneyAction amount="-2000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathcoldcavernsseparatists.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathcoldcavernsseparatists.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathcoldcavernsseparatists.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpatheuropanridgeseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="40" faction="separatists" biome="europanridge">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 40">
+        <Success>
+          <ConversationAction text="eventtext.unlockpatheuropanridgeseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpatheuropanridge.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpatheuropanridge.o1">
+              <CheckMoneyAction amount="4000">
+                <Success>
+                  <MoneyAction amount="-4000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathaphoticplateauseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="50" faction="separatists" biome="theaphoticplateau">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 50">
+        <Success>
+          <ConversationAction text="EventText.unlockpathaphoticplateauseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathaphoticplateau.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathaphoticplateau.o1">
+              <CheckMoneyAction amount="8000">
+                <Success>
+                  <MoneyAction amount="-8000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathaphoticplateauseparatists.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathgreatseaseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="75" faction="separatists" biome="thegreatsea">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 75">
+        <Success>
+          <ConversationAction text="eventtext.unlockpathgreatseaseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular" eventsprite="captain"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathgreatsea.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathgreatsea.o1">
+              <CheckMoneyAction amount="16000">
+                <Success>
+                  <MoneyAction amount="-16000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    
+
+    <ScriptedEvent identifier="healreaperstax" commonness="100">    
+      <WaitAction time="5" />
+      <TagAction criteria="crew" tag="crew" />
+        <!-- one of the players needs to have the reaper's tax affliction for the event to do anything -->
+      <CheckAfflictionAction identifier="reaperstax" targettag="crew">
+        <Success>
+          <ConversationAction text="EventText.healreaperstax.c1" speakertag="outpostdoctor" invokertag="patient" endeventifinterrupted="false" dialogtype="Regular" eventsprite="redbluebottles"/>
+          <CheckAfflictionAction identifier="reaperstax" targettag="patient">
+            <Success>
+              <ConversationAction text="EventText.healreaperstax.c2" speakertag="outpostdoctor" waitforinteraction="false" targettag="patient" endeventifinterrupted="false" dialogtype="Regular" eventsprite="redbluebottles">
+                <Option text="EventText.healreaperstax.o1" endconversation="true">
+                  <CheckMoneyAction amount="1000" endconversation="true">
+                    <Success endconversation="true">
+                      <MoneyAction amount="-1000" />
+                      <AfflictionAction affliction="reaperstax" strength="-100" targettag="patient" />
+                      <TriggerEventAction identifier="healreaperstax" />
+                    </Success>
+                    <Failure endconversation="true">
+                      <ConversationAction speakertag="outpostdoctor" waitforinteraction="false" targettag="patient" text="EventText.healreaperstax.o1.nomoney" eventsprite="redbluebottles" />
+                      <TriggerEventAction identifier="healreaperstax" />
+                    </Failure>
+                  </CheckMoneyAction>
+                </Option>
+                <Option text="EventText.healreaperstax.o2" endconversation="true">
+                  <TriggerEventAction identifier="healreaperstax" />
+                </Option>
+              </ConversationAction>
+            </Success>
+            <Failure endconversation="true">
+              <TriggerEventAction identifier="healreaperstax" />
+            </Failure>
+          </CheckAfflictionAction>
+        </Success>
+        <Failure />
+      </CheckAfflictionAction>
+    </ScriptedEvent>
+
+    <!--RANDOM NPC MISSIONS-->
+    <ScriptedEvent identifier="missionevent_killmonster" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="missionnpc" spawnlocation="Outpost" spawnpointtype="Path" />
+      <ConversationAction text="EventText.missionevent_killmonster.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small"/>
+      <MissionAction missiontag="killmonster_set1" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargo" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="missionnpc" spawnlocation="Outpost" spawnpointtype="Path" />
+      <ConversationAction text="EventText.missionevent_cargo.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small"/>
+      <MissionAction missiontag="cargo" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvage" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="missionnpc" spawnlocation="Outpost" spawnpointtype="Path" />
+      <ConversationAction text="EventText.missionevent_salvage.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvage" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_clownoutbreak" commonness="40">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_hrflyers" tag="potentialflyers" submarinetype="outpost" />
+      <TriggerAction target1tag="potentialflyers" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.missionevent_clownoutbreak.c1">
+        <Option text="EventText.missionevent_clownoutbreak.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.missionevent_clownoutbreak.o1.c1" />
+          <MissionAction missiontag="cargoclown" />
+        </Option>
+        <Option text="EventText.missionevent_clownoutbreak.o2">
+          <ConversationAction targettag="triggerer_player" text="EventText.missionevent_clownoutbreak.o2.c1" />
+          <MissionAction missiontag="cargoclown" />
+        </Option>
+        <Option text="EventText.missionevent_clownoutbreak.o3" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--MANAGER MISSIONS-->
+    <ScriptedEvent identifier="missionevent_cargo1" commonness="125">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargomaterials" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargo2" commonness="50">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo2.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoexplosive" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargo3" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo3.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoresearch" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargoany" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargo" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargoweaponscoalition.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoweaponscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargocompoundn.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoexplosiveseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set1" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set2" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set3" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set4" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set4" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set1" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonstercommon.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set1" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonstercommon.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set2" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonsterrare.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set3" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonsterrare.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set4" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvageartifact" commonness="75">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_salvageartifact.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvageartifact" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvagewreck" commonness="75">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_salvagewreck.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvagewreck" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_crawlernest" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_crawlernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="crawlernest" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_mudraptornest" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_mudraptornest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="mudraptornest" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_tigerthreshernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="tigerthreshernest" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent> 
+    <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_crawlernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="crawlernesthard" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_mudraptornest_hard" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_mudraptornest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="mudraptornesthard" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_tigerthreshernest_hard" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_tigerthreshernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="tigerthreshernesthard" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_beacon" commonness="200" requirebeaconstation="True">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text= "EventText.missionevent_beacon.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missionidentifier="beacon" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_mainpath" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_mainpath" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set1" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set2" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set3" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set4" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort1coalition" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonerscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort2coalition" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort2.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortVIPcoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort3coalition" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort3.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortprisonerscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort4coalition" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort4.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortterroristscoalition" />
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="missionevent_escort1separatists" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort1separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonersseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort2separatists" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort2separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortVIPseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort3separatists" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort3separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortprisonersseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort4separatists" commonness="60">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Success>
+          <NPCWaitAction npctag="outpostmanager" wait="true" />
+          <ConversationAction text="EventText.missionevent_escort4separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+          <MissionAction missiontag="escortterroristsseparatists" />
+        </Success>
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    
+    <ScriptedEvent identifier="missionevent_pirate1" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_pirate1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="combatcoalitionvsseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_pirate1separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="combatseparatistsvscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_scanruin" commonness="200">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text= "eventtext.missionevent_scanruin.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="alienruinscan" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_clearruin" commonness="200">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text= "eventtext.missionevent_clearruin.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="alienruinclear" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+  </EventPrefabs>
+
+  <!--EVENT SETS-->
+  <EventSet identifier="outpostevents" leveltype="outpost" locationtype="outpost,city,research,military,mine" allowatstart="true" minleveldifficulty="0" maxleveldifficulty="80" chooserandom="false" ignorecooldown="true">
+    
+    <!-- TODO: more sets here-->
+    
+    <!-- low-difficulty random events -->
+    <EventSet identifier="outpostevents.easy.generic.randomevents" minleveldifficulty="0" maxleveldifficulty="30" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <OverrideEventCount locationtype="City" eventcount="3" />
+      <ScriptedEvent identifier="givingdirections" commonness="100" />
+      <ScriptedEvent identifier="goodsamaritan" commonness="100" />      
+      <ScriptedEvent identifier="miketheidiot1" commonness="25" />      
+      <ScriptedEvent identifier="Engineers_are_special" commonness="100" />
+      <ScriptedEvent identifier="fanclub" commonness="100" />
+      <ScriptedEvent identifier="shockjock" commonness="60" />
+      <ScriptedEvent identifier="manandhisraptor1" commonness="50" />
+      <ScriptedEvent identifier="assassinationofjacovsubra2" commonness="100" />
+      <ScriptedEvent identifier="assassinationofjacovsubra3" commonness="100" />
+      <ScriptedEvent identifier="propaganda" commonness="100" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="bombscare" commonness="50" faction="coalition" />      
+      <ScriptedEvent identifier="terrorism101" commonness="50" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="separatistrelations" commonness="100" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <!-- events that only occur in low difficulty-->
+      <ScriptedEvent identifier="atwitsend" commonness="60" />
+    </EventSet>
+    <!-- low-difficulty clown events -->
+    <EventSet identifier="outpostevents.easy.generic.randomevents.clowns" minleveldifficulty="0" maxleveldifficulty="30" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="clownrelations1" commonness="100" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="infiltration" commonness="70" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="censorship" commonness="60" faction="clowns" probability="0.5" />
+    </EventSet>
+    <!-- low-difficulty husk cult events -->
+    <EventSet identifier="outpostevents.easy.generic.randomevents.huskcult" minleveldifficulty="0" maxleveldifficulty="30" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="huskcultist" commonness="100" faction="huskcult" probability="0.5" />
+    </EventSet>
+
+    <!-- high-difficulty random events -->
+    <EventSet identifier="outpostevent.difficult.generic.randomevents" minleveldifficulty="30" maxleveldifficulty="80" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <OverrideEventCount locationtype="City" eventcount="3" />
+      <!-- events that can occur in both low and high difficulty, commoness reduced here to favor the more difficult ones-->
+      <ScriptedEvent identifier="givingdirections" commonness="50" />
+      <ScriptedEvent identifier="goodsamaritan" commonness="50" />     
+      <ScriptedEvent identifier="miketheidiot1" commonness="12" />     
+      <ScriptedEvent identifier="Engineers_are_special" commonness="50" />
+      <ScriptedEvent identifier="fanclub" commonness="50" />
+      <ScriptedEvent identifier="shockjock" commonness="40" />
+      <ScriptedEvent identifier="manandhisraptor1" commonness="60" />
+      <ScriptedEvent identifier="assassinationofjacovsubra2" commonness="100" />
+      <ScriptedEvent identifier="assassinationofjacovsubra3" commonness="100" />
+      <ScriptedEvent identifier="nothingtoseehere" commonness="50" faction="coalition" />
+      <ScriptedEvent identifier="propaganda" commonness="50" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="bombscare" commonness="40" faction="coalition" />     
+      <ScriptedEvent identifier="terrorism101" commonness="40" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="separatistrelations" commonness="50" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->      
+      <!-- events that only occur in high difficulty-->
+      <ScriptedEvent identifier="blackmarket" commonness="100" />
+      <ScriptedEvent identifier="mediator" commonness="100" />
+      <ScriptedEvent identifier="firefighting" commonness="100" />
+      <ScriptedEvent identifier="sleightofhand" commonness="100" />
+      <ScriptedEvent identifier="miketheidiot2" commonness="25" />
+      <ScriptedEvent identifier="goblincooking1" commonness="50" />
+      <ScriptedEvent identifier="soundinthevent" commonness="100" />
+      <ScriptedEvent identifier="badvibrations3" commonness="50" />
+      <ScriptedEvent identifier="stuckinthemiddle" commonness="50" faction="coalition" /> <!-- technically a separatist event, but happens in a coalition outpost -->
+      <ScriptedEvent identifier="returner" commonness="50" />
+    </EventSet>
+    <!-- high-difficulty clown events -->
+    <EventSet identifier="outpostevent.difficult.generic.randomevents.clowns" minleveldifficulty="30" maxleveldifficulty="80" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="clownrelations1" commonness="50" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="clownbrutality" commonness="100" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="clownrelations2" commonness="100" faction="clowns" probability="0.5" />
+    </EventSet>
+    <!-- high-difficulty husk cult events -->
+    <EventSet identifier="outpostevent.difficult.generic.randomevents.huskcult" minleveldifficulty="30" maxleveldifficulty="80" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="outbreak" commonness="100" faction="huskcult" probability="0.5" />
+      <ScriptedEvent identifier="huskcultist" commonness="50" faction="huskcult" probability="0.5" />
+      <ScriptedEvent identifier="huskcultambush" commonness="50" faction="huskcult" probability="0.5" />
+      <ScriptedEvent identifier="huskcultrelations" commonness="100" faction="huskcult" probability="0.5" />
+    </EventSet>
+    
+    <!-- Events specific to military outposts -->    
+    <EventSet identifier="outpostevent.military.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="military" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a military-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="bigbrother" commonness="150" probability="0.5" faction="coalition"/>
+      <ScriptedEvent identifier="explosivemishap" commonness="50" probability="0.5" />
+    </EventSet>
+    
+    <!-- Events specific to research outposts -->
+    <EventSet identifier="outpostevent.research.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="research" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a research-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="tastetest" commonness="150" probability="0.5" />
+      <ScriptedEvent identifier="crawleroutbreak" commonness="150" probability="0.5" />
+      <ScriptedEvent identifier="impromptuengineering" commonness="150" probability="0.5" />
+      <ScriptedEvent identifier="captivesouls" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="researcherescort" commonness="50" />
+    </EventSet>
+    
+    <!-- Events specific to mining outposts -->
+    <EventSet identifier="outpostevent.mine.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="mine" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a mine-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="consultant" commonness="150" probability="0.5" />
+      <ScriptedEvent identifier="occupationalhazards" commonness="150" probability="0.5" />
+    </EventSet>
+
+    <!-- Events specific to cities -->
+    <EventSet identifier="outpostevent.city.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="city" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a city-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="captivesouls" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="explosivemishap" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="hognose" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="radiationescapee" commonness="50" />
+    </EventSet>
+
+    <!--Always trigger when past difficulty 25, unless completed. Introduces alien ruins.-->
+    <EventSet identifier="ruinintroduction" allowatstart="true" minleveldifficulty="25">
+      <ScriptedEvent identifier="badvibrations1" />
+    </EventSet>
+
+    <!-- Biome specific sets. Difficulty progression. -->
+    
+    <EventSet identifier="missionevents.coldcaverns.start" minleveldifficulty="0" maxleveldifficulty="1" allowatstart="true" eventcount="3" chooserandom="false" exhaustible="true">
+      <ScriptedEvent identifier="missionevent_cargoany" />
+      <ScriptedEvent identifier="missionevent_killmonster_set1" />
+      <ScriptedEvent identifier="missionevent_collectminerals_mainpath" />
+    </EventSet>
+
+    <EventSet identifier="missionevents.coldcaverns.basic" minleveldifficulty="1" maxleveldifficulty="5" allowatstart="true" setcount="3" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.coldcaverns.basic.cargo" chooserandom="true" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_cargoany" commonness="50" />
+        <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="25" faction="separatists" />
+      </EventSet>
+      <EventSet identifier="missionevents.coldcaverns.basic.monster" chooserandom="true" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="25" />
+        <ScriptedEvent identifier="missionevent_killmonster_set1" commonness="75" />
+      </EventSet>
+      <EventSet identifier="missionevents.coldcaverns.basic.mining" chooserandom="true" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_collectminerals_mainpath" commonness="50" />
+        <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="50" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.coldcaverns.advanced" minleveldifficulty="5" maxleveldifficulty="15" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.coldcaverns.advanced.general" chooserandom="true" setcount="2" allowatstart="true">
+        <EventSet identifier="missionevents.coldcaverns.advanced.general.cargo" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="50" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="50" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="50" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.coldcaverns.advanced.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="20" />
+          <ScriptedEvent identifier="missionevent_killmonster_set1" commonness="40" />
+          <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="40" />
+        </EventSet>
+        <EventSet identifier="missionevents.coldcaverns.advanced.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="75" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="25" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.coldcaverns.advanced.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort1coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.europanridge.basic" minleveldifficulty="15" maxleveldifficulty="25" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.europanridge.basic.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.europanridge.basic.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="30" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="35" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="35" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="75" />
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="100" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest" commonness="75" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="75" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.europanridge.basic.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort1coalition,missionevent_escort2coalition,missionevent_escort3coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort1separatists,missionevent_escort2separatists,missionevent_escort3separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.europanridge.advanced" minleveldifficulty="25" maxleveldifficulty="35" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.europanridge.advanced.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.europanridge.advanced.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="20" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="40" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="40" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="75" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvagewreck" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest" commonness="50" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commonness="25" />
+          <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="50" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="25" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.europanridge.advanced.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="50" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="50" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.theaphoticplateau" minleveldifficulty="35" maxleveldifficulty="50" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.theaphoticplateau.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.theaphoticplateau.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="10" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="45" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="45" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvageartifact" commonness="50" />
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="33" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commmonness="33"/>
+          <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="33" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.ruin" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_scanruin" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.theaphoticplateau.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.greatsea" minleveldifficulty="50" maxleveldifficulty="65" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.greatsea.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.greatsea.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="10" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="45" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="45" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killswarm_set4" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="75" />
+          <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvageartifact" commonness="50" />
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="33" />
+          <ScriptedEvent identifier="missionevent_mudraptornest_hard" commmonness="33"/>
+          <ScriptedEvent identifier="missionevent_tigerthreshernest_hard" commonness="33" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.ruin" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_scanruin" commonness="100" />
+          <ScriptedEvent identifier="missionevent_clearruin" commonness="100" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.greatsea.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.wastes" minleveldifficulty="65" maxleveldifficulty="100" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.wastes.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.wastes.general.cargo" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="10" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="45" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="45" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killswarm_set4" commonness="75" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="75" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvageartifact" commonness="50" />
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="20" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commmonness="40"/>
+          <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="40" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="75" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.ruin" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_scanruin" commonness="50" />
+          <ScriptedEvent identifier="missionevent_clearruin" commonness="150" />
+        </EventSet>
+      </EventSet>
+      <EventSet idenfitier="missionevents.wastes.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <!-- generic clown missions -->
+    <EventSet identifier="outpostevents.clowns.missionevents" minleveldifficulty="0" maxleveldifficulty="100" allowatstart="true" chooserandom="true" exhaustible="true">
+      <ScriptedEvent identifier="missionevent_escort1clowns" commonness="50" faction="clowns" probability="0.8" />
+      <ScriptedEvent identifier="missionevent_clownoutbreak" commonness="50" faction="clowns" probability="0.8" />
+    </EventSet>
+    <!-- generic husk cult missions -->
+    <EventSet identifier="outpostevents.huskcult.missionevents" minleveldifficulty="0" maxleveldifficulty="100" allowatstart="true" chooserandom="true" exhaustible="true">
+      <ScriptedEvent identifier="missionevent_escort1huskcult" commonness="50" faction="huskcult" probability="0.8" />
+      <ScriptedEvent identifier="missionevent_cargohuskcult" commonness="50" faction="huskcult" probability="0.8" />
+    </EventSet>
+
+    <!--  Faction-specific events that can only occur once. 
+        In a separate set to make these very common (when they are valid for the situation) -->
+    <EventSet identifier="outpostevents.clowns" allowatstart="true" chooserandom="true" eventcount="3" faction="clowns">
+      <ScriptedEvent identifier="clownspecialhire1" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn1" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn2" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn3" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn4" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn5" commonness="100" />
+    </EventSet>
+    <EventSet identifier="outpostevents.separatists" allowatstart="true" chooserandom="true" eventcount="2" faction="separatists">
+      <ScriptedEvent identifier="separatistspecialhire1" commonness="100" />
+      <ScriptedEvent identifier="separatistspecialhire2" commonness="100" />
+      <ScriptedEvent identifier="missionevent_tormsdalereport" commonness="100" />
+      <ScriptedEvent identifier="missionevent_jailbreak_sootman" commonness="10" faction="separatists" />
+    </EventSet>
+    <EventSet identifier="outpostevents.separatists.triggeralways" allowatstart="true" eventcount="1" faction="separatists">
+      <ScriptedEvent identifier="tormsdalereport_complete" commonness="100" />
+    </EventSet>
+    <EventSet identifier="outpostevents.coalition" allowatstart="true" chooserandom="true" eventcount="1" faction="coalition">
+      <ScriptedEvent identifier="coalitionspecialhire1" commonness="50" />
+      <ScriptedEvent identifier="coalitionspecialhire2" commonness="50" />
+    </EventSet>
+    <EventSet identifier="outpostevents.huskcult" allowatstart="true" chooserandom="true" eventcount="4" faction="huskcult">
+      <ScriptedEvent identifier="huskcultspecialhire1" commonness="100" />
+      <ScriptedEvent identifier="youngcultists" commonness="100" />
+      <ScriptedEvent identifier="waytoascension1" commonness="100" />
+      <ScriptedEvent identifier="waytoascension2" commonness="100" />
+      <ScriptedEvent identifier="waytoascension3" commonness="100" />
+      <ScriptedEvent identifier="waytoascension4" commonness="100" />
+      <ScriptedEvent identifier="waytoascension5" commonness="100" />
+    </EventSet>
+  </EventSet>
+  
+  <!--TRANSIT EVENTS-->
+  <EventSet identifier="transitevents" allowatstart="true" minleveldifficulty="0" maxleveldifficulty="80" chooserandom="true" campaign="true" additive="true">
+    <ScriptedEvent identifier="stowaway1" commonness="100" probability="0.1" triggercooldown="false" />
+    <!--<ScriptedEvent identifier="stowaway2" commonness="100" probability="0.2" triggercooldown="false" />-->
+  </EventSet>
+
+  <EventSet identifier="outpostevent.endoutpostentrance" leveltype="LocationConnection" biome="endzone" chooserandom="false" allowatstart="true" campaign="true" ignoreintensity="true">
+    <Commonness commonness="0">
+      <Override leveltype="endoutpostentrance" commonness="1" />
+    </Commonness>
+    <ScriptedEvent identifier="alienwriting1" />
+    <ScriptedEvent identifier="buttonpressed1" />
+    <ScriptedEvent identifier="prophetofsierpinsk" />
+  </EventSet>
+  <EventSet identifier="outpostevent.endoutpostmid" leveltype="Outpost" biome="endzone" chooserandom="false" allowatstart="true" campaign="true" ignoreintensity="true">
+    <Commonness commonness="0">
+      <Override leveltype="endoutpostmid" commonness="1" />
+    </Commonness>
+    <ScriptedEvent identifier="alienwriting2" />
+    <ScriptedEvent identifier="alienwriting3" />
+  </EventSet>
+  <EventSet identifier="outpostevent.endoutpostfinal" leveltype="Outpost" biome="endzone" chooserandom="false" allowatstart="true" campaign="true" ignoreintensity="true">
+    <Commonness commonness="0">
+      <Override leveltype="endoutpostfinal" commonness="1" />
+    </Commonness>
+    <ScriptedEvent identifier="ancientencounter" />
+  </EventSet>
+  
+</Randomevents>

--- a/OutpostEvents.xml
+++ b/OutpostEvents.xml
@@ -1927,11 +1927,15 @@
         </Failure>
       </CheckDataAction>
     </ScriptedEvent>
+    
     <!--Captive souls-->
     <ScriptedEvent identifier="captivesouls" commonness="50">
       <TagAction criteria="player" tag="player" />
+      <!-- needs a containement tank preplaced or event will end. hopefully in research module -->
+      <TagAction criteria="itemidentifier:op_researchcontainmenttank3" tag="captivesoulstank" SubmarineType="Outpost" ContinueIfNoTargetsFound="false" />
       <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="researcher" targettag="captivesouls_scientist" targetmoduletags="airlock" spawnlocation="Outpost" />
       <NPCWaitAction npctag="captivesouls_scientist" wait="true" />
+      <!-- scientist conversation -->
       <TriggerAction target1tag="player" target2tag="captivesouls_scientist" applytotarget1="triggerer_player" waitforinteraction="true" />
       <ConversationAction text="EventText.captivesouls.c1" targettag="triggerer_player" eventsprite="mediator">
         <Option text="EventText.captivesouls.o1">
@@ -1953,8 +1957,8 @@
           <!--END-->
         </Option>
       </ConversationAction>
-      <!--Trigger at research module-->
-      <TriggerAction target1tag="triggerer_player" targetmoduletype="researchmodule" radius="100" />
+      <!--Interact with containement tank-->
+      <TriggerAction target1tag="triggerer_player" target2tag="captivesoulstank" waitforinteraction="true" />
       <ConversationAction text="EventText.captivesouls.c1.c1" targettag="triggerer_player">
         <Option text="EventText.captivesouls.c1.o1">
           <ConversationAction text="EventText.captivesouls.c1.o1.c1" targettag="triggerer_player">
@@ -1964,7 +1968,31 @@
                   <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.c1" targettag="triggerer_player">
                     <Option text="EventText.captivesouls.c1.o1.o1.o1.o1">
                       <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.c1" targettag="triggerer_player">
-                        <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1">
+                        <!-- break the glass and spawn the crawler -->
+                        <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1" endconversation="true" >
+                          <StatusEffectAction targettag="captivesoulstank">
+                            <StatusEffect>
+                              <SpawnItem identifier="banditprop7" spawnposition="This" Offset="0,-10"/>
+                              <Sound file="Content/Sounds/Damage/GlassImpact2.ogg" range="500" />
+                              <ParticleEmitter particle="watersplash" particleamount="10" velocitymin="0" velocitymax="50" anglemin="240" anglemax="300" scalemin="1" scalemax="2"  />
+                            </StatusEffect>
+                          </StatusEffectAction>
+                          <SpawnAction speciesname="crawler_hatchling" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="captivesoulstank" TargetTag="crawlerhybrid" />
+                          <StatusEffectAction targettag="crawlerhybrid">
+                            <StatusEffect disabledeltatime="true" >
+                              <!-- stun to prevent crazy ragdolling when it spawns -->
+                              <Affliction identifier="stun" strength="1" />
+                              <Affliction identifier="nausea" strength="100" />    
+                            </StatusEffect>
+                            <StatusEffect delay="2" duration="10">
+                              <!-- dies after a few seconds from organ failure -->
+                              <Affliction identifier="organdamage" strength="3" />                          
+                            </StatusEffect>
+                          </StatusEffectAction>
+                          <!-- add combataction to make crawler flee instead of fighting? make crawler neutral? how? -->
+                          <!-- 3 seconds after breaking glass, interact with the tank again to grab the curio -->
+                          <WaitAction time="3" />
+                          <TriggerAction target1tag="triggerer_player" target2tag="captivesoulstank" waitforinteraction="true" />
                           <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
                             <Option text="EventText.generic.continue">
                               <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">


### PR DESCRIPTION
The event `captivesouls` where you supposedly free a crawler-human hybrid from a containement tank is played via text entirely

This changes the event to spawn an actual crawler from a containement tank, complete with effects


https://github.com/Regalis11/Barotrauma/assets/73229309/19faeb65-b40f-429b-888c-2e2351e24a34

**Changes:**
-Breaking the glass spawns a crawler hatchling
-The crawler is aggressive _(it says you shouldnt break the glass after all)_
-Crawler dies of organ failure outside the tank
-Interact with the tank a second time after smashing the glass to grab the curio

# TODO:
Change the text in `EventText.captivesouls.c1.o1.o1.o1.o1.o1.c1` when you interact with the tank after the crawler spawns to reflect what actually happens (crawler bites you). _I'm not a writer_ 😔 

![image](https://github.com/Regalis11/Barotrauma/assets/73229309/4b64f3de-5be8-4dfe-a867-3a1e309c8ebc)


You can also remove it entirely and skip to this:
![image](https://github.com/Regalis11/Barotrauma/assets/73229309/dcbac0fc-9e7c-4045-b243-65aa275472cb)

# Details

Make sure the cracked glass spawns in front of the item. Cracked glass depth is 750, I don't think it can inherit depth of the containement tank

Offset doesnt seem to work on Spawnaction, wanted to make sure the crawler spawned dead center on the containement tank
