### PR TITLE
Make "fuel_percentage_left" pin output a float

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Reactor.cs
@@ -378,7 +378,7 @@ namespace Barotrauma.Items.Components
             item.SendSignal(((int)-CurrPowerConsumption).ToString(), "power_value_out");
             item.SendSignal(((int)Load).ToString(), "load_value_out");
             item.SendSignal(((int)AvailableFuel).ToString(), "fuel_out");
-            item.SendSignal(((int)fuelLeft).ToString(), "fuel_percentage_left");
+            item.SendSignal((fuelLeft).ToString(), "fuel_percentage_left");
 
             UpdateFailures(deltaTime);
 #if CLIENT


### PR DESCRIPTION
Made "fuel_percentage_left" pin on reactor output a float instead of an int (then to a string) for better precision. 

I just want to be able to display how much longer the fuel in the reactor will last👍