### PR TITLE
Bombscare event changes

### DIFF
--- a/Bombscare/EnglishVanilla.xml
+++ b/Bombscare/EnglishVanilla.xml
@@ -6234,6 +6234,9 @@
 <eventtext.heartofgold.o2.o2.c1>“I was captured along with the rest of my crew and sub. They're all gone now.” They scowl. “Eaten. They were used as bait for the crawlers that used to inhabit this place. I was spared because I know how to make morphine and fent.”</eventtext.heartofgold.o2.o2.c1>
 <eventtext.heartofgold.o2.o2.o1>“You're a drug dealer?”</eventtext.heartofgold.o2.o2.o1>
 <eventtext.heartofgold.o2.o2.o1.c1>“Give me a break. Like you haven't done any opiates yourself? The way I see it I provided a service and, in return, nobody pointed a gun my way.” A dry smile creeps on their face. “Until you, that is.”</eventtext.heartofgold.o2.o2.o1.c1>
+
+<!-- bombscare event-->
+
 <eventtext.bombscare.c1>“Hey, you there.”</eventtext.bombscare.c1>
 <eventtext.bombscare.o1>“Me?”</eventtext.bombscare.o1>
 <eventtext.bombscare.o1.c1>The guard takes a long look at you. “Never mind. I thought you looked like someone else. You're free to go.”</eventtext.bombscare.o1.c1>
@@ -6241,15 +6244,28 @@
 <eventtext.bombscare.o1.o1.c1>“Just be careful,” the guard cautions. “We received a bomb threat a few hours ago, by some usual suspects. It's been a while and no bomb has been found, but we advise caution.”</eventtext.bombscare.o1.o1.c1>
 <eventtext.bombscare.o1.o1.o1>“Usual suspects?”</eventtext.bombscare.o1.o1.o1>
 <eventtext.bombscare.o1.o1.o1.c1>The guard lowers their voice. “Look, you better stay clear of this separatist business. There have been some serious attacks lately. Just come to me if you see something suspicious.”</eventtext.bombscare.o1.o1.o1.c1>
-<eventtext.bombscare.o1.o1.o1.c1.c1>Out of the corner of your eye, you see a pile of scrap electronics.</eventtext.bombscare.o1.o1.o1.c1.c1>
-<eventtext.bombscare.o1.o1.o1.c1.o1>Salvage.</eventtext.bombscare.o1.o1.o1.c1.o1>
-<eventtext.bombscare.o1.o1.o1.c1.o1.c1>To your surprise, the pile of scrap turns out to be a homemade pipe bomb. As luck would have it some wires have come loose, preventing the bomb from going off. You carefully remove the detonator, pick up the bomb and place it in your bag. The guard from earlier should be interested in seeing this.</eventtext.bombscare.o1.o1.o1.c1.o1.c1>
+
+<!-- added: -->
+<eventtext.bombscare.tickingnoise>What's that noise?</eventtext.bombscare.tickingnoise>
+<eventtext.bombscare.leavethebomb>"I'm out of here!"</eventtext.bombscare.leavethebomb>
+<eventtext.bombscare.nobombtogive>"Yes? Don't waste my time."</eventtext.bombscare.nobombtogive>
+
+<!-- changed: -->
+<eventtext.bombscare.o1.o1.o1.c1.c1>You reach for the source of the sound. It's a bomb, and it's ticking!</eventtext.bombscare.o1.o1.o1.c1.c1>
+<eventtext.bombscare.o1.o1.o1.c1.o1>Try to defuse the bomb.</eventtext.bombscare.o1.o1.o1.c1.o1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.c1>With expert dexterity, you pull some wires to the side and manage to carefully remove the detonator. The ticking stops. The guard from earlier should be interested in seeing this.</eventtext.bombscare.o1.o1.o1.c1.o1.c1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.c2>Your hands shake furiously, you almost drop the bomb. In pure panic, wires are ripped, buttons are pressed and somehow, the timer stops.</eventtext.bombscare.o1.o1.o1.c1.o1.c2>
+<eventtext.bombscare.o1.o1.o1.c1.o1.o1>That wasn't so hard.</eventtext.bombscare.o1.o1.o1.c1.o1.o1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1>Before you can catch your breath, the ticking resumes... and accelerates!</eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1>
+
 <eventtext.bombscare.o1.o1.o1.c1.o1.c1.c1>You thrust the bomb to the arms of the guard, who flinches a bit. You recount your experience and the guard thanks you for finding the bomb and gives you a small reward for dismantling it.</eventtext.bombscare.o1.o1.o1.c1.o1.c1.c1>
-<eventtext.bombscare.o1.o1.o1.c1.o1.c2>To your surprise, the pile of scrap is wired to a timer. You turn it around and see “00:01” displayed on the timer.</eventtext.bombscare.o1.o1.o1.c1.o1.c2>
-<eventtext.bombscare.o1.o1.o1.c1.o1.o1>Take cover.</eventtext.bombscare.o1.o1.o1.c1.o1.o1>
-<eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1>You drop the bomb and dive down onto the floor, covering your head with your hands. Seconds pass by, but nothing happens. Gingerly, you stand up and dust yourself off. Seems like this bomb is a dud. The guard from earlier should be interested in seeing this.</eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1>
+
+<!-- unused -->
 <eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1.c1>You report finding a bomb in the hallway and the guard immediately springs to action. They thank you for finding and reporting the bomb.</eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1.c1>
+
 <eventtext.bombscare.o1.o2>Leave the guard.</eventtext.bombscare.o1.o2>
+
+
 <eventtext.terrorism101.c1>You see a person crouched next to a vending machine, assembling or fixing something.</eventtext.terrorism101.c1>
 <eventtext.terrorism101.o1>Find out what they're working on.</eventtext.terrorism101.o1>
 <eventtext.terrorism101.o1.c1>You sneak behind the person and crane your neck. It seems they're fiddling with some kind of a device with lots of wires. They glance back and jump up when they see you. “Shit! Don't just stand there!”</eventtext.terrorism101.o1.c1>

--- a/Bombscare/EnglishVanilla.xml
+++ b/Bombscare/EnglishVanilla.xml
@@ -1,0 +1,8016 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<infotexts language="English" nowhitespace="false" translatedname="English">
+
+
+<!-- Loading Screen -->
+<loading>Loading...</loading>
+<pressanykey>Press any key to continue</pressanykey>
+
+<!-- Loading Screen tips -->
+<loadingscreentip>You will not get paid for delivering cargo if any of the cargo goes missing or gets damaged during the transport.</loadingscreentip>
+<loadingscreentip>Generating more power than the devices in the submarine are consuming may damage junction boxes or cause fires.</loadingscreentip>
+<loadingscreentip>Junction boxes and other electrical devices may get damaged if they stay submerged too long.</loadingscreentip>
+<loadingscreentip>Letting the submarine's nuclear reactor overheat may cause fires. If an overheated reactor is not shut down, it will eventually lead to a nuclear meltdown.</loadingscreentip>
+<loadingscreentip>Most submarines are equipped with stationary batteries that can be used as a temporary source of backup power in the case of a reactor failure.</loadingscreentip>
+<loadingscreentip>Railgun shells and depth charges include a compartment that can hold additional explosives.</loadingscreentip>
+<loadingscreentip>Passive sonar can be used to detect nearby sound sources without attracting unwanted attention. You can also get a rough idea of your surroundings based on the sounds reflected from the ice walls.</loadingscreentip>
+<loadingscreentip>There are many ways to get past locked doors, including forcing them open with a crowbar or rewiring them to a button you have access to.</loadingscreentip>
+<loadingscreentip>Stationary batteries are equipped with docks that can be used to charge battery cells.</loadingscreentip>
+<loadingscreentip>Oxygen generators are equipped with docks that can be used to refill oxygen tanks.</loadingscreentip>
+<loadingscreentip>Supercapacitors can deliver large bursts of power, but cannot store as much energy as batteries. They are often used to power railguns and other devices that require brief bursts of high current.</loadingscreentip>
+<loadingscreentip>Nuclear reactors are equipped with an automatic control system that adjusts the power output to a suitable level when enabled. However, the system is not always fast enough to react to large fluctuations in power consumption.</loadingscreentip>
+<loadingscreentip>The sonar imaging on the navigation terminal may become inaccurate if the terminal is damaged—make sure your engineers keep the terminal in a good condition!</loadingscreentip>
+<loadingscreentip>When deploying a decoy, be sure to deactivate your active sonar for best results.</loadingscreentip>
+<loadingscreentip>Attempting to rewire powered devices without adequate electrical engineering skills may get you electrocuted.</loadingscreentip>
+<loadingscreentip>Welding tools are simple enough to be used by any submariner, but trained mechanics are generally faster welders and have a lower risk of injuring themselves with the tool.</loadingscreentip>
+<loadingscreentip>All submariners have been trained to do basic repairs on electrical devices, but electrical engineers get the job done much faster.</loadingscreentip>
+<loadingscreentip>All submariners have been trained to do basic repairs on mechanical devices, but mechanics get the job done much faster.</loadingscreentip>
+<loadingscreentip>Captains are generally much more adept at maneuvering the submarine than the average sailor.</loadingscreentip>
+<loadingscreentip>If the reactor on a sub is not able to produce sufficient power to run all onboard systems, try reducing the charge rate for the onboard batteries and supercapacitors, or regulate the times when the sub is running at full speed.</loadingscreentip>
+<loadingscreentip>The electrical and mechanical systems on a sub will gradually degrade due to the harsh conditions and constant wear and tear. Be sure to have mechanics and engineers perform maintenance from time to time in order to avoid breakdowns at inopportune moments.</loadingscreentip>
+<loadingscreentip>Breaking down alien artifacts in a deconstructor may provide you with exotic raw materials.</loadingscreentip>
+<loadingscreentip>Some of the alien structures on Europa have been constructed of a metamaterial that's outstandingly resistant to physical damage, and as such has become an important subject of research to Europan scientists.</loadingscreentip>
+<loadingscreentip>Special caution must be taken when bringing alien artifacts on board the submarine.</loadingscreentip>
+<loadingscreentip>Very little is known of the presumably extinct alien civilization that built the ruins scattered all across Europa. The age of the ruins is also a mystery, since the self-repairing properties of the structures and devices make chronological dating methods wildly inaccurate.</loadingscreentip>
+<loadingscreentip>No remains of the alien lifeforms that built the ruins scattered all across Europa have ever been discovered. The only life encountered inside the structures are the biomechanical entities that maintain and guard them.</loadingscreentip>
+<loadingscreentip>While exploring ruins or caves, drop flares as often as possible to help mark a path out, should you need to make a hasty exit for some reason.</loadingscreentip>
+<loadingscreentip>Watchers are docile but inquisitive creatures: Despite having no desire to attack submarines, they frequently approach ships to gaze at human activities.</loadingscreentip>
+<loadingscreentip>Cannibalistic behavior is very common among crawlers. Killing one in a swarm may distract the rest as they enter into a feeding frenzy.</loadingscreentip>
+<loadingscreentip>Mudraptors can easily tear their way through metal doors with their sharp beaks.</loadingscreentip>
+<loadingscreentip>The so-called husk parasites slowly take over and consume the body of their host, eventually turning them into nothing but an empty exoskeleton controlled by the parasite.</loadingscreentip>
+<loadingscreentip>Many creatures on Europa are protected by a strong shell, and are difficult to damage with conventional weapons, though there may be weak points in their armor.</loadingscreentip>
+<loadingscreentip>Loud devices and sonar pings may alert nearby creatures.</loadingscreentip>
+<loadingscreentip>Performing CPR without adequate medical skills may cause internal damage to the patient.</loadingscreentip>
+<loadingscreentip>Opiates such as morphine and fentanyl are an effective way of treating injuries in an emergency, but regular use may eventually lead to a state of addiction and cause dangerous withdrawal symptoms.</loadingscreentip>
+<loadingscreentip>Bleeding wounds can be treated with bandages and hemostatic agents. The patient may also need saline or blood packs to replace the lost blood.</loadingscreentip>
+<loadingscreentip>Mental disorders such as psychosis are unfortunately common among submarine crews, particularly after ruin expeditions. If your crewmates start seeing or hearing things others don't see or hear, report it to a medical doctor immediately.</loadingscreentip>
+<loadingscreentip>The medical doctors' main task is to keep the crew in a good shape, but a medic with a syringe gun and a bit of knowhow on poisons can also be very useful in fending off intruders.</loadingscreentip>
+<loadingscreentip>Many drugs may have unintended side effects. Keep an eye on the patient and be ready to administer additional medications to counteract these side effects if necessary.</loadingscreentip>
+<loadingscreentip>When using a diving mask, be careful not to mix up welding fuel tanks and oxygen tanks.</loadingscreentip>
+<loadingscreentip>Diving masks let you breathe underwater, but don't offer any protection against the bone-crushing pressure outside the submarine. If there's a major hull breach, find a diving suit immediately.</loadingscreentip>
+<loadingscreentip>In the event of a fire, burns are not the only thing to watch out for—fires can quickly consume all the oxygen inside the submarine.</loadingscreentip>
+<loadingscreentip>Traversing the so-called Hydrothermal Wastes requires special caution. Not only are they abundant in wildlife, but the water currents caused by geothermal activity make navigation even more hazardous.</loadingscreentip>
+<loadingscreentip>Some of the sessile lifeforms in Europa emit low-frequency sounds that may disrupt the submarine's sonar.</loadingscreentip>
+<loadingscreentip>Europa is rich in natural resources, and an enterprising captain with a sharp eye and a plasma cutter may stand to make a tidy profit.</loadingscreentip>
+<loadingscreentip>You can disguise yourself as someone else by wearing their ID card and something that covers your face.</loadingscreentip>
+<loadingscreentip>It's possible to build voice-controlled systems by linking wifi components to the radio chat in the submarine editor.</loadingscreentip>
+<loadingscreentip>The radiation belts around Jupiter make it impracticable to establish permanent settlements above Europa's surface, and as such almost all Europan outposts are located below its icy crust.</loadingscreentip>
+<loadingscreentip>The dynamics of Europa's underwater ecosystem are still not fully understood, but it is believed that the base of the food chain is mostly formed by chemosynthetic bacteria.</loadingscreentip>
+<loadingscreentip>The Europa Coalition started off as a trade and cooperation agreement between the two largest Europan settlements and a handful of private paramilitary groups, but gradually grew to become what is essentially the Europan government.</loadingscreentip>
+<loadingscreentip>The much-ridiculed initiative to help submariners cope in a high-stress environment by including professional entertainers in the crews was promptly deemed a failure and discontinued.</loadingscreentip>
+<loadingscreentip>Most vessels avoid venturing outside the tunnels and cracks within Europa's icy crust—the vast, empty Abyss between the surface layers and the rocky interior hosts many of Europa's largest and most dangerous inhabitants.</loadingscreentip>
+<loadingscreentip>If left undisturbed for several years, a colony of ballast flora can eventually grow into a Thalamus, an intelligent organism capable of exerting some degree of control over the systems of the submarine it's inhabiting.</loadingscreentip>
+<loadingscreentip>You can give context-sensitive commands when the cursor is over a usable object by holding down shift and opening the command interface.</loadingscreentip>
+<loadingscreentip>Making trouble at an outpost hurts your reputation. A bad reputation might cause the inhabitants of the outpost to charge you a premium for their services, or, in more extreme cases, lead to a confrontation with their security.</loadingscreentip>
+<loadingscreentip>Many Europan outposts don't recognize the Coalition's authority, although it is still powerful enough that few dare to openly oppose it. However, there are groups such as the Jovian Separatists who do fight against it, aiming to bring it down and create a more democratic society.</loadingscreentip>
+<loadingscreentip>Behold the Watcher. Don't lose your mind.</loadingscreentip>
+<loadingscreentip>Straddling the border between surface ice and the denser, rockier subsurface ice layer, the Europan Ridge is the area along the western-most slope of the Eye of Europa. Warmer water is convected into this area, allowing a wider array of life to subsist.</loadingscreentip>
+<loadingscreentip>The Aphotic Plateau sits atop the western rim of an ancient impact crater known as the Eye of Europa. As with the neighboring Europan Ridge, the Plateau’s tunnel networks consist mostly of dark, rocky ice pressed as hard as any stone by the unimaginable weight of the ice above it.</loadingscreentip>
+<loadingscreentip>Most of the human habitation on Europa is situated in the so-called Cold Caverns. Due to the cold water and relative proximity to the surface, this biome is biologically less diverse than others, primarily hosting moderate concentrations of crawlers and practically no vegetation.</loadingscreentip>
+<loadingscreentip>Ice spires are enormous icy projections that sometimes burst through the subsurface tunnels under Europa's crust. Submarine crews are advised to avoid any contact with the spires, or to destroy any they come across, as the sharp edges can easily tear through a submarine's hull.</loadingscreentip>
+<loadingscreentip>The poorly understood "Piezo Crystals" found in The Great Sea pose some extra challenges to crews travelling through the region: Navigating too close to one may cause disruptions in the submarine's electrical grid.</loadingscreentip>
+<loadingscreentip>Administering drugs without sufficient medical knowledge may reduce the quality of the effects of the drug.</loadingscreentip>
+<loadingscreentip>Generating more power than your sub's devices require leads to overvoltage, which can be used to push some devices (such as engines and pumps) past their normal capacity. However, a too-high voltage level may also damage devices.</loadingscreentip>
+
+<!-- Main menu labels -->
+<campaignlabel>Campaign</campaignlabel>
+<multiplayerlabel>Multiplayer</multiplayerlabel>
+<customizelabel>Customize</customizelabel>
+<privacypolicy>Privacy policy</privacypolicy>
+
+<!-- Main menu buttons -->
+<tutorialbutton>Training</tutorialbutton>
+<newgamebutton>New Game</newgamebutton>
+<loadgamebutton>Load Game</loadgamebutton>
+<joinserverbutton>Server browser</joinserverbutton>
+<hostserverbutton>Host Server</hostserverbutton>
+<subeditorbutton>Submarine Editor</subeditorbutton>
+<charactereditorbutton>Character Editor</charactereditorbutton>
+<settingsbutton>Settings</settingsbutton>
+<steamworkshopbutton>Steam Workshop</steamworkshopbutton>
+<creditsbutton>Credits</creditsbutton>
+<quitbutton>Quit</quitbutton>
+
+<!-- Pause menu -->
+<pausemenuresume>Resume</pausemenuresume>
+<pausemenusettings>Settings</pausemenusettings>
+<pausemenuretry>Retry</pausemenuretry>
+<pausemenusavequit>Save and Quit</pausemenusavequit>
+<pausemenuquit>Main Menu</pausemenuquit>
+<pausemenuquitverification>Are you sure you want to return to the main menu? All your unsaved progress will be lost.</pausemenuquitverification>
+<pausemenuretryverification>Are you sure you want to stop the mission and load the previous save file? All your unsaved progress will be lost.</pausemenuretryverification>
+<pausemenuquitverificationeditor>Are you sure you want to return to the main menu? All your unsaved progress will be lost.</pausemenuquitverificationeditor>
+<pausemenusaveandquitverification>If you quit now, you will lose the progress you've made during the round, and you'll have to start the mission from the beginning when continuing the campaign. Are you sure you want to quit?</pausemenusaveandquitverification>
+<pausemenusaveandreturntoserverlobbyverification>Are you sure you want to save the game and return to the server lobby?</pausemenusaveandreturntoserverlobbyverification>
+<pausemenusaveandreturntomainmenuverification>Are you sure you want to save the game and return to the main menu?</pausemenusaveandreturntomainmenuverification>
+
+
+<!-- Host server menu -->
+<servername>Server name</servername>
+<serverport>Server port</serverport>
+<serverporttooltip>The port used to communicate with clients. If clients fail to connect to your server, you may need to enable UPnP port forwarding or forward the port manually.</serverporttooltip>
+<serverqueryport>Query port</serverqueryport>
+<serverqueryporttooltip>The port used to communicate with Steam's server browser and respond to info pings from clients. If clients don't see your server in the server list or if authenticating their Steam ID fails, you may need to enable UPnP port forwarding or forward the port manually.</serverqueryporttooltip>
+<maxplayers>Max players</maxplayers>
+<password>Password</password>
+<publicserver>Public server</publicserver>
+<publicservertooltip>Public servers are shown in the list of available servers in the "Server Browser."</publicservertooltip>
+<attemptupnp>Attempt UPnP port forwarding</attemptupnp>
+<attemptupnptooltip>UPnP can be used for forwarding ports on your router to allow players to join the server. However, UPnP isn't supported by all routers, so you may need to setup port forwards manually if players are unable to join the server (see the readme for instructions).</attemptupnptooltip>
+<startserverbutton>Start</startserverbutton>
+<pleasewaitupnp>Please wait...</pleasewaitupnp>
+<attemptingupnp>Attempting UPnP port forwarding.</attemptingupnp>
+<upnpunavailable>UPnP not available.</upnpunavailable>
+<upnptimedout>UPnP discovery timed out.</upnptimedout>
+<incorrectpassword>Incorrect password</incorrectpassword>
+
+<!-- Game modes -->
+<gamemode.singleplayercampaign>Single Player</gamemode.singleplayercampaign>
+<gamemode.tutorial>Tutorial</gamemode.tutorial>
+<gamemode.devsandbox>Dev Sandbox</gamemode.devsandbox>
+<gamemode.sandbox>Sandbox</gamemode.sandbox>
+<gamemode.mission>Mission</gamemode.mission>
+<gamemode.multiplayercampaign>Campaign</gamemode.multiplayercampaign>
+<gamemode.testmode>Testing Mode</gamemode.testmode>
+<gamemode.pvp>PvP</gamemode.pvp>
+<gamemodedescription.singleplayercampaign>Embark on a journey through the depths of Europa. Travel from location to location, complete missions to earn money for supplies, discover new biomes…</gamemodedescription.singleplayercampaign>
+<gamemodedescription.sandbox>A game mode with no specific objectives.</gamemodedescription.sandbox>
+<gamemodedescription.mission>The crew must work together to complete a single mission, such as retrieving an alien artifact or killing a creature that's terrorizing nearby outposts.</gamemodedescription.mission>
+<gamemodedescription.multiplayercampaign>Embark on a journey through the depths of Europa. Travel from location to location, complete missions to earn money for supplies, discover new biomes…</gamemodedescription.multiplayercampaign>
+<gamemodedescription.pvp>The players are split up into two separate subs, tasked with destroying each other.</gamemodedescription.pvp>
+
+<!-- Steam Workshop menu -->
+<settingstab.mods>Mods</settingstab.mods>
+<browsetab>Popular Mods</browsetab>
+<publishtab>Publish</publishtab>
+<modstab>Subscribed Mods</modstab>
+<downloadbutton>Subscribe</downloadbutton>
+<subscribedmods>Mods</subscribedmods>
+<nosubscribedmods>You haven't subscribed to any mods on the Steam Workshop. Select the "Popular Mods" tab to find some!</nosubscribedmods>
+<popularmods>Popular mods</popularmods>
+<findmodsbutton>Find more mods...</findmodsbutton>
+<workshopitemunsubscribe>Unsubscribe</workshopitemunsubscribe>
+<publishedworkshopitems>Published items</publishedworkshopitems>
+<yourworkshopitems>Your items</yourworkshopitems>
+<createworkshopitem>Create a new item</createworkshopitem>
+<workshoplabelsubmarines>Submarines</workshoplabelsubmarines>
+<workshoplabelcontentpackages>Content packages</workshoplabelcontentpackages>
+<workshopitemenabled>Enable</workshopitemenabled>
+<workshopitemdownloading>Downloading...</workshopitemdownloading>
+<workshopshowiteminsteam>Show in Steam</workshopshowiteminsteam>
+<workshopitemscore>Score</workshopitemscore>
+<workshopitemvotes>[votecount] votes</workshopitemvotes>
+<workshopitemcreator>Creator</workshopitemcreator>
+<workshopitemcreationdate>Published</workshopitemcreationdate>
+<workshopitemmodificationdate>Updated</workshopitemmodificationdate>
+<workshopitemfilesize>File size</workshopitemfilesize>
+<workshopitemtitle>Title</workshopitemtitle>
+<workshopitemdescription>Description</workshopitemdescription>
+<workshopitemtags>Tags</workshopitemtags>
+<workshopitemcreatehelptext>You can use this tab to publish new items in the Steam Workshop. You can select a submarine or a content package to publish from the "Your items" menu at the left.</workshopitemcreatehelptext>
+<workshopitempreviewimage>Preview Image</workshopitempreviewimage>
+<workshopitembrowse>Browse...</workshopitembrowse>
+<workshopitemcorepackage>Core package</workshopitemcorepackage>
+<workshopitemcorepackagetooltip>Core packages are special content packages that contain all the core files (executables, configuration files) the game won't run without. There must always be one (and only one) core package selected. Only select this if you wish to create a mod that replaces all the Vanilla files. Mods that only add things to the Vanilla game (or another core package) should not be marked as core packages.</workshopitemcorepackagetooltip>
+<workshopitemfiles>Files included in the item</workshopitemfiles>
+<workshopitemshowfolder>Show folder</workshopitemshowfolder>
+<workshopitemchangenote>Change note</workshopitemchangenote>
+<workshopitemchangenotetooltip>You're publishing an update for an existing Workshop item. You can use the change note to explain what's new in the update.</workshopitemchangenotetooltip>
+<workshopitemrefreshfilelist>Refresh</workshopitemrefreshfilelist>
+<workshopitemaddfiles>Add files...</workshopitemaddfiles>
+<workshopitempublish>Publish item</workshopitempublish>
+<workshopitemupdate>Update item</workshopitemupdate>
+<workshopitemdelete>Delete item</workshopitemdelete>
+<workshopitemdeletetooltip>Deletes the item from Steam Workshop.</workshopitemdeletetooltip>
+<workshopitemdeleteverification>Are you sure you want to delete the item "[itemname]" from the Steam Workshop?</workshopitemdeleteverification>
+<workshopitempublishtooltip>Uploads the files to the Steam Workshop.</workshopitempublishtooltip>
+<workshopitemfileincluded>File will be included in the Workshop item.</workshopitemfileincluded>
+<workshopitemfilenotincluded>File is not present in the Workshop item folder and will not be included in the Workshop item. This may be desirable if you want the mod to use Vanilla files that the players already have—otherwise you should copy the file to the Workshop item folder.</workshopitemfilenotincluded>
+<workshopitemfilenotfound>File not found.</workshopitemfilenotfound>
+<workshopitemillegalpath>Workshop items are only allowed to modify files in the Mod folder or add submarine files to the Submarines folder. Please create a separate subfolder for the files.</workshopitemillegalpath>
+<workshopitemrefreshfilelisttooltip>Reload the configuration file of the Workshop item (filelist.xml inside the item's folder) and add all new files in it to the file list.</workshopitemrefreshfilelisttooltip>
+<workshoppublishpleasewait>Please wait</workshoppublishpleasewait>
+<workshoppublishinprogress>Publishing "[itemname]" in the Steam Workshop.</workshoppublishinprogress>
+<workshopitempublished>[itemname] is now available in the Steam Workshop!</workshopitempublished>
+<workshopitempublishfailed>Publishing "[itemname]" in the Steam Workshop failed.</workshopitempublishfailed>
+<workshopitempreviewimagedialogtitle>Select the preview image for the Steam Workshop item.</workshopitempreviewimagedialogtitle>
+<workshopitempreviewimagetoolarge>The file size of the preview image has to be less than 1 MB.</workshopitempreviewimagetoolarge>
+<workshoperrorinstallrequiredtoedit>Cannot edit the Workshop item "[itemname]" because it has not been installed.</workshoperrorinstallrequiredtoedit>
+<workshoperrorinstallrequiredtoenable>Cannot enable the Workshop item "[itemname]" because it has not been installed.</workshoperrorinstallrequiredtoenable>
+<workshoperroroverwriteonenable>Cannot enable Workshop item "[itemname]". The file "[filename]" would be overwritten by the item.</workshoperroroverwriteonenable>
+<workshoperrorillegalpathonenable>Could not install the file "[filename]." Workshop items are only allowed to modify files in the Mod folder or add submarine files to the Submarines folder.</workshoperrorillegalpathonenable>
+<workshoperrorenablefailed>Enabling the workshop item "[itemname]" failed.</workshoperrorenablefailed>
+<workshopitemincompatible>Incompatible</workshopitemincompatible>
+<workshopitemincompatibletooltip>This Workshop item is not compatible with your version of Barotrauma.</workshopitemincompatibletooltip>
+<workshop.contenttag.submarine>Submarine</workshop.contenttag.submarine>
+<workshop.contenttag.item>Item</workshop.contenttag.item>
+<workshop.contenttag.art>Art</workshop.contenttag.art>
+<workshop.contenttag.environment>Environment</workshop.contenttag.environment>
+<workshop.contenttag.monster>Monster</workshop.contenttag.monster>
+<workshop.contenttag.mission>Mission</workshop.contenttag.mission>
+<workshop.contenttag.eventset>Event set</workshop.contenttag.eventset>
+<workshop.contenttag.totalconversion>Total conversion</workshop.contenttag.totalconversion>
+<workshop.contenttag.itemassembly>Item assembly</workshop.contenttag.itemassembly>
+<workshop.contenttag.language>Language</workshop.contenttag.language>
+<workshoperroronenable>Cannot enable Workshop item "[itemname]".</workshoperroronenable>
+<workshoppublisherror.limitexceeded>Publishing the Workshop item failed (limit exceeded). Make sure you have enabled Steam Cloud and haven't exceeded your Steam Cloud quota. If you are using Steam Cloud sync, having a large number of save files can cause you to run out of space on the cloud. You may want to check [savepath] to make sure you're not storing an excessive number of save files.</workshoppublisherror.limitexceeded>
+<workshoppublisherror.limiteduseraccount>Publishing the Workshop item failed. Limited user accounts are not allowed to publish items in the Steam Workshop. You need to spend at least $5 in the Steam store to become a non-limited user.</workshoppublisherror.limiteduseraccount>
+<workshoppublisherror.banned>Publishing the Workshop item failed because your account has been banned.</workshoppublisherror.banned>
+<workshoppublisherror.insufficientprivilege>Publishing the Workshop item failed (insufficient privileges). This can happen due to a hub ban, account lock or a community ban. You may need to contact Steam Support.</workshoppublisherror.insufficientprivilege>
+<workshoppublisherror.serviceunavailable>Publishing the Workshop item failed (service unavailable). The workshop servers may be having issues. Please try again in a moment.</workshoppublisherror.serviceunavailable>
+<workshopitemupdated>Workshop item [itemname] was updated successfully.</workshopitemupdated>
+<workshopitemupdatefailed>Failed to update Workshop item [itemname]. [errormessage]</workshopitemupdatefailed>
+<workshopfilenotfound>File [path] not found.</workshopfilenotfound>
+<unstableworkshopitempublishwarning>Releasing workshop items with Barotrauma Unstable is not recommended. Features in Unstable are not guaranteed to make it to the public version in the exact same form, and mods developed for Unstable may not work as-is in the public version. Players who are using the normal version of Barotrauma will also not be able to install the item. Are you sure you want to publish the item?</unstableworkshopitempublishwarning>
+<workshopitemvisibility>Visibility</workshopitemvisibility>
+<workshopitemvisibilitytooltip>Restricts who can see and subscribe to your Workshop item.</workshopitemvisibilitytooltip>
+<workshopitemvisibility.public>Public</workshopitemvisibility.public>
+<workshopitemvisibility.friendsonly>Friends only</workshopitemvisibility.friendsonly>
+<workshopitemvisibility.private>Hidden</workshopitemvisibility.private>
+<workshoperrorsamepathinstalled>Could not install "[itemname]" because there is already a mod installed at "[itempath]."</workshoperrorsamepathinstalled>
+<workshopiteminstalled>Installed</workshopiteminstalled>
+<workshopitemdownloadpending>Download pending</workshopitemdownloadpending>
+<confirmfiledeletionheader>Deleting file</confirmfiledeletionheader>
+<confirmfiledeletion>Are you sure you want to permanently delete "[file]"?</confirmfiledeletion>
+<workshopitemreinstall>Reinstall</workshopitemreinstall>
+<modsinstallednotif>Mods installed; open settings to enable</modsinstallednotif>
+<modsdownloadingnotif>Downloading mods...</modsdownloadingnotif>
+<workshopitemdownloadtitle>Workshop items required</workshopitemdownloadtitle>
+<workshopitemdownloadprompt>The following Workshop items are required to play on this server: [items] Would you like to subscribe to them?</workshopitemdownloadprompt>
+<workshopitemdownloadprompttruncated>+ [number] more</workshopitemdownloadprompttruncated>
+<workshopmenutab.installedmods>Installed mods</workshopmenutab.installedmods>
+<workshopmenutab.popularmods>Popular mods</workshopmenutab.popularmods>
+<workshopmenutab.publish>Publish</workshopmenutab.publish>
+<enabledcore>Current core package</enabledcore>
+<enabledregular>Enabled regular packages</enabledregular>
+<disabledregular>Disabled regular packages</disabledregular>
+<LocalCopyRequired>You do not have a local copy of this item. This is required to publish updates to it.\n\nWould you like to create one?</LocalCopyRequired>
+<ItemInstallRequired>You do not have this item installed. This is required to publish updates to it.\n\nWould you like to install it?</ItemInstallRequired>
+<WorkshopItemVersion>Mod version</WorkshopItemVersion>
+<PublishedModsHeader>Published</PublishedModsHeader>
+<UnpublishedModsHeader>Not published</UnpublishedModsHeader>
+<LastLocalEditTime>Last modified locally on [datetime]</LastLocalEditTime>
+<LatestPublishTime>Latest update published on [datetime]</LatestPublishTime>
+<FreeWeekendCantPublish>You're currently playing Barotrauma through a free weekend.\n\nOnly players who have purchased the game can publish items to the Steam Workshop.</FreeWeekendCantPublish>
+<FamilySharedCantPublish>You're currently playing Barotrauma via Family Sharing.\n\nOnly players who have purchased the game can publish items to the Steam Workshop.</FamilySharedCantPublish>
+<WorkshopItemVisibility.Unlisted>Unlisted</WorkshopItemVisibility.Unlisted>
+<ModDownloadTitle>Mods required</ModDownloadTitle>
+<ModDownloadHeader>The following mods are missing or mismatched and are required to play on this server:</ModDownloadHeader>
+<ModDownloadFooter>Would you like to download them?</ModDownloadFooter>
+<ModDownloadFooterFail>This server does not allow users to download its mods directly. You may need to visit the Steam Workshop to download them, or contact the server host.</ModDownloadFooterFail>
+<SubscribeToAllOnWorkshop>Subscribe to all on Steam Workshop</SubscribeToAllOnWorkshop>
+<ModNameAndHashFormat>[name] ([hash])</ModNameAndHashFormat>
+<ModDirInfo>[filecount] files, [size] total</ModDirInfo>
+<PublishPopupDownload>Downloading [percentage]%</PublishPopupDownload>
+<PublishPopupInstall>Installing...</PublishPopupInstall>
+<PublishPopupCreateLocal>Creating local copy...</PublishPopupCreateLocal>
+<PublishPopupStaging>Copying item to staging folder...</PublishPopupStaging>
+<PublishPopupSubmit>Submitting item to the Workshop...</PublishPopupSubmit>
+<OpenLocalModInExplorer>Local mod\nClick to open in Explorer</OpenLocalModInExplorer>
+<ViewWorkshopModDetails>View details</ViewWorkshopModDetails>
+<EnableWorkshopMod>Enable</EnableWorkshopMod>
+<DisableWorkshopMod>Disable</DisableWorkshopMod>
+<EnableSelectedWorkshopMods>Enable all selected</EnableSelectedWorkshopMods>
+<DisableSelectedWorkshopMods>Disable all selected</DisableSelectedWorkshopMods>
+<DownloadedWorkshopMod>Workshop mod</DownloadedWorkshopMod>
+<PublishedWorkshopMod>Published mod</PublishedWorkshopMod>
+<ViewModDetailsUpdateAvailable>An update to this item is available!\nClick to view details</ViewModDetailsUpdateAvailable>
+<ModUpdatesAvailable>Updates available! Click here to install</ModUpdatesAvailable>
+<RefreshModLists>Refresh</RefreshModLists>
+<WorkshopItemUpdate>Update</WorkshopItemUpdate>
+<ServerExecutable>Server executable</ServerExecutable>
+<ModServerExesAtYourOwnRisk>Modded server executables could be unsafe or malicious.\n\nYOU RUN MODDED SERVER EXECUTABLES AT YOUR OWN RISK.\n\nDo you still want to switch to [exename]?</ModServerExesAtYourOwnRisk>
+<CannotChangeMods>You may only enable/disable mods in the main menu.</CannotChangeMods>
+<WorkshopItemSubscriptions>[subscriptioncount] subscriptions</WorkshopItemSubscriptions>
+<Ugc.TransferTitle>Transfer mods</Ugc.TransferTitle>
+<Ugc.TransferDesc>It looks like you've created some mods in an old version of Barotrauma.\n\nPlease select which of these mods you would like to transfer to the new local mods directory.\n\nAny non-transferred mods will remain inaccessible to this version of the game, but may still be found in their original locations among the game's files should you choose to transfer them yourself manually.</Ugc.TransferDesc>
+<Ugc.TransferButton>Transfer</Ugc.TransferButton>
+<Ugc.Transferring>Transferring mods...</Ugc.Transferring>
+<Ugc.TransferComplete>Mod transfer complete.</Ugc.TransferComplete>
+<DeterminingRequiredModUpdates>Determining which mods require updates...</DeterminingRequiredModUpdates>
+<PreparingWorkshopDownloads>Preparing Steam Workshop downloads...</PreparingWorkshopDownloads>
+<PlayerIsDownloadingFiles>This player is downloading files from the server.</PlayerIsDownloadingFiles>
+<ModFilter.ShowLocal>Show local mods</ModFilter.ShowLocal>
+<ModFilter.ShowWorkshop>Show Workshop mods</ModFilter.ShowWorkshop>
+<ModFilter.ShowPublished>Show published mods</ModFilter.ShowPublished>
+<ModFilter.ShowOnlySubs>Show only submarines</ModFilter.ShowOnlySubs>
+<ModFilter.ShowOnlyItemAssemblies>Show only item assemblies</ModFilter.ShowOnlyItemAssemblies>
+<MergeSelectedMods>Merge all selected</MergeSelectedMods>
+<MergeModsHeader>Merge mods</MergeModsHeader>
+<MergeModsDesc>You are about to merge the following mods:</MergeModsDesc>
+<MergeModsFooter>Name the resulting content package:</MergeModsFooter>
+<ConfirmModMerge>Merge</ConfirmModMerge>
+<UnsubscribeFromAllSelected>Unsubscribe from all selected</UnsubscribeFromAllSelected>
+<LoadModListPresetHeader>Load mod list</LoadModListPresetHeader>
+<SaveModListPresetHeader>Save mod list</SaveModListPresetHeader>
+<AutoDetectRequiredPackages>Auto-detect</AutoDetectRequiredPackages>
+<SaveToLocalPackage>Add to local package</SaveToLocalPackage>
+<CreateNewLocalPackage>Create new local package</CreateNewLocalPackage>
+<UpdateExistingLocalPackage>Update "[mod]" local package</UpdateExistingLocalPackage>
+<CorePackage>Core package</CorePackage>
+<RegularPackages>Regular packages</RegularPackages>
+<ContentPackageEnableError>The content package "[packagename]" could not be enabled due to an error. Check the debug console by pressing F3 for more details.</ContentPackageEnableError>
+<ContentPackageHasFatalErrors>Errors found in content package "[packagename]."</ContentPackageHasFatalErrors>
+<ModUpdatesAvailableLabel>Updates available! Click here for more details</ModUpdatesAvailableLabel>
+<ModLoadOrderExplanation>You can change the load order of the mods by rearranging the list. Mods at the top of the list have a higher priority than the ones below them, meaning that if multiple mods override the same content, the one highest on the list takes precedence over the others.</ModLoadOrderExplanation>
+
+<!-- Settings Menu -->
+<settings>Settings</settings>
+<restartrequiredgeneric>You need to restart the game for the changes to take effect.</restartrequiredgeneric>
+<settingresetlabel>Confirm reset</settingresetlabel>
+<unsavedchangeslabel>Unsaved changes</unsavedchangeslabel>
+<unsavedchangesverification>Are you sure you want to leave without saving the changes made to the settings?</unsavedchangesverification>
+
+<!-- General tab -->
+<settingstab.general>General</settingstab.general>
+<contentpackage>Content package</contentpackage>
+<contentpackages>Content packages</contentpackages>
+<corepackagerequiredwarning>You cannot deselect the content package because it is a core package required for the game to work. You may switch it by selecting another core package.</corepackagerequiredwarning>
+<cannotremovecontentpackagesub>Cannot remove the submarine file because it's a part of the content package "[contentpackage]." Please uninstall the content package through the Steam Workshop menu.</cannotremovecontentpackagesub>
+<settingresetverification>Are you sure you want to reset the settings?</settingresetverification>
+<incorrectexe>The executable you have launched is not present in the content package [selectedpackage]. Do you want to launch [exename]?</incorrectexe>
+<language>Language</language>
+<language.english>English</language.english>
+<applysettingsbutton>Apply</applysettingsbutton>
+<applysettingslabel>Apply changes?</applysettingslabel>
+<applysettingsquestion>Do you want to apply the settings or discard the changes?</applysettingsquestion>
+<applysettingsyes>Apply</applysettingsyes>
+<applysettingsno>Discard</applysettingsno>
+<applysettingsbuttonunsavedchanges>Apply</applysettingsbuttonunsavedchanges>
+<restartrequiredlabel>Restart required</restartrequiredlabel>
+<restartrequiredresolution>You need to restart the game for the resolution changes to take effect.</restartrequiredresolution>
+<restartrequiredlanguage>You need to restart the game for the language change to take effect.</restartrequiredlanguage>
+<contentpackagenotfound>Content package "[packagepath]" not found.</contentpackagenotfound>
+<incompatiblecontentpackage>Content package "[packagename]" is not compatible with this version of Barotrauma. The package was made for the version [packageversion]; your game version is [gameversion].</incompatiblecontentpackage>
+<incompatiblecontentpackageunknownversion>Content package "[packagename]" is not compatible with this version of Barotrauma. The package was made for an unknown version; your game version is [gameversion].</incompatiblecontentpackageunknownversion>
+<contentpackagemissingcorefiles>Content package "[packagename]" is marked as a core package but does not contain all the required files for a core package. Missing content file types: [missingfiletypes]</contentpackagemissingcorefiles>
+<contentpackagecantmakecorepackage>Content package "[packagename]" cannot be marked as a core package because it does not contain all the required files for a core package. Missing content file types: [missingfiletypes]</contentpackagecantmakecorepackage>
+<pauseonfocuslost>Pause on focus lost</pauseonfocuslost>
+<pauseonfocuslosttooltip>Pauses the game when its window is not in focus. Note that the game won't be paused when a multiplayer session is active.</pauseonfocuslosttooltip>
+<voipcapturedevicenotfound>Could not start voice capture; suitable capture device not found.</voipcapturedevicenotfound>
+<enablesplashscreen>Enable splash screen</enablesplashscreen>
+<contentpackagehaserrors>Errors found in content package "[packagename]"; some of its features may not work correctly.</contentpackagehaserrors>
+<restartrequiredcontentpackage>You need to restart the game for some content package changes to take effect.</restartrequiredcontentpackage>
+<ShowEnemyHealthBars>Enemy healthbars</ShowEnemyHealthBars>
+<ShowEnemyHealthBars.ShowAll>Show all</ShowEnemyHealthBars.ShowAll>
+<ShowEnemyHealthBars.BossHealthBarsOnly>Only boss healthbars</ShowEnemyHealthBars.BossHealthBarsOnly>
+<ShowEnemyHealthBars.HideAll>Hide all</ShowEnemyHealthBars.HideAll>
+
+<!-- Graphics tab -->
+<settingstab.graphics>Graphics</settingstab.graphics>
+<resolution>Resolution</resolution>
+<displaymode>Display mode</displaymode>
+<fullscreen>Fullscreen</fullscreen>
+<windowed>Windowed</windowed>
+<borderlesswindowed>Borderless windowed</borderlesswindowed>
+<enablevsync>Enable vertical sync</enablevsync>
+<enablevsynctooltip>Synchronizes the game's frame rate with your monitor's refresh rate. Helps prevent screen tearing artifacts.</enablevsynctooltip>
+<particlelimit>Particle limit</particlelimit>
+<VisibleLightLimit>Visible light limit</VisibleLightLimit>
+<VisibleLightLimitTooltip>If there are more lights than this visible on the screen, the least noticeable ones won't be drawn. A lower limit improves performance, but may cause lighting to flicker or look strange.</VisibleLightLimitTooltip>
+<loseffect>Line of sight effect</loseffect>
+<losmodenone>None</losmodenone>
+<losmodetransparent>Transparent</losmodetransparent>
+<losmodeopaque>Opaque</losmodeopaque>
+<lightmapscale>Lighting resolution</lightmapscale>
+<lightmapscaletooltip>Lower values improve performance, but cause shadows to appear more pixellated.</lightmapscaletooltip>
+<specularlighting>Specular lighting</specularlighting>
+<specularlightingtooltip>Enables specular lighting, an effect which creates brighter spots of light on shiny objects.</specularlightingtooltip>
+<chromaticaberration>Chromatic aberration</chromaticaberration>
+<chromaticaberrationtooltip>Enables a subtle color distortion effect at the edges of the screen.</chromaticaberrationtooltip>
+<hudscale>HUD scale</hudscale>
+<inventoryscale>Inventory scale</inventoryscale>
+<enabletexturecompression>Enable texture compression</enabletexturecompression>
+<enabletexturecompressiontooltip>Significantly reduces the amount of video memory used by textures. This may increase loading times and generate visual artifacts.</enabletexturecompressiontooltip>
+<radialdistortion>Fisheye lens effect</radialdistortion>
+<radialdistortiontooltip>Enables the fisheye screen distortion effect that's caused by certain afflictions and environmental hazards.</radialdistortiontooltip>
+<textscale>Text scale</textscale>
+
+<!-- Audio tab -->
+<settingstab.audioandvc>Audio &amp; voice chat</settingstab.audioandvc>
+<settingstab.audio>Audio</settingstab.audio>
+<soundvolume>Sound volume</soundvolume>
+<musicvolume>Music volume</musicvolume>
+<uisoundvolume>UI Sound volume</uisoundvolume>
+<voicechatvolume>Voice chat volume</voicechatvolume>
+<muteonfocuslost>Mute on focus lost</muteonfocuslost>
+<muteonfocuslosttooltip>Mutes the game when its window is not in focus.</muteonfocuslosttooltip>
+<audionodevices>No audio output devices found</audionodevices>
+<localvoicebydefault>Use local voice chat by default</localvoicebydefault>
+<localvoicebydefaulttooltip>When enabled, your voice will be sent through the local voice chat (meaning that only nearby players can hear you). You can use the push-to-talk key to speak through the radio.</localvoicebydefaulttooltip>
+<audiooutputdevice>Output device</audiooutputdevice>
+<audioinputdevice>Input device</audioinputdevice>
+<vcinputmode>Input mode</vcinputmode>
+<settingstab.voicechat>Voice chat</settingstab.voicechat>
+<microphonevolume>Microphone volume</microphonevolume>
+<voicechat>Voice chat</voicechat>
+<currentdevice>Current device</currentdevice>
+<currentdevicetooltip.osx>This device will be used for voice chat. Unfortunately there is no way to change the input device on Mac OS X—it will only use your system's default.</currentdevicetooltip.osx>
+<refreshdefaultdevice>Refresh default device</refreshdefaultdevice>
+<refreshdefaultdevicetooltip>Refreshes the input device used for voice chat. If you swap/hotplug the default input on your system then press this to detect that change.</refreshdefaultdevicetooltip>
+<voicemode.disabled>Disabled</voicemode.disabled>
+<voicemode.disabledtooltip>Voice chat is disabled.</voicemode.disabledtooltip>
+<voicemode.pushtotalk>Push-to-talk</voicemode.pushtotalk>
+<voicemode.pushtotalktooltip>Voice activity is sent only when a certain key is held down.</voicemode.pushtotalktooltip>
+<voicemode.activity>Voice activity</voicemode.activity>
+<voicemode.activitytooltip>Voice activity is sent whenever the sound coming through surpasses the noise gate threshold.</voicemode.activitytooltip>
+<noisegatethreshold>Noise gate threshold</noisegatethreshold>
+<directionalvoicechat>Directional voice chat</directionalvoicechat>
+<directionalvoicechattooltip>When enabled, voice chat messages are panned according to the direction of the speaker relative to your position.</directionalvoicechattooltip>
+<dynamicrangecompression>Dynamic range compression</dynamicrangecompression>
+<dynamicrangecompressiontooltip>Adjusts the game's volume automatically to prevent audio distortion.</dynamicrangecompressiontooltip>
+<voipnodevices>No audio capture devices found</voipnodevices>
+<voipattenuation>Voice chat attenuation</voipattenuation>
+<voipattenuationtooltip>Lowers the game's volume when players are speaking.</voipattenuationtooltip>
+<cutoffprevention>Cutoff prevention</cutoffprevention>
+<cutoffpreventiontooltip>Continues voice transmission for a certain amount of time after the push-to-talk key has been released or the voice activity goes under the threshold.</cutoffpreventiontooltip>
+
+<!-- Controls tab -->
+<settingstab.controls>Controls</settingstab.controls>
+<aimassist>Aim assist</aimassist>
+<aimassisttooltip>Affects how close the cursor has to be to an item to highlight it. If set to 0%, the cursor has to be exactly on the item.</aimassisttooltip>
+<enablemouselook>Enable mouse look</enablemouselook>
+<enablemouselooktooltip>When enabled, the camera moves according to the direction you point the cursor to.</enablemouselooktooltip>
+<inputtype.select>Select</inputtype.select>
+<inputtype.deselect>Deselect</inputtype.deselect>
+<inputtype.shoot>Shoot</inputtype.shoot>
+<inputtype.use>Use</inputtype.use>
+<inputtype.aim>Aim</inputtype.aim>
+<inputtype.up>Up</inputtype.up>
+<inputtype.down>Down</inputtype.down>
+<inputtype.left>Left</inputtype.left>
+<inputtype.right>Right</inputtype.right>
+<inputtype.attack>Creature Attack</inputtype.attack>
+<inputtype.run>Run</inputtype.run>
+<inputtype.crouch>Crouch</inputtype.crouch>
+<inputtype.infotab>Info tab</inputtype.infotab>
+<inputtype.radiochat>Radio chat</inputtype.radiochat>
+<inputtype.creworders>Crew orders</inputtype.creworders>
+<inputtype.ragdoll>Ragdoll</inputtype.ragdoll>
+<inputtype.health>Health</inputtype.health>
+<inputtype.grab>Grab</inputtype.grab>
+<inputtype.selectnextcharacter>Next character</inputtype.selectnextcharacter>
+<inputtype.selectpreviouscharacter>Previous character</inputtype.selectpreviouscharacter>
+<inputtype.voice>Push-to-talk</inputtype.voice>
+<inputtype.command>Command Interface</inputtype.command>
+<inputtype.toggleinventory>Toggle inventory</inputtype.toggleinventory>
+<inputtype.localvoice>Local voice chat</inputtype.localvoice>
+<inputtype.nextfiremode>Next fire mode</inputtype.nextfiremode>
+<inputtype.previousfiremode>Previous fire mode</inputtype.previousfiremode>
+<inputtype.takeallfrominventoryslot>Take all from slot</inputtype.takeallfrominventoryslot>
+<inputtype.takehalffrominventoryslot>Take half from slot</inputtype.takehalffrominventoryslot>
+<inputtype.takeonefrominventoryslot>Take one from slot</inputtype.takeonefrominventoryslot>
+<inputtype.togglechatmode>Toggle Chat Mode</inputtype.togglechatmode>
+<inputtype.activechat>Chat</inputtype.activechat>
+<inputtype.chat>Local chat</inputtype.chat>
+<input.leftmouse>Left mouse</input.leftmouse>
+<input.rightmouse>Right mouse</input.rightmouse>
+<input.middlemouse>Middle mouse</input.middlemouse>
+<input.mousebutton4>Mouse 4</input.mousebutton4>
+<input.mousebutton5>Mouse 5</input.mousebutton5>
+<input.mousewheelup>Mouse wheel up</input.mousewheelup>
+<input.mousewheeldown>Mouse wheel down</input.mousewheeldown>
+<inputtype.toggleinventory>Toggle entity list</inputtype.toggleinventory>
+<inputtype.voice>Voice chat</inputtype.voice>
+<inputtype.radiovoice>Radio voice chat</inputtype.radiovoice>
+<inputtype.chatbox>Toggle chat box</inputtype.chatbox>
+<setdefaultbindings>Set Default Bindings</setdefaultbindings>
+<setdefaultbindingstooltip>Set key bindings to the recommended default settings (left mouse button to select items, right mouse button or esc to deselect).</setdefaultbindingstooltip>
+<setlegacybindings>Set Legacy Bindings</setlegacybindings>
+<setlegacybindingstooltip>Set key bindings to ones that were used in the old pre-alpha versions of Barotrauma (E to select and deselect items, left mouse button to use item the in hand).</setlegacybindingstooltip>
+<inventoryslotkeybind>Inventory slot [slotnumber]</inventoryslotkeybind>
+<duplicatebindwarning>You have bound [savedbind] to [key]. It overlaps with the new keybind [defaultbind]. This can lead to unexpected behavior. Consider revisiting your keybinds in the settings.</duplicatebindwarning>
+<hudbutton.chatbox>Chat ([key])</hudbutton.chatbox>
+
+<!-- Gameplay tab -->
+<settingstab.gameplay>Gameplay &amp; UI</settingstab.gameplay>
+<resetingamehints>Reset in-game hints</resetingamehints>
+<resetingamehintstooltip>Are you sure you want to reset in-game hints? This will allow the game to show you hints that you've previously set to not be shown again.</resetingamehintstooltip>
+
+
+<!-- Server settings -->
+<serversettingsgeneraltab>General</serversettingsgeneraltab>
+<serversettingsantigriefingtab>Anti-griefing</serversettingsantigriefingtab>
+<serversettingsroundstab>Gameplay</serversettingsroundstab>
+<serversettingsservertab>Server</serversettingsservertab>
+<serversettingsbanlisttab>Banlist</serversettingsbanlisttab>
+<serversettingswhitelisttab>Whitelist</serversettingswhitelisttab>
+<serversettingssubselection>Submarine selection</serversettingssubselection>
+<serversettingsmodeselection>Game mode selection</serversettingsmodeselection>
+<serversettingsendroundwhendestreached>End round when destination reached</serversettingsendroundwhendestreached>
+<serversettingsendroundvoting>End round by voting</serversettingsendroundvoting>
+<serversettingsendroundvotesrequired>Votes required:</serversettingsendroundvotesrequired>
+<serversettingsallowrespawning>Allow respawning</serversettingsallowrespawning>
+<serversettingsrespawninterval>Interval:</serversettingsrespawninterval>
+<serversettingsminrespawn>Minimum players to respawn:</serversettingsminrespawn>
+<serversettingsminrespawntooltip>What percentage of players has to be dead/spectating until a respawn shuttle is dispatched.</serversettingsminrespawntooltip>
+<serversettingsrespawnduration>Duration of respawn transport:</serversettingsrespawnduration>
+<serversettingsrespawndurationtooltip>The amount of time respawned players have to navigate the respawn shuttle to the main submarine. After the duration expires, the shuttle will automatically head back out of the level.</serversettingsrespawndurationtooltip>
+<serversettingsmonsterspawns>Monster Spawns</serversettingsmonsterspawns>
+<serversettingsadditionalcargo>Additional Cargo</serversettingsadditionalcargo>
+<serversettingsautorestartdelay>Autorestart delay:</serversettingsautorestartdelay>
+<serversettingsstartwhenclientsready>Start when players are ready</serversettingsstartwhenclientsready>
+<serversettingsstartwhenclientsreadyratio>[percentage] % need to be ready</serversettingsstartwhenclientsreadyratio>
+<serversettingsallowspectating>Allow spectating</serversettingsallowspectating>
+<serversettingsallowvotekick>Allow vote kicking</serversettingsallowvotekick>
+<serversettingskickvotesrequired>Votes required:</serversettingskickvotesrequired>
+<serversettingsautobantime>Autoban duration:</serversettingsautobantime>
+<serversettingssharesubfiles>Share submarine files with players</serversettingssharesubfiles>
+<serversettingsrandomizeseed>Randomize level seed between rounds</serversettingsrandomizeseed>
+<serversettingssavelogs>Save server logs</serversettingssavelogs>
+<serversettingsallowragdollbutton>Allow ragdoll button</serversettingsallowragdollbutton>
+<serversettingsusetraitorratio>Use % of players for max traitors</serversettingsusetraitorratio>
+<serversettingstraitorratio>Traitor ratio:</serversettingstraitorratio>
+<serversettingstraitorcount>Traitor count:</serversettingstraitorcount>
+<serversettingstraitorsminplayercount>Minimum players for traitors</serversettingstraitorsminplayercount>
+<serversettingstraitorsminplayercounttooltip>How many players need to join the server before traitors can appear.</serversettingstraitorsminplayercounttooltip>
+<serversettingsusekarma>Use Karma</serversettingsusekarma>
+<serversettingsvoicechatenabled>Voice chat enabled</serversettingsvoicechatenabled>
+<serversettingsbanafterwrongpassword>Ban after incorrect password</serversettingsbanafterwrongpassword>
+<serversettingspasswordretriesbeforeban>Password retries before a ban</serversettingspasswordretriesbeforeban>
+<serversettingsdisablebotconversations>Disable bot conversations</serversettingsdisablebotconversations>
+<serversettingsdestructibleoutposts>Destructible outposts</serversettingsdestructibleoutposts>
+<serversettingskillablenpcs>Killable outpost NPCs</serversettingskillablenpcs>
+<serverrestartrequiredcontentpackage>Before hosting a server, you need to restart the game for the content package changes to take effect.</serverrestartrequiredcontentpackage>
+<banlistremove>Remove</banlistremove>
+<banexpires>Expires [time]</banexpires>
+<banduration>Duration</banduration>
+<banpermanent>Permanent</banpermanent>
+<banreason>Reason:</banreason>
+<serversettingslockalldefaultwires>Lock all default wires</serversettingslockalldefaultwires>
+<publiclobbytag>Public</publiclobbytag>
+<privatelobbytag>Private</privatelobbytag>
+<hostserverkarmasetting>Playing with friends?</hostserverkarmasetting>
+<hostserverkarmasettingtooltip>Enabling this will disable Karma.\n\nKarma is a customizable automatic moderation system that gives you an invisible score based on helpful and harmful actions you've performed and may apply certain penalties if your score gets too low. Karma can help in keeping your public servers in check, but with friends, you may want to interact more freely.</hostserverkarmasettingtooltip>
+<serversettingsmaximumtransferrequest>Max money transfer request</serversettingsmaximumtransferrequest>
+<serversettingsmaximumtransferrequesttooltip>How much money players are allowed to request from the bank. Setting to 0 will completely disable requesting money from the bank by voting.</serversettingsmaximumtransferrequesttooltip>
+<serversettingslootedmoneydestination>Looted money destination</serversettingslootedmoneydestination>
+<serversettingslootedmoneydestinationtooltip>Choose whether looting corpses sends the money to the bank or to the looter's personal wallet.</serversettingslootedmoneydestinationtooltip>
+<lootedmoneydestination.bank>Bank</lootedmoneydestination.bank>
+<lootedmoneydestination.wallet>Personal wallet</lootedmoneydestination.wallet>
+<serversettingsenabledosprotection>Enable DoS protection</serversettingsenabledosprotection>
+<serversettingsenabledosprotectiontooltip>Automatically kick players who cause the server to perform slowly.</serversettingsenabledosprotectiontooltip>
+<serversettingsmaxpacketamount>Rate limiter kick threshold:</serversettingsmaxpacketamount>
+<serversettingsmaxpacketamounttooltip>How many network messages the client is allowed to send per minute before they will get automatically kicked.</serversettingsmaxpacketamounttooltip>
+<packetlimit>How many network messages the client is allowed to send per minute before they will get automatically kicked.</packetlimit>
+<serversettingsnolimit>No limit</serversettingsnolimit>
+<packetlimitwarning>WARNING: Setting the limit this low may kick legitimate players.</packetlimitwarning>
+<dosprotectionkicked>Kicked for causing the server to perform slowly.</dosprotectionkicked>
+<packetlimitkicked>Kicked for sending too much data to the server. If you weren't intentionally spamming the server, it could be the server is using mods or custom settings that cause the game to send higher-than-normal amounts of data, and the host may need to increase the rate limiter kick threshold or set it to "no limit" in the server settings.</packetlimitkicked>
+
+<!-- Tab menu -->
+<tabmenu.voip>VOIP</tabmenu.voip>
+<tabmenu.job>Job</tabmenu.job>
+<tabmenu.character>Character</tabmenu.character>
+<tabmenu.characterchangespending>Changes to your character will be applied after the current round ends.</tabmenu.characterchangespending>
+<tabmenu.traitor>Traitor</tabmenu.traitor>
+<tabmenu.bot>Bot</tabmenu.bot>
+<tabmenu.inlobby>In lobby</tabmenu.inlobby>
+<tabmenu.talents>Talents</tabmenu.talents>
+
+<!-- Round summary -->
+<roundsummaryprogress>[sub] has made its way to [location].</roundsummaryprogress>
+<roundsummaryprogress>[sub] has arrived at [location].</roundsummaryprogress>
+<roundsummaryreturn>[sub] has returned to [location].</roundsummaryreturn>
+<roundsummarygameover>The ocean has claimed [sub] and its crew.</roundsummarygameover>
+<roundsummarycrewstatus>Crew status</roundsummarycrewstatus>
+<roundsummaryroundhasended>The round has ended.</roundsummaryroundhasended>
+<roundsummaryleaving>[sub] is leaving from [location].</roundsummaryleaving>
+<roundsummaryprogresstoemptylocation>[sub] has made its way through [location].</roundsummaryprogresstoemptylocation>
+<roundsummaryreturntoemptylocation>[sub] is returning back through [location].</roundsummaryreturntoemptylocation>
+
+<!-- Character HUD -->
+<oxygenhudwarning>Oxygen low</oxygenhudwarning>
+<pressurehudwarning>High pressure</pressurehudwarning>
+<grabbing>Grabbing</grabbing>
+<stun>Stun</stun>
+<disguised>(Disguised)</disguised>
+<useitembutton>Use</useitembutton>
+<grabhint>[[key]] Grab</grabhint>
+<eathint>[[key]] Eat</eathint>
+<healhint>[[key]] Heal</healhint>
+<talkhint>[[key]] Talk</talkhint>
+<playhint>[[key]] Play</playhint>
+<quickuseaction.equip>Equip</quickuseaction.equip>
+<quickuseaction.unequip>Unequip</quickuseaction.unequip>
+<quickuseaction.drop>Hold to drop</quickuseaction.drop>
+<quickuseaction.takefromcontainer>Take</quickuseaction.takefromcontainer>
+<quickuseaction.takefromcharacter>Take</quickuseaction.takefromcharacter>
+<quickuseaction.puttocontainer>Put to container</quickuseaction.puttocontainer>
+<quickuseaction.puttocharacter>Put to selected character</quickuseaction.puttocharacter>
+<quickuseaction.usetreatment>Use as treatment</quickuseaction.usetreatment>
+<quickuseaction.holdtounequip>Hold to unequip</quickuseaction.holdtounequip>
+<quickuseaction.puttoequippeditem>Put to [equippeditem]</quickuseaction.puttoequippeditem>
+<hudbutton.healthinterface>Health interface ([key])</hudbutton.healthinterface>
+<hudbutton.crewlist>Crew list ([key])</hudbutton.crewlist>
+<hudbutton.commandinterface>Command interface ([key])</hudbutton.commandinterface>
+<hudbutton.tabmenu>Info tab ([key])</hudbutton.tabmenu>
+<divingsuitwarning>Caution: Exterior pressure exceeds diving suit capabilities.</divingsuitwarning>
+<steeringdepthwarninglow>APPROACHING CRUSH DEPTH ([crushdepth] m)</steeringdepthwarninglow>
+
+<!-- Limbs -->
+<lefthand>Left hand</lefthand>
+<righthand>Right hand</righthand>
+<hands>Hands</hands>
+<leftarm>Left arm</leftarm>
+<rightarm>Right arm</rightarm>
+<leftleg>Left leg</leftleg>
+<rightleg>Right leg</rightleg>
+<leftfoot>Left foot</leftfoot>
+<rightfoot>Right foot</rightfoot>
+<head>Head</head>
+<torso>Torso</torso>
+<tail>Tail</tail>
+<legs>Legs</legs>
+<rightthigh>Right thigh</rightthigh>
+<leftthigh>Left thigh</leftthigh>
+<waist>Waist</waist>
+
+<!-- Misc -->
+<yes>Yes</yes>
+<yestoall>Yes to All</yestoall>
+<no>No</no>
+<notoall>No to All</notoall>
+<maybe>Maybe</maybe>
+<ok>OK</ok>
+<skills>Skills</skills>
+<male>Male</male>
+<female>Female</female>
+<order>Order</order>
+<submarine>Submarine</submarine>
+<respawnshuttle>Respawn shuttle</respawnshuttle>
+<shuttle>Shuttle</shuttle>
+<editing>Editing</editing>
+<error>Error</error>
+<warning>Warning</warning>
+<unknown>Unknown</unknown>
+<none>None</none>
+<any>Any</any>
+<close>Close</close>
+<cancel>Cancel</cancel>
+<done>Done</done>
+<delete>Delete</delete>
+<load>Load</load>
+<save>Save</save>
+<back>Back</back>
+<days>Days</days>
+<hours>Hours</hours>
+<retry>Retry</retry>
+<manageplayers>Manage players</manageplayers>
+<destination>Destination</destination>
+<previous>Previous</previous>
+<next>Next</next>
+<name>Name</name>
+<unlimited>Unlimited</unlimited>
+<deletedialoglabel>Delete file?</deletedialoglabel>
+<deletedialogquestion>Are you sure you want to delete "[file]"?</deletedialogquestion>
+<deletefileverification>Do you want to delete [filename]?</deletefileverification>
+<deletefileerror>Could not delete file "[file]"!</deletefileerror>
+<steamdllnotfound>Initializing Steam client failed (steam_api64.dll not found). All Steam features have been disabled—you will not be able to use the Steam Workshop or join servers that use Steam.</steamdllnotfound>
+<steamclientinitfailed>Initializing Steam client failed. Please make sure Steam is running and you are logged in to an account. All Steam features have been disabled—you will not be able to use the Steam Workshop or join servers that use Steam.</steamclientinitfailed>
+<create>Create</create>
+<walls>Walls</walls>
+<reset>Reset</reset>
+<genericreplaceverification>Do you want to replace it?</genericreplaceverification>
+<dontshownotificationagain>Don't show this again</dontshownotificationagain>
+<video>Video</video>
+<search>Search</search>
+<damagebutton>Damage</damagebutton>
+<pending>Pending</pending>
+<inprogress>In progress</inprogress>
+<complete>Complete</complete>
+<wrongfiletype>Wrong file type!</wrongfiletype>
+<debugconsolehelptext>Debug console—press F3 to open/close; enter "help" for a list of available commands</debugconsolehelptext>
+<failed>Failed</failed>
+<invalidcontentpackage>Content package "[packagename]" cannot be loaded.</invalidcontentpackage>
+<xmlfileinvalid>File "[filepath]" is not a valid XML file ([errormessage]).</xmlfileinvalid>
+<openlinkinbrowserprompt>Do you want to open the link "[link]" in your web browser?</openlinkinbrowserprompt>
+<contentpackagemismatchwarninggeneric>The submarine may not be compatible with the currently selected content packages. Are you sure you want to choose the submarine?</contentpackagemismatchwarninggeneric>
+<bankbalanceformat>Bank: [money] mk</bankbalanceformat>
+<moneygainformat>+ [money]</moneygainformat>
+<moneyloseformat>- [money]</moneyloseformat>
+<percentageformat>[value]%</percentageformat>
+<timeformathours>[hours] h</timeformathours>
+<timeformatminutes>[minutes] m</timeformatminutes>
+<timeformatseconds>[seconds] s</timeformatseconds>
+<timeformatmilliseconds>[milliseconds] ms</timeformatmilliseconds>
+<kilowatt>kW</kilowatt>
+<charge>Charge</charge>
+<rechargerate>Recharge rate</rechargerate>
+<kilowattminute>kWmin</kilowattminute>
+<depth>Depth</depth>
+<meter>m</meter>
+<descentvelocity>Descent velocity</descentvelocity>
+<velocity>Velocity</velocity>
+<kilometersperhour>km/h</kilometersperhour>
+<output>Output</output>
+<showinfolder>Show in folder</showinfolder>
+<showinfoldererror>Failed to open the folder "[folder]" ([errormessage]).</showinfoldererror>
+<wreckeditemformat>[name] (Wrecked)</wreckeditemformat>
+<message>Message</message>
+<legacyitemformat>[name] (Legacy)</legacyitemformat>
+<moderationmenu.userdetails>Details</moderationmenu.userdetails>
+<moderationmenu.manageplayer>Manage</moderationmenu.manageplayer>
+<crushdepthwarninglow>This route may be too deep to traverse safely without upgrading the durability of your current submarine's hull, or utilizing a more suitable sub. The route starts at the depth of [initialdepth] meters, but your submarine's hull can only withstand a depth of [submarinecrushdepth] meters.</crushdepthwarninglow>
+<crushdepthwarninghigh>You cannot traverse this route without upgrading the durability of your current submarine's hull, or utilizing a more suitable sub. The route starts at the depth of [initialdepth] meters, but your submarine's hull can only withstand a depth of [submarinecrushdepth] meters.</crushdepthwarninghigh>
+<navterminalicespirewarning>Ice spire detected. Destroying the spire or switching to manual steering is advised.</navterminalicespirewarning>
+<confirm>Confirm</confirm>
+<restart>Restart</restart>
+
+<!-- Editor -->
+<charactereditor.contentpackagenameinuse>A content package with the same name already exists. Please choose another name or select the existing content package from the dropdown if you want to add the character to it.</charactereditor.contentpackagenameinuse>
+<charactereditor.crouch>Crouch</charactereditor.crouch>
+<subeditorlights>Lights</subeditorlights>
+<subeditorshadowcastinglights>Shadow-casting lights</subeditorshadowcastinglights>
+<subeditor.shadowcastinglightswarning>The submarine includes a very high number of shadow-casting lights, which can cause performance issues. You may want to go through the light sources and disable shadow casting where possible: Dim and/or low-range static lights don't necessarily need to cast shadows if letting the light go through walls and doors is not noticeable, and lights outside the submarine can be set to be drawn behind the submarine so shadows don't need to be cast.</subeditor.shadowcastinglightswarning>
+<subeditor.outpostcommonness>Commonness</subeditor.outpostcommonness>
+<subeditor.price>Price</subeditor.price>
+<subeditor.autosaveage>Saved [hours]h [minutes]m [seconds]s ago.</subeditor.autosaveage>
+<subeditor.savedjustnow>Just now</subeditor.savedjustnow>
+<subeditor.saveageminutes>[minutes] minute(s) ago</subeditor.saveageminutes>
+<subeditor.savedmorethanhour>More than an hour ago</subeditor.savedmorethanhour>
+<subeditor.autosaveentry>[submarine] ([saveage])</subeditor.autosaveentry>
+<subeditor.toggleimageediting>Toggle image editing</subeditor.toggleimageediting>
+<subeditor.addimage>Add image</subeditor.addimage>
+<subeditor.imageeditingmode>Image editing mode</subeditor.imageeditingmode>
+<subeditor.togglegrid>Toggle grid</subeditor.togglegrid>
+<subeditor.editbackgroundcolor>Edit background color</subeditor.editbackgroundcolor>
+<subeditor.toggletransparency>Toggle wiring mode transparency</subeditor.toggletransparency>
+<subeditor.pasteassembly>Paste item assembly</subeditor.pasteassembly>
+<subeditor.snaptogrid>Snap to Grid</subeditor.snaptogrid>
+<subeditor.loadconfirmbody>Are you sure you want to load the [submarine]? All unsaved changes will be lost.</subeditor.loadconfirmbody>
+<subeditor.duplicateiderror>The submarine contains entities with duplicate IDs ([entity1], [entity2])—the file may be corrupted. Do you want to attempt to fix the issue by deleting [entity2]?</subeditor.duplicateiderror>
+<subeditorvisibilitybutton>Toggle visibility</subeditorvisibilitybutton>
+<subeditorvisibilitytooltip>Choose which types of entities are visible.</subeditorvisibilitytooltip>
+<subeditoreditingmode>Edit mode</subeditoreditingmode>
+<editor.layer>Group</editor.layer>
+<editor.layer.movetolayer>Send selection to group...</editor.layer.movetolayer>
+<editor.layer.createlayer>Create new group from selection</editor.layer.createlayer>
+<editor.layer.selectall>Select all items in these groups</editor.layer.selectall>
+<editor.layer.nolayer>No group</editor.layer.nolayer>
+<editor.layer.newlayer>New group</editor.layer.newlayer>
+<editor.layer.renamelayer>Rename group</editor.layer.renamelayer>
+<editor.layer.deletelayer>Delete group</editor.layer.deletelayer>
+<editor.layer.openlayermenu>Toggle group panel</editor.layer.openlayermenu>
+<editor.layer.button>Manage groups</editor.layer.button>
+<editor.layer.tooltip>Toggle, create, delete and rename groups.</editor.layer.tooltip>
+<editor.layer.headervisible>Visibility</editor.layer.headervisible>
+<editor.layer.headerlink>Link</editor.layer.headerlink>
+<editor.cut>Cut</editor.cut>
+<editor.paste>Paste</editor.paste>
+<editor.togglereferencecharacter>Toggle size reference character</editor.togglereferencecharacter>
+<particle.muzzleflash>Muzzle Flash</particle.muzzleflash>
+<gapinsidehullwarning>This gap will do nothing, because both sides of the gap are inside the same hull. If you want water and oxygen to flow through the gap, or a door to block water/oxygen flow, it must be placed between two hulls.</gapinsidehullwarning>
+<opensubbutton>Open...</opensubbutton>
+<generatewaypointsverification>Are you sure you want to regenerate the waypoints in the submarine? This will reset all the existing waypoints. To ensure that AI characters can navigate the submarine effectively, you may need to make some manual adjustments to the waypoints after they have been generated, such as adding extra waypoints and links between them to make sure the paths between the waypoints cover all rooms.</generatewaypointsverification>
+<waypointsgeneratedsuccesfully>Waypoints have been successfully generated.</waypointsgeneratedsuccesfully>
+<loadautosave>Load autosave</loadautosave>
+<loadautosavetooltip>Recover the latest autosave.</loadautosavetooltip>
+<autosaved>Autosaved.</autosaved>
+<wirelistformat>[item] ([pin])</wirelistformat>
+<entitymenutoggletooltip>Toggle entity menu</entitymenutoggletooltip>
+<testsubbutton>Test</testsubbutton>
+<pausemenureturntoeditor>Return to editor</pausemenureturntoeditor>
+<gamemode.subtest>Submarine Testing Mode</gamemode.subtest>
+<nohumanspawnpointwarning>The submarine does not have spawnpoints for humans, meaning the crew will not be able to spawn correctly. To fix this, create a new spawnpoint and change its "spawn type" parameter to "human."</nohumanspawnpointwarning>
+<editable.minvalue>Min</editable.minvalue>
+<editable.maxvalue>Max</editable.maxvalue>
+<savesubtospecialfolderprompt>You have marked the submarine's type as "[type]." Do you want to save it to "[outpostpath]" instead of the default submarine folder?</savesubtospecialfolderprompt>
+<addtocontentpackageprompt>Do you want to add the file to the content package "[packagename]"?</addtocontentpackageprompt>
+<editor.selectsame>Select matching items</editor.selectsame>
+<sp.regexfindcomponent.usecapturegroup.name>Use capture group</sp.regexfindcomponent.usecapturegroup.name>
+<sp.regexfindcomponent.usecapturegroup.description>Should the component output a value of a named capture group.</sp.regexfindcomponent.usecapturegroup.description>
+<sp.regexfindcomponent.output.description>The signal this item outputs when the received signal matches the target signal or the name of the capture group to use as a signal.</sp.regexfindcomponent.output.description>
+<sp.regexfindcomponent.OutputEmptyCaptureGroup.name>Output empty capture group</sp.regexfindcomponent.OutputEmptyCaptureGroup.name>
+<sp.regexfindcomponent.OutputEmptyCaptureGroup.description>Should the component still display the value of a capture group, even if it's empty?</sp.regexfindcomponent.OutputEmptyCaptureGroup.description>
+<sp.nametag.writtenname.name>Name</sp.nametag.writtenname.name>
+<sp.nametag.writtenname.description>Name written on the tag.</sp.nametag.writtenname.description>
+<sp.item.rotation.name>Rotation</sp.item.rotation.name>
+<sp.colorcomponent.usehsv.name>Use HSV</sp.colorcomponent.usehsv.name>
+<sp.colorcomponent.usehsv.description>When enabled makes the component translate the signal from HSV into RGB where red is the hue between 0 and 360, green is the saturation between 0 and 1 and blue is the value between 0 and 1.</sp.colorcomponent.usehsv.description>
+<lightcomponent.lightcolor>Color</lightcomponent.lightcolor>
+<sp.memorycomponent.value.description>The currently stored signal the item outputs.</sp.memorycomponent.value.description>
+<sp.motionsensor.target.name>Target</sp.motionsensor.target.name>
+<sp.motionsensor.target.description>Which kind of targets can trigger the sensor?</sp.motionsensor.target.description>
+<sp.wificomponent.channel.description>Wifi components can only communicate with components that use the same channel.</sp.wificomponent.channel.description>
+<sp.arithmeticcomponent.clampmin.name>Clamp min</sp.arithmeticcomponent.clampmin.name>
+<sp.arithmeticcomponent.clampmin.description>The output of the item is restricted above this value.</sp.arithmeticcomponent.clampmin.description>
+<sp.arithmeticcomponent.clampmax.name>Clamp max</sp.arithmeticcomponent.clampmax.name>
+<sp.arithmeticcomponent.clampmax.description>The output of the item is restricted below this value.</sp.arithmeticcomponent.clampmax.description>
+<sp.concatcomponent.separator.name>Separator</sp.concatcomponent.separator.name>
+<sp.concatcomponent.separator.description>Symbol(s) to place between the input strings.</sp.concatcomponent.separator.description>
+<falseoutput>False output</falseoutput>
+<timeframe>Timeframe</timeframe>
+<timeframe.description>The item must have received signals to both inputs within this timeframe to output the result. If set to 0, the inputs must be received at the same time</timeframe.description>
+<sp.equalscomponent.output.description>The signal sent when the received inputs are equal (if empty, no signal is sent).</sp.equalscomponent.output.description>
+<sp.equalscomponent.falseoutput.description>The signal sent when the received inputs are not equal (if empty, no signal is sent).</sp.equalscomponent.falseoutput.description>
+<sp.exponentiationcomponent.exponent.name>Exponent</sp.exponentiationcomponent.exponent.name>
+<sp.exponentiationcomponent.exponent.description>The exponent of the operation.</sp.exponentiationcomponent.exponent.description>
+<sp.modulocomponent.modulus.name>Modulus</sp.modulocomponent.modulus.name>
+<sp.modulocomponent.modulus.description>The modulus of the operation. Must be non-zero.</sp.modulocomponent.modulus.description>
+<sp.regexfindcomponent.modulus.name>Modulus</sp.regexfindcomponent.modulus.name>
+<sp.regexfindcomponent.falseoutput.description>The signal this item outputs when the received signal does not match the regular expression.</sp.regexfindcomponent.falseoutput.description>
+<continuousoutput.description>Should the component keep sending the output even after it stops receiving a signal, or only send an output when it receives a signal.</continuousoutput.description>
+<sp.regexfindcomponent.expression.description>The regular expression used to check the incoming signals.</sp.regexfindcomponent.expression.description>
+<sp.smokedetector.output.description>The signal the item outputs when it has detected a fire.</sp.smokedetector.output.description>
+<sp.smokedetector.falseoutput.description>The signal the item outputs when it has not detected a fire.</sp.smokedetector.falseoutput.description>
+<sp.trigonometricfunctioncomponent.useradians.name>Use radians</sp.trigonometricfunctioncomponent.useradians.name>
+<sp.trigonometricfunctioncomponent.useradians.description>If set to true, the trigonometric function uses radians instead of degrees.</sp.trigonometricfunctioncomponent.useradians.description>
+<editor.undohistorybutton>History</editor.undohistorybutton>
+<undo.beginning>Beginning</undo.beginning>
+<undo.beginningtooltip>The beginning of the undo history.</undo.beginningtooltip>
+<undo.removeditem>Deleted [item]</undo.removeditem>
+<undo.removeditemsmultiple>Deleted [count] items</undo.removeditemsmultiple>
+<undo.addeditem>Added [item]</undo.addeditem>
+<undo.addeditemsmultiple>Added [count] items</undo.addeditemsmultiple>
+<undo.changedproperty>Set [property] of [item] to [value]</undo.changedproperty>
+<undo.changedpropertymultiple>Set [property] of [count] items to [value]</undo.changedpropertymultiple>
+<undo.resizeditem>Resized [item]</undo.resizeditem>
+<undo.moveditem>Moved [item]</undo.moveditem>
+<undo.moveditemsmultiple>Moved [count] items</undo.moveditemsmultiple>
+<undo.droppeditem>Dropped [item]</undo.droppeditem>
+<undo.containeditem>Moved [item] inside [container]</undo.containeditem>
+<undo.containeditemsmultiple>Moved [count] items inside [container]</undo.containeditemsmultiple>
+<editor.suppresswarnings>Suppress these warnings for this session.</editor.suppresswarnings>
+<showwires>Wires</showwires>
+<editor.undounavailable>Undo history is not supported in wiring mode</editor.undounavailable>
+<editor.copytoclipboard>Copy to clipboard</editor.copytoclipboard>
+<editortip.shiftforextraoptions>Shift+RMB to show extra options</editortip.shiftforextraoptions>
+<editortip.altforruler>Hold alt to enable ruler</editortip.altforruler>
+<itemassemblyvanillafileexistswarning>There's already a vanilla item assembly with the same name. Overwriting vanilla files is not allowed, please choose another name.</itemassemblyvanillafileexistswarning>
+<cantdeletevanillasub>You cannot delete vanilla submarines.</cantdeletevanillasub>
+<cantdeletemodsub>You cannot delete this submarine because it's part of the mod "[modname]." Please disable the mod from the settings menu instead.</cantdeletemodsub>
+<LoadingPublishedSubmarineHeader>Loading a published submarine</LoadingPublishedSubmarineHeader>
+<LoadingPublishedSubmarineDesc>You are about to load a submarine from a non-local copy of "[modname]."\n\nThe submarine editor is only able to save to a local content package; if you already have a local copy, it's recommended that you load that version instead.\n\nIf you do not have a local copy, you may create one by selecting your mod in the "Publish" tab in the Steam Workshop menu.</LoadingPublishedSubmarineDesc>
+<LoadingSubscribedSubmarineHeader>Loading a Workshop submarine</LoadingSubscribedSubmarineHeader>
+<LoadingSubscribedSubmarineDesc>You are about to load a submarine from a mod you've subscribed to on the Workshop.\n\nThe submarine editor is only able to save to a local content package; saving changes to this submarine will result in multiple submarines with the same name.</LoadingSubscribedSubmarineDesc>
+<LoadingVanillaSubmarineHeader>Loading a Vanilla submarine</LoadingVanillaSubmarineHeader>
+<LoadingVanillaSubmarineDesc>You are about to load a Vanilla submarine.\n\nThe submarine editor is only able to save to a local content package; saving changes to this submarine will result in multiple submarines with the same name.</LoadingVanillaSubmarineDesc>
+<LoadAnyway>Load anyway</LoadAnyway>
+
+<!-- Characters -->
+<MyCharacter>My character</MyCharacter>
+<character.charybdis>Charybdis</character.charybdis>
+<character.coelanth>Coelanth</character.coelanth>
+<character.crawler>Crawler</character.crawler>
+<character.endworm>Endworm</character.endworm>
+<character.doomworm>Doomworm</character.doomworm>
+<character.fractalguardian>Fractal Guardian</character.fractalguardian>
+<character.fractalguardian2>Fractal Guardian</character.fractalguardian2>
+<character.human>Human</character.human>
+<character.humanhusk>Human Husk</character.humanhusk>
+<character.husk>Husk</character.husk>
+<character.mudraptor>Mudraptor</character.mudraptor>
+<character.deathraptor>Deathraptor</character.deathraptor>
+<character.mantis>Mantis</character.mantis>
+<character.moloch>Moloch</character.moloch>
+<character.molochboss>Moloch Boss</character.molochboss>
+<character.tigerthresher>Tiger Thresher</character.tigerthresher>
+<character.tigerthresherboss>Tiger Thresher Boss</character.tigerthresherboss>
+<character.watcher>Watcher</character.watcher>
+<character.hammerhead>Hammerhead</character.hammerhead>
+<character.blackmoloch>Black Moloch</character.blackmoloch>
+<character.hammerheadgold>Golden Hammerhead</character.hammerheadgold>
+<character.hammerheadmatriarch>Hammerhead Matriarch</character.hammerheadmatriarch>
+<character.bonethresher>Bone Thresher</character.bonethresher>
+<character.thalamus>Thalamus</character.thalamus>
+<character.terminalcell>Terminal Cell</character.terminalcell>
+<character.leucocyte>Leucocyte</character.leucocyte>
+<character.molochbaby>Moloch Pupa</character.molochbaby>
+<character.molochblack>Black Moloch</character.molochblack>
+<character.peanut>Peanut</character.peanut>
+<character.orangeboy>Orange Boy</character.orangeboy>
+<character.psilotoad>Psilotoad</character.psilotoad>
+<character.cthulhu>Cthulhu</character.cthulhu>
+<character.hammerheadspawn>Hammerhead Spawn</character.hammerheadspawn>
+<character.spineling>Spineling</character.spineling>
+<ballastflora>Ballast Flora</ballastflora>
+<character.crawlerbroodmother>Crawler Broodmother</character.crawlerbroodmother>
+<character.spineling_giant>Giant Spineling</character.spineling_giant>
+<character.Hammerhead_mNamed>Moping Jack</character.Hammerhead_mNamed>
+<character.Latcher>Latcher</character.Latcher>
+<character.defensebot>Defense Bot</character.defensebot>
+<character.mudraptor_pet>Petraptor</character.mudraptor_pet>
+<npctitle.outpostmanager>Outpost Manager</npctitle.outpostmanager>
+<npctitle.outpostmanagerseparatists>Outpost Manager</npctitle.outpostmanagerseparatists>
+<npctitle.hrmanager>HR Manager</npctitle.hrmanager>
+<npctitle.subupgradenpc>Chief Mechanic</npctitle.subupgradenpc>
+<npctitle.subsalesnpc>Submarine Merchant</npctitle.subsalesnpc>
+<npctitle.merchantoutpost>Merchant</npctitle.merchantoutpost>
+<npctitle.merchantcity>Merchant</npctitle.merchantcity>
+<npctitle.merchantmine>Merchant</npctitle.merchantmine>
+<npctitle.merchantresearch>Merchant</npctitle.merchantresearch>
+<npctitle.merchantmilitary>Merchant</npctitle.merchantmilitary>
+<npctitle.merchantarmory>Arms Dealer</npctitle.merchantarmory>
+<npctitle.merchantmedical>Medicine Merchant</npctitle.merchantmedical>
+<npctitle.merchantengineering>Engineering Merchant</npctitle.merchantengineering>
+<npctitle.outpostdoctor>Outpost Doctor</npctitle.outpostdoctor>
+<charactername.captaintrainee>Captain trainee</charactername.captaintrainee>
+<charactername.engineertrainee>Engineer trainee</charactername.engineertrainee>
+<charactername.mechanictrainee>Mechanic trainee</charactername.mechanictrainee>
+<charactername.securitytrainee>Security trainee</charactername.securitytrainee>
+<charactername.medictrainee>Medic trainee</charactername.medictrainee>
+<charactername.captaininstructor>Captain Sterner</charactername.captaininstructor>
+<charactername.hognose>Captain Hognose</charactername.hognose>
+<charactername.shockjock>William O'Kelly</charactername.shockjock>
+<charactername.raptorowner>Severo Ruiz</charactername.raptorowner>
+<charactername.jacovsubra>Jacov Subra</charactername.jacovsubra>
+<charactername.artiedolittle>Artie Dolittle</charactername.artiedolittle>
+<charactername.stowaway>Titus Zell</charactername.stowaway>
+<charactername.raptorvictim>Rudy</charactername.raptorvictim>
+<charactername.receptiondude>Todd Burdock</charactername.receptiondude>
+<charactername.engineerinstructor>Kayleigh Friar</charactername.engineerinstructor>
+<charactername.mechanicinstructor>Amos Arbor</charactername.mechanicinstructor>
+<charactername.securityinstructor>Ofc. Pérez</charactername.securityinstructor>
+<charactername.medicalinstructor>Dr. James Beem</charactername.medicalinstructor>
+
+<!-- Customization -->
+<clicktoselectjob>Click to select a job</clicktoselectjob>
+<faceattachment.hair>Hair</faceattachment.hair>
+<faceattachment.beard>Beard</faceattachment.beard>
+<faceattachment.moustache>Moustache</faceattachment.moustache>
+<faceattachment.accessories>Accessories</faceattachment.accessories>
+<characterappearance>Appearance</characterappearance>
+
+<!-- Pronouns -->
+<pronounmale>He</pronounmale>
+<pronounpossessivemale>His</pronounpossessivemale>
+<pronounreflexivemale>Himself</pronounreflexivemale>
+<pronounfemale>She</pronounfemale>
+<pronounpossessivefemale>Her</pronounpossessivefemale>
+<pronounreflexivefemale>Herself</pronounreflexivefemale>
+
+<!-- Campaign -->
+<campaignsetup>Campaign Setup</campaignsetup>
+<newcampaign>New campaign</newcampaign>
+<loadcampaign>Load campaign</loadcampaign>
+<loadbutton>Load</loadbutton>
+<deletebutton>Delete</deletebutton>
+<subnotselected>Submarine not selected!</subnotselected>
+<selectsubrequest>Please select a submarine.</selectsubrequest>
+<selectedsub>Selected submarine</selectedsub>
+<savenameinuseheader>Save name already in use</savenameinuseheader>
+<savenameinusetext>Please choose another name for the save file</savenameinusetext>
+<savename>Save name</savename>
+<savefile.defaultname>Save</savefile.defaultname>
+<lastsaved>Last saved</lastsaved>
+<mapseed>Map seed</mapseed>
+<startcampaignbutton>Start</startcampaignbutton>
+<campaignenteroutpostprompt>Do you want to enter [locationname]?</campaignenteroutpostprompt>
+<leavelocation>Select mission and leave [locationname]</leavelocation>
+<selectmission>Select a mission</selectmission>
+<campaignstartingpleasewait>Please wait</campaignstartingpleasewait>
+<campaignstarting>Waiting for the campaign to start.</campaignstarting>
+<campaignsubtooexpensive>This submarine is too expensive to purchase with the starting balance. If you choose it, you will start with 0 marks, and there's a chance the campaign will be easier than intended.</campaignsubtooexpensive>
+<campaignsubincompatible>This submarine has not been marked as compatible with the campaign mode. There's a chance this submarine will make the campaign unbalanced or impossible to complete.</campaignsubincompatible>
+<shuttleselected>Shuttle selected</shuttleselected>
+<shuttlewarning>Most shuttles are not adequately equipped to deal with the dangers of the Europan depths. Are you sure you want to choose a shuttle as your vessel?</shuttlewarning>
+<contentpackagemismatch>Mismatching content package</contentpackagemismatch>
+<contentpackagemismatchwarning>The submarine may not be compatible with the currently selected content packages, because it requires the content packages [requiredcontentpackages]. Are you sure you want to choose the submarine?</contentpackagemismatchwarning>
+<campaignstartfailedsubnotfound>Failed to start a campaign. Submarine [subname] not found.</campaignstartfailedsubnotfound>
+<campaignfiletransferinprogress>Please wait for the campaign save file to finish downloading.</campaignfiletransferinprogress>
+<endcampaignverification>Are you sure you want to quit the campaign? All your unsaved progress will be lost.</endcampaignverification>
+<campaignmode.missingcontentpackage>The content package "[missingcontentpackage]" was in use when saving the campaign, but is not currently enabled.</campaignmode.missingcontentpackage>
+<campaignmode.missingcontentpackages>The content packages [missingcontentpackages] were in use when saving the campaign, but are not currently enabled.</campaignmode.missingcontentpackages>
+<campaignmode.incompatiblecontentpackage>The content package "[incompatiblecontentpackage]" was not in use when saving the campaign.</campaignmode.incompatiblecontentpackage>
+<campaignmode.incompatiblecontentpackages>The content packages [incompatiblecontentpackages] were not in use when saving the campaign.</campaignmode.incompatiblecontentpackages>
+<campaignmode.contentpackageordermismatch>The load order of the content packages was different when saving the campaign ([loadorder]).</campaignmode.contentpackageordermismatch>
+<campaignmode.contentpackagemismatchwarning>Content package mismatches may cause errors or crashes. You may want to switch to the correct packages before continuing the campaign.</campaignmode.contentpackagemismatchwarning>
+<campaignmode.incompatiblesave>The save file is not compatible with this version of Barotrauma.</campaignmode.incompatiblesave>
+<campaignmode.savenotreceived>Accessing the campaign save file from the server, please wait...</campaignmode.savenotreceived>
+<undefinedsubmarineclasswarning>Submarines with an undefined class cannot be used in the campaign!\n\nAre you sure you want to save the submarine without assigning a submarine class?</undefinedsubmarineclasswarning>
+<undefinedsubmarineselected>Submarines with an undefined class cannot be used in the campaign!</undefinedsubmarineselected>
+<nohashsubmarineselected>This submarine doesn't have a valid hash; you may need to wait to download it from the server!</nohashsubmarineselected>
+<campaignstartingmoney>Starting balance: [money] mk</campaignstartingmoney>
+<campaignoption.enableradiation>Enable Jovian radiation</campaignoption.enableradiation>
+<campaignoption.enableradiation.tooltip>The radiation belts around Jupiter are slowly becoming more intense, forcing Europans to delve deeper below the moon's icy crust. In practice, this feature slowly pushes you toward the more dangerous areas of the game, ensuring a gradual increase in difficulty.</campaignoption.enableradiation.tooltip>
+<campaignoption.enablehardcore>Enable Hardcore</campaignoption.enablehardcore>
+<campaignoption.enablehardcore.tooltip>A challenge for expert sailors. Difficulty is increased. Characters gain more experience, but all character progress is lost on death.</campaignoption.enablehardcore.tooltip>
+<campaignoption.enabletutorial>Enable tutorial</campaignoption.enabletutorial>
+<campaignoption.enabletutorial.tooltip>Start the game in a tutorial outpost and learn the basics of navigating through the campaign mode!</campaignoption.enabletutorial.tooltip>
+<radiationtooltip>LETHAL RADIATION\nThe intensity of Jovian radiation has reached lethal levels in this area. Travelling inside the area is strongly díscouraged.</radiationtooltip>
+<nomissionprompt>There are missions available, but you haven't selected any. Are you sure you want to depart without a mission?</nomissionprompt>
+<storename.merchantarmory>Armory</storename.merchantarmory>
+<storename.merchantmedical>Medical Supplies</storename.merchantmedical>
+<storename.merchantengineering>Engineering Supplies</storename.merchantengineering>
+<campaignstore.sellvaluetooltip>When buying things from you, merchants will always offer you less than what you paid for them. Item sell value is further affected by the merchant's balance and your reputation at the outpost, as well as slightly by the mood of the merchant.</campaignstore.sellvaluetooltip>
+<campaignmoney>Balance: [money] mk</campaignmoney>
+<customization.skincolor>Skin Color</customization.skincolor>
+<customization.haircolor>Hair Color</customization.haircolor>
+<customization.facialhaircolor>Facial Hair Color</customization.facialhaircolor>
+<maxmissioncount>Max missions per round</maxmissioncount>
+<maxmissioncounttooltip>How many missions can be selected for a given round.</maxmissioncounttooltip>
+<startingfundsdescription>Starting balance</startingfundsdescription>
+<startingfundstooltip>How much money is received at the start of the campaign. Also affects which starting submarine can be bought.</startingfundstooltip>
+<startingfunds.low>Low</startingfunds.low>
+<startingfunds.medium>Medium</startingfunds.medium>
+<startingfunds.high>High</startingfunds.high>
+<startitemset>Starting supplies</startitemset>
+<startitemsettooltip>How many items will the selected submarine start with.</startitemsettooltip>
+<startitemset.easy>High</startitemset.easy>
+<startitemset.normal>Normal</startitemset.normal>
+<startitemset.hard>Low</startitemset.hard>
+<campaignsettingpreset>Preset</campaignsettingpreset>
+<preset.easy>Easy</preset.easy>
+<preset.normal>Normal</preset.normal>
+<preset.hard>Hard</preset.hard>
+<difficulty.easiest>Easiest</difficulty.easiest>
+<difficulty.challenging>Challenging</difficulty.challenging>
+
+<!-- Campaign menu -->
+<map>Map</map>
+<crew>Crew</crew>
+<campaignmenucrew>Your crew</campaignmenucrew>
+<store>Store</store>
+<outpost>Outpost</outpost>
+<campaignmenuhireable>Hireable people</campaignmenuhireable>
+<hirebutton>Hire</hirebutton>
+<firebutton>Fire</firebutton>
+<firewarningheader>Are you sure?</firewarningheader>
+<firewarningtext>Are you sure you want to fire [charactername] from your crew? You will not be able to hire the character again.</firewarningtext>
+<location>Location</location>
+<hireunavailable>No one available for hire.</hireunavailable>
+<mission>Mission</mission>
+<nomission>No mission</nomission>
+<reward>Reward: [reward] marks</reward>
+<canthiremorecharacters>You cannot hire any more crew.</canthiremorecharacters>
+<medicalclinic.vitalitydifference>Vitality [amount]</medicalclinic.vitalitydifference>
+<medicalclinic.requesttimeout>No response from the server, please try again.</medicalclinic.requesttimeout>
+<medicalclinic.heal>Heal</medicalclinic.heal>
+<medicalclinic.medicalclinic>Medical Clinic</medicalclinic.medicalclinic>
+<medicalclinic.treatall>Treat all</medicalclinic.treatall>
+<medicalclinic.unabletoheal>Healing unavailable</medicalclinic.unabletoheal>
+<medicalclinic.insufficientfunds>You do not have enough marks to afford that.</medicalclinic.insufficientfunds>
+<medicalclinic.healrefused>Due to an ongoing incident at the outpost the medics are currently too busy to help your crew.</medicalclinic.healrefused>
+<sortingmethod.severity>Severity</sortingmethod.severity>
+<medicalclinic.pendingheals>Pending heals</medicalclinic.pendingheals>
+<medicalclinic.treateveryone>Treat everyone</medicalclinic.treateveryone>
+<crewwallet.wallet>Wallet</crewwallet.wallet>
+<crewwallet.bank>Bank</crewwallet.bank>
+<crewwallet.transfer>Transfer</crewwallet.transfer>
+<crewwallet.balance.toomuchtoshow>Lots!</crewwallet.balance.toomuchtoshow>
+<crewwallet.transfer.tooltip>Transfer money into or out of this wallet.</crewwallet.transfer.tooltip>
+<crewwallet.salary>Salary</crewwallet.salary>
+<crewwallet.salary.tooltip>Salary determines the distribution of mission rewards</crewwallet.salary.tooltip>
+<crewwallet.salary.over100toolitp>The sum of reward distribution is over 100% (‖color:gui.orange‖[sum]%‖end‖). The salary will be adjusted to ‖color:gui.orange‖[newvalue]%‖end‖.</crewwallet.salary.over100toolitp>
+<crewwallet.missionreward.get>You receive: ‖color:gui.orange‖[money] mk‖end‖ ([share]%)</crewwallet.missionreward.get>
+<crewwallet.requestmoney>Request</crewwallet.requestmoney>
+<crewwallet.requestbanktoselfvote>[requester] wants to transfer [amount] mk from the bank to their personal wallet.</crewwallet.requestbanktoselfvote>
+<crewwallet.requestselftobankvote>[requester] wants to transfer [amount] mk from their personal wallet to the bank.</crewwallet.requestselftobankvote>
+<crewwallet.requesttransfervote>[requester] wants to transfer [amount] mk from [player1] to [player2].</crewwallet.requesttransfervote>
+<crewwallet.banktoplayer.votepassed>The crew agreed to transfer [amount] marks from the bank to [playername], with [yesvotecount] votes for and [novotecount] against.</crewwallet.banktoplayer.votepassed>
+<crewwallet.banktoplayer.votefailed>The vote to transfer [amount] marks from the bank to [playername] failed, with [yesvotecount] votes for and [novotecount] against.</crewwallet.banktoplayer.votefailed>
+<wallettransferrequestdisabled>The server host has disabled money transfer requests.</wallettransferrequestdisabled>
+<walletdescription>The wallet is a personal storage for money that can be freely spent on various outpost services.</walletdescription>
+<bankdescription>The bank is shared storage for money that cannot be lost on death. Players with permissions can also use the bank as an extension to their wallet when they lack sufficient funds.</bankdescription>
+
+<!-- In-game menus -->
+<credit>Marks</credit>
+<playercredits>Marks: [credits]</playercredits>
+<missioninfo>Mission info</missioninfo>
+<outpostmissions>Outpost missions</outpostmissions>
+<missionreward>Reward: [reward]</missionreward>
+<missionrewardcargopercrate>Reward: [rewardpercrate] x [itemcount] (out of max [maxitemcount]) = [totalreward]</missionrewardcargopercrate>
+<missionrewardcargo>Reward: [totalreward] ([itemcount] crates out of max [maxitemcount])</missionrewardcargo>
+<infobutton>Info</infobutton>
+<endround>End round</endround>
+<enterlocation>Enter [locationname]</enterlocation>
+<leavesubbehind>One of your vessels isn't at the exit yet. Do you want to leave it behind?</leavesubbehind>
+<leavesubsbehind>Some of your vessels aren't at the exit yet. Do you want to leave them behind?</leavesubsbehind>
+
+<!-- In-game messages -->
+<endroundvotes>Votes to end the round [votes]/[max]</endroundvotes>
+<respawnshuttledispatching>Respawn shuttle dispatching in [time]</respawnshuttledispatching>
+<respawnshuttleleavingin>Respawn shuttle leaving in [time]</respawnshuttleleavingin>
+<replacelostshuttles>Replace lost shuttles</replacelostshuttles>
+<replaceshuttles>Replace</replaceshuttles>
+<replaceshuttledockingportoccupied>The lost shuttle cannot be replaced because the docking port is already in use. Clear the docking port before requisitioning a new shuttle.</replaceshuttledockingportoccupied>
+<respawningin>Respawning players in [time]</respawningin>
+<camfollowsubmarine>Follow submarine</camfollowsubmarine>
+<insufficientskills>Your skills may be insufficient to use the item! [requiredskill] level [requiredlevel] required.</insufficientskills>
+<skillincreased>[name]'s [skillname] skill increased to [newlevel]!</skillincreased>
+<crewdeadnorespawns>No living players on the server and respawning is not enabled during this round. If no characters revive or rejoin, the server will end round in [time] seconds.</crewdeadnorespawns>
+<minimapoutpostdockinginfo>Docked to [outpost].\nUndock before attempting to maneuver the submarine.</minimapoutpostdockinginfo>
+<cargospawnnotification>The purchased supplies have been delivered to [roomname].</cargospawnnotification>
+<connectionerrornoresponse>No response from the server. There may be a connection issue at the server's end.</connectionerrornoresponse>
+<radioannouncername>Central command</radioannouncername>
+<toofarfromoutpostwarning>To whoever's out there swimming below the outpost, please head back immediately. It's not safe out there.</toofarfromoutpostwarning>
+<toofarfromoutpostwarning>Hey! You there, below the outpost—what the hell do you think you're doing? I saw you on the sonar and thought you were a crawler for a second! Get back here before someone with an itchier trigger finger gets you killed.</toofarfromoutpostwarning>
+<toofarfromoutpostwarning>To the diver below the outpost: Head back immediately. You're almost out of sonar range, and I really don't want to send a rescue team to save your ass when you get yourself lost.</toofarfromoutpostwarning>
+<handcuffed>You have been handcuffed.</handcuffed>
+<handcuffequipconfirmation>Are you sure you want to handcuff yourself?</handcuffequipconfirmation>
+<autocontroltip>When the light is on, this device is controlled elsewhere.</autocontroltip>
+<reactorheattip>The reactor is generating too much heat. Lower heat or raise turbine output.</reactorheattip>
+<reactortemptip>The reactor isn't generating enough heat to match the turbine's output.</reactortemptip>
+<reactoroutputtip>The reactor is outputting excess power, which will cause damage to devices in the power grid.</reactoroutputtip>
+<killedbytraitornotification>Your death was caused by a traitor on a secret mission…</killedbytraitornotification>
+<endroundsubnotatlevelend>Do you want to abort the mission and end the round now?</endroundsubnotatlevelend>
+<lockedpathtooltip>The passageway is sealed off. You need a permission from an officer in the outpost to transit further.</lockedpathtooltip>
+<lockedpathreputationrequirement>[reputation] reputation needed to unlock: [biomename]</lockedpathreputationrequirement>
+<pathunlockedgeneric>The passageway to the next biome has been opened.</pathunlockedgeneric>
+<respawnquestionprompt>Do you want to respawn now with Reaper's Tax, an affliction that applies an additional penalty to your skills and health, or wait for the next round to spawn?</respawnquestionprompt>
+<respawnquestionpromptrespawn>Respawn with Reaper's Tax</respawnquestionpromptrespawn>
+<respawnquestionpromptwait>I'll wait</respawnquestionpromptwait>
+<respawnwaiting>Respawning players in [time]</respawnwaiting>
+<respawnwaitingformoredeadplayers>Waiting for a respawn... (Players waiting to respawn: [deadplayers]/[requireddeadplayers])</respawnwaitingformoredeadplayers>
+<respawnskillpenalty>You have died and lost [percentage]% of your skill gains.</respawnskillpenalty>
+<turretloaderbroken>Loader broken</turretloaderbroken>
+<autodockverification>The submarine's docking port is trying to automatically dock with the outpost. Are you sure you want to dock?</autodockverification>
+<autoundockverification>The submarine's docking port is trying to automatically undock from the outpost. Are you sure you want to undock?</autoundockverification>
+
+<!-- Server list -->
+<joinserver>Server browser</joinserver>
+<yourname>Player name</yourname>
+<serverip>Server IP</serverip>
+<serverlistname>Name</serverlistname>
+<serverlistplayers>Players</serverlistplayers>
+<serverlistversion>Game version</serverlistversion>
+<serverlisthaspassword>Password</serverlisthaspassword>
+<serverlistusingwhitelist>Using whitelist</serverlistusingwhitelist>
+<serverlistcontentpackages>Content packages</serverlistcontentpackages>
+<serverlistsubselection>Submarine selection</serverlistsubselection>
+<serverlistmodeselection>Game mode selection</serverlistmodeselection>
+<serverlistallowspectating>Allow spectating</serverlistallowspectating>
+<serverlistcompatible>Compatible</serverlistcompatible>
+<serverlistping>Ping</serverlistping>
+<serverlistroundstarted>Round started</serverlistroundstarted>
+<serverlistroundnotstarted>Round has not started</serverlistroundnotstarted>
+<serverlistinfo>Info</serverlistinfo>
+<serverlistrefresh>Scan Servers</serverlistrefresh>
+<serverlistjoin>Join</serverlistjoin>
+<serverlistdirectjoin>Direct Join</serverlistdirectjoin>
+<serverlistunknownversion>Could not determine compatibility (unknown game version)</serverlistunknownversion>
+<serverlistnosteamqueryresponse>Could not determine compatibility with the server because it did not respond to queries. This may happen if the server is down or if the host has not forwarded their query port, but you may still attempt to connect to the server.</serverlistnosteamqueryresponse>
+<serverlistunknowncontentpackage>Could not determine compatibility (unknown content package)</serverlistunknowncontentpackage>
+<serverlistincompatibleversion>This server is not compatible with your version of Barotrauma ([version] required).</serverlistincompatibleversion>
+<serverlistincompatiblecontentpackage>Content package "[contentpackage]" (MD5: [hash]) required to play on this server. By joining this server, you will be prompted to download all missing mods.</serverlistincompatiblecontentpackage>
+<serverlistcontentpackagenotenabled>You need to enable the content package "[contentpackage]" in the game's settings to play on this server.</serverlistcontentpackagenotenabled>
+<serverlistincompatiblecontentpackageworkshopavailable>Content package "[contentpackage]" required to play on this server. By joining this server, you will be prompted to subscribe to all required mods on the Steam Workshop.</serverlistincompatiblecontentpackageworkshopavailable>
+<serverlistsubscribemissingpackages>Get missing packages from Workshop</serverlistsubscribemissingpackages>
+<serverlistsubscribemissingpackagestooltip>Subscribe to the missing content packages in the Steam Workshop and open the Workshop menu where you can download and enable them.</serverlistsubscribemissingpackagestooltip>
+<serverlistsubscribemissingpackagestooltipnosteam>The missing content packages are available in the Steam Workshop, but Steam features are not available if you don't own Barotrauma on Steam.</serverlistsubscribemissingpackagestooltipnosteam>
+<filterservers>Filter servers</filterservers>
+<filterpassword>No password</filterpassword>
+<filterincompatibleservers>Hide incompatible</filterincompatibleservers>
+<filterfullservers>Hide full</filterfullservers>
+<filteremptyservers>Hide empty</filteremptyservers>
+<nomatchingservers>No matching servers found.</nomatchingservers>
+<refreshingserverlist>Refreshing server list...</refreshingserverlist>
+<noservers>Could not find any servers.</noservers>
+<serverlistnosteamconnection>Could not find any servers (not connected to Steam).</serverlistnosteamconnection>
+<masterservererrorlabel>Connection error</masterservererrorlabel>
+<masterservertimeouterror>Could not connect to master server (request timed out).</masterservertimeouterror>
+<masterservererrorexception>Error while connecting to master server { [error] }</masterservererrorexception>
+<masterservererror404>Error while connecting to master server (404 - [masterserverurl] not found)</masterservererror404>
+<masterservererrorunavailable>Error while connecting to master server (505 - Service Unavailable). The master server may be down for maintenance or temporarily overloaded. Please try again in a few moments.</masterservererrorunavailable>
+<masterservererrordefault>Error while connecting to master server ([statuscode]: [statusdescription])</masterservererrordefault>
+<couldnotconnecttoserver>Could not connect to the server.</couldnotconnecttoserver>
+<invalidipaddress>Failed to resolve address "[serverip]:[port]." Please make sure you have entered a valid IP address.</invalidipaddress>
+<connecting>CONNECTING</connecting>
+<disconnect>Disconnect</disconnect>
+<disconnecting>Disconnecting</disconnecting>
+<passwordrequired>Password required</passwordrequired>
+<connectionlost>Connection lost</connectionlost>
+<connectionlostreconnecting>You have been disconnected from the server. Reconnecting...</connectionlostreconnecting>
+<connectionfailed>Connecting failed</connectionfailed>
+<connectingto>Connecting to [serverip]</connectingto>
+<serverfullquestionprompt>Do you want to join the server queue and wait for a slot to free up?</serverfullquestionprompt>
+<serverqueue>Queue</serverqueue>
+<serverqueuepleasewait>Please wait...</serverqueuepleasewait>
+<waitinginserverqueue>Waiting for a slot to free up on the server.</waitinginserverqueue>
+<messagereaderror>Error while reading a message from the server. ([message] [targetsite])</messagereaderror>
+<cheatsenabledtitle>Cheats enabled.</cheatsenabledtitle>
+<cheatsenableddescription>Cheat commands have been enabled on this server. You cannot get Steam Achievements during this play session.</cheatsenableddescription>
+<pleasewait>Please wait</pleasewait>
+<serverplaystyle>Playstyle</serverplaystyle>
+<servertags>Server tags</servertags>
+<servermotd>Message of the day</servermotd>
+<serverbanner>Server banner</serverbanner>
+<serverlogo>Server logo</serverlogo>
+<servertagline>Tagline</servertagline>
+<serverendpoint>Server IP / SteamID</serverendpoint>
+<serveroffline>The server seems to be offline.</serveroffline>
+<forbiddenservernameverification>Your server will be hidden from the server list by default because it contains the word "[forbiddenword]." Are you sure you want to name your server "[servername]"?</forbiddenservernameverification>
+<filteroffensiveservers>Hide offensive server names</filteroffensiveservers>
+<filteroffensiveserverstooltip>Filters out servers with certain offensive words in the name. You can add or remove disallowed words by editing the file Data/forbiddenwordlist.txt in the game folder.</filteroffensiveserverstooltip>
+<filteroffensiveserversprompt>Would you like to automatically hide servers with offensive words in their names? You can also add or remove disallowed words by editing the file Data/forbiddenwordlist.txt in the game folder.</filteroffensiveserversprompt>
+<steamp2pserver>Player-hosted server</steamp2pserver>
+<dedicatedserver>Dedicated server</dedicatedserver>
+<serverprocessclosed>The server process has closed unexpectedly.</serverprocessclosed>
+<serverprocesscrashed>The server process has crashed. A crash report ([reportfilepath]) has been generated in the game's root directory.</serverprocesscrashed>
+<Region>Region</Region>
+<AllLanguages>All</AllLanguages>
+
+<!-- Disconnect reasons -->
+<disconnectreason.banned>You have been banned from the server.</disconnectreason.banned>
+<disconnectreason.kicked>You have been kicked from the server.</disconnectreason.kicked>
+<disconnectreason.servershutdown>The server has shut down.</disconnectreason.servershutdown>
+<disconnectreason.serverfull>The server is full.</disconnectreason.serverfull>
+<disconnectreason.authenticationrequired>Client did not properly request authentication.</disconnectreason.authenticationrequired>
+<disconnectreason.steamauthenticationrequired>Steam authentication required. Please make sure Steam is running and you are logged in to an account.</disconnectreason.steamauthenticationrequired>
+<disconnectreason.steamauthenticationfailed>Steam authentication failed.</disconnectreason.steamauthenticationfailed>
+<disconnectreason.sessiontaken>Your session was taken by a new connection on the same IP address.</disconnectreason.sessiontaken>
+<disconnectreason.toomanyfailedlogins>Too many failed login attempts.</disconnectreason.toomanyfailedlogins>
+<disconnectreason.noname>No name given.</disconnectreason.noname>
+<disconnectreason.invalidname>Your name contains symbols disallowed by the server host. Please enter another name in the "Player name" field in the server browser.</disconnectreason.invalidname>
+<disconnectreason.nametaken>That name is taken.</disconnectreason.nametaken>
+<disconnectreason.invalidversion>Non-matching game version.</disconnectreason.invalidversion>
+<disconnectreason.missingcontentpackage>Missing content package.</disconnectreason.missingcontentpackage>
+<disconnectreason.incompatiblecontentpackage>Incompatible content package.</disconnectreason.incompatiblecontentpackage>
+<disconnectreason.notonwhitelist>You are not on the server's whitelist.</disconnectreason.notonwhitelist>
+<disconnectreason.servercrashed>The server has crashed.</disconnectreason.servercrashed>
+<disconnectmessage.afk>You have been away from keyboard for too long.</disconnectmessage.afk>
+<disconnectmessage.steamauthnolongervalid>Steam authentication is no longer valid ([status]).</disconnectmessage.steamauthnolongervalid>
+<disconnectmessage.toomanyfailedlogins>Too many failed login attempts.</disconnectmessage.toomanyfailedlogins>
+<disconnectmessage.invalidversion>Version "[version]" required to connect to the server (your version: "[clientversion]").</disconnectmessage.invalidversion>
+<disconnectmessage.missingcontentpackage>You need the content package [missingcontentpackage] to play on the server.</disconnectmessage.missingcontentpackage>
+<disconnectmessage.missingcontentpackages>You need the content packages [missingcontentpackages] to play on the server.</disconnectmessage.missingcontentpackages>
+<disconnectmessage.incompatiblecontentpackage>You must disable the content package [incompatiblecontentpackage] before joining.</disconnectmessage.incompatiblecontentpackage>
+<disconnectmessage.incompatiblecontentpackages>You must disable the content packages [incompatiblecontentpackages] before joining.</disconnectmessage.incompatiblecontentpackages>
+<disconnectreason.steamp2perror>SteamP2P connection could not be established.</disconnectreason.steamp2perror>
+<disconnectreason.steamp2ptimeout>SteamP2P connection timed out.</disconnectreason.steamp2ptimeout>
+<DisconnectReason.Timeout>Connection timed out.</DisconnectReason.Timeout>
+<ChatMsg.DisconnectedWithReason>[client] has disconnected. Reason: [reason]</ChatMsg.DisconnectedWithReason>
+<ChatMsg.DisconnectReason.Unknown>Unknown</ChatMsg.DisconnectReason.Unknown>
+<ChatMsg.DisconnectReason.Banned>Banned</ChatMsg.DisconnectReason.Banned>
+<ChatMsg.DisconnectReason.Kicked>Kicked</ChatMsg.DisconnectReason.Kicked>
+<ChatMsg.DisconnectReason.ServerShutdown>Server shut down</ChatMsg.DisconnectReason.ServerShutdown>
+<ChatMsg.DisconnectReason.ServerCrashed>Server crashed</ChatMsg.DisconnectReason.ServerCrashed>
+<ChatMsg.DisconnectReason.ServerFull>Server full</ChatMsg.DisconnectReason.ServerFull>
+<ChatMsg.DisconnectReason.AuthenticationRequired>Connection authentication failed</ChatMsg.DisconnectReason.AuthenticationRequired>
+<ChatMsg.DisconnectReason.SteamAuthenticationFailed>Steam authentication failed</ChatMsg.DisconnectReason.SteamAuthenticationFailed>
+<ChatMsg.DisconnectReason.SessionTaken>Session taken</ChatMsg.DisconnectReason.SessionTaken>
+<ChatMsg.DisconnectReason.TooManyFailedLogins>Too many failed logins</ChatMsg.DisconnectReason.TooManyFailedLogins>
+<ChatMsg.DisconnectReason.InvalidName>Invalid name</ChatMsg.DisconnectReason.InvalidName>
+<ChatMsg.DisconnectReason.NameTaken>Name taken</ChatMsg.DisconnectReason.NameTaken>
+<ChatMsg.DisconnectReason.InvalidVersion>Version mismatch</ChatMsg.DisconnectReason.InvalidVersion>
+<ChatMsg.DisconnectReason.SteamP2PError>SteamP2P error</ChatMsg.DisconnectReason.SteamP2PError>
+<ChatMsg.DisconnectReason.Timeout>Timed out</ChatMsg.DisconnectReason.Timeout>
+<ChatMsg.DisconnectReason.ExcessiveDesyncOldEvent>Event desync (waiting for old event)</ChatMsg.DisconnectReason.ExcessiveDesyncOldEvent>
+<ChatMsg.DisconnectReason.ExcessiveDesyncRemovedEvent>Event desync (waiting for removed event)</ChatMsg.DisconnectReason.ExcessiveDesyncRemovedEvent>
+<ChatMsg.DisconnectReason.SyncTimeout>Event desync (timed out)</ChatMsg.DisconnectReason.SyncTimeout>
+<ChatMsg.DisconnectReason.SteamP2PTimeOut>SteamP2P timed out</ChatMsg.DisconnectReason.SteamP2PTimeOut>
+
+<!-- Server lobby -->
+<restartingin>Restarting in</restartingin>
+<votes>Votes</votes>
+<manual>Manual</manual>
+<vote>Vote</vote>
+<gamemode>Game mode</gamemode>
+<missiontype>Mission type</missiontype>
+<random>Random</random>
+<levelseed>Level seed</levelseed>
+<leveldifficulty>Difficulty</leveldifficulty>
+<difficulty.easy>Easy</difficulty.easy>
+<difficulty.medium>Medium</difficulty.medium>
+<difficulty.hard>Hard</difficulty.hard>
+<difficulty.hellish>Hellish</difficulty.hellish>
+<leveldifficultyexplanation>The difficulty setting affects how the level is generated and what kinds of random encounters you may face during the mission. Expect more environmental hazards, larger numbers of creatures and more dangerous enemies on higher difficulty levels.</leveldifficultyexplanation>
+<traitors>Traitors</traitors>
+<botcount>Bot count</botcount>
+<botspawnmode>Bot spawn mode</botspawnmode>
+<botspawnmode.normal.tooltip>Adds the specified amount of bots to the crew.</botspawnmode.normal.tooltip>
+<botspawnmode.fill.tooltip>Adds enough bots to make the total size of the crew equal to the specified value.</botspawnmode.fill.tooltip>
+<botspawn.campaignnote>In the campaign mode, the bots only spawn when you start the campaign for the first time. New bots need to be hired from the outposts.</botspawn.campaignnote>
+<normal>Normal</normal>
+<fill>Fill</fill>
+<autorestart>Automatic restart</autorestart>
+<serverlog>Server log</serverlog>
+<campaignview>Campaign view</campaignview>
+<createnew>Create New</createnew>
+<playyourself>Play yourself</playyourself>
+<startgamebutton>Start</startgamebutton>
+<readytostarttickbox>Ready to start</readytostarttickbox>
+<roundstartingpleasewait>Please wait</roundstartingpleasewait>
+<roundstarting>Waiting for the round to start.</roundstarting>
+<serversettingsbutton>Settings</serversettingsbutton>
+<spectatebutton>Spectate</spectatebutton>
+<gender>Gender</gender>
+<jobpreferences>Job preferences</jobpreferences>
+<randompreferences>Random Preferences</randompreferences>
+<playingasspectator>Playing as a spectator</playingasspectator>
+<subnotfound>Submarine not found in your submarine folder</subnotfound>
+<subdoesntmatch>Your version of the submarine doesn't match the server's version</subdoesntmatch>
+<rank>Rank</rank>
+<customrank>Custom</customrank>
+<permissions>Permissions</permissions>
+<kick>Kick</kick>
+<votetokick>Vote to kick</votetokick>
+<ban>Ban</ban>
+<banrange>Ban range</banrange>
+<banreasonprompt>Reason for the ban?</banreasonprompt>
+<kickreasonprompt>Reason for kicking?</kickreasonprompt>
+<privatemessagetag>[PM]</privatemessagetag>
+<subnotfounderror>Submarine [subname] was selected by the server. Matching file not found in your submarine folder.</subnotfounderror>
+<subloaderror>Could not load submarine [subname]. The file may be corrupted.</subloaderror>
+<subdoesntmatcherror>Your version of the submarine file [subname] does not match the server's version!\nYour MD5 hash: [myhash]\nServer's MD5 hash: [serverhash]\n</subdoesntmatcherror>
+<subnotdownloaded>Submarine not downloaded</subnotdownloaded>
+<downloadsublabel>Submarine not found!</downloadsublabel>
+<downloadsubquestion>Do you want to download the file from the server host?</downloadsubquestion>
+<waitforfiletransfers>Waiting for file transfers to finish before starting the round...</waitforfiletransfers>
+<startnow>Start now</startnow>
+<serverinitfailed>Starting the server failed.</serverinitfailed>
+<serverinitfailedaddressalreadyinuse>[errormsg]. Are you trying to run multiple servers on the same port?</serverinitfailedaddressalreadyinuse>
+<permissionsremoved>The host has removed all your special permissions.</permissionsremoved>
+<currentpermissions>Current permissions:</currentpermissions>
+<permissionschanged>Permissions changed</permissionschanged>
+<permittedconsolecommands>Permitted console commands:</permittedconsolecommands>
+<pleasewaitroundrunning>Please wait</pleasewaitroundrunning>
+<roundrunningspectatedisabled>A round is already running and the admin has disabled spectating. You will have to wait for a new round to start.</roundrunningspectatedisabled>
+<roundrunningspectateenabled>A round is already running, but you can spectate the game while waiting for a respawn shuttle or a new round.</roundrunningspectateenabled>
+<serverdownloadfinished>Download finished</serverdownloadfinished>
+<downloadingfile>Downloading [filename]</downloadingfile>
+<filedownloadednotification>File "[filename]" was downloaded successfully.</filedownloadednotification>
+<newcampaigncharacterheader>Are you sure?</newcampaigncharacterheader>
+<newcampaigncharactertext>Creating a new character will discard your previous character, and you will lose all your skill progress and all the items in your possession. Do you wish to create a new character?</newcampaigncharactertext>
+<mute>Mute</mute>
+<unmute>Unmute</unmute>
+<mutedlocally>Muted Locally</mutedlocally>
+<mutedglobally>Muted Globally</mutedglobally>
+<mutedbyserver>You have been muted by the server.</mutedbyserver>
+<unmutedbyserver>You have been unmuted by the server.</unmutedbyserver>
+<viewsteamprofile>View Steam profile</viewsteamprofile>
+<serverlisttab.all>All servers</serverlisttab.all>
+<serverlisttab.favorites>Favorites</serverlisttab.favorites>
+<serverlisttab.recent>Recent</serverlisttab.recent>
+<addtofavorites>Add to favorites</addtofavorites>
+<removefromfavorites>Remove from favorites</removefromfavorites>
+<servertag.casual>Casual</servertag.casual>
+<servertagdescription.casual>Having fun is more important than completing the objective. A good choice for new players.</servertagdescription.casual>
+<servertag.serious>Serious</servertag.serious>
+<servertagdescription.serious>The crew should focus on working together efficiently and completing their objective. No unnecessary messing around.</servertagdescription.serious>
+<servertag.roleplay>Roleplay</servertag.roleplay>
+<servertagdescription.roleplay>The crew should aim to act like a real submarine crew. Chain of command is important, as is taking care of your responsibilities and following orders. Speaking out-of-character should be avoided when a round is running.</servertagdescription.roleplay>
+<servertag.somethingdifferent>Something different</servertag.somethingdifferent>
+<servertagdescription.somethingdifferent>Gameplay differs significantly from the usual Barotrauma gameplay. Modded servers, very unconventional subs, battle royale rounds, shuttle racing, deathrun maps... Anything goes!</servertagdescription.somethingdifferent>
+<servertag.rampage>Rampage</servertag.rampage>
+<servertagdescription.rampage>Get ready to fight for your life! A server heavily geared toward combat. This can mean player-versus-player combat, PvE or both—the server description should include guidelines as to what kind of violence is allowed on the server.</servertagdescription.rampage>
+<servertag.modded.true>Modded</servertag.modded.true>
+<servertagdescription.modded.true>One or more mods enabled. Installing mods from the Workshop may be required to join the server.</servertagdescription.modded.true>
+<servertag.modded.false>Vanilla</servertag.modded.false>
+<servertagdescription.modded.false>The server is not using any mods.</servertagdescription.modded.false>
+<servertag.247.true>24/7</servertag.247.true>
+<servertagdescription.247.true>Runs around the clock.</servertagdescription.247.true>
+<servertag.247.false>Occasionally up</servertag.247.false>
+<servertagdescription.247.false>The server is not run 24/7.</servertagdescription.247.false>
+<servertagdescription.friendlyfire.true>Causing damage to your crew mates is enabled.</servertagdescription.friendlyfire.true>
+<servertagdescription.friendlyfire.false>Causing damage to your crew mates is disabled.</servertagdescription.friendlyfire.false>
+<servertagdescription.voip.true>Voice chat is enabled.</servertagdescription.voip.true>
+<servertagdescription.voip.false>Voice chat is disabled.</servertagdescription.voip.false>
+<servertagdescription.karma.true>Karma system is enabled.</servertagdescription.karma.true>
+<servertagdescription.karma.false>Karma system is disabled.</servertagdescription.karma.false>
+<servertagdescription.traitors.true>Traitors are enabled on the server.</servertagdescription.traitors.true>
+<servertagdescription.traitors.false>Traitors are disabled on the server.</servertagdescription.traitors.false>
+<servertag.friendlyfire.label>Friendly fire</servertag.friendlyfire.label>
+<servertag.friendlyfire.true>On</servertag.friendlyfire.true>
+<servertag.friendlyfire.false>Off</servertag.friendlyfire.false>
+<servertag.voip.label>Voice chat</servertag.voip.label>
+<servertag.voip.true>Enabled</servertag.voip.true>
+<servertag.voip.false>Disabled</servertag.voip.false>
+<servertag.karma.label>Karma</servertag.karma.label>
+<servertag.karma.true>Enabled</servertag.karma.true>
+<servertag.karma.false>Disabled</servertag.karma.false>
+<servertag.traitors.label>Traitors</servertag.traitors.label>
+<servertag.traitors.true>Enabled</servertag.traitors.true>
+<servertag.traitors.false>Disabled</servertag.traitors.false>
+<servertag.modded.label>Mods</servertag.modded.label>
+<friendplayingbarotrauma>Playing Barotrauma</friendplayingbarotrauma>
+<friendplayinganothergame>Playing another game</friendplayinganothergame>
+<friendnotplaying>Not playing</friendnotplaying>
+<FriendPlayingOnServer>Playing on [servername]</FriendPlayingOnServer>
+<serversettingsplaystyle>Play style</serversettingsplaystyle>
+<serversettingsallowfriendlyfire>Allow friendly fire</serversettingsallowfriendlyfire>
+<serversettingsallowrewiring>Allow rewiring</serversettingsallowrewiring>
+<serversettingsallowdisguises>Allow disguises</serversettingsallowdisguises>
+<serversettingsallowwifichat>Allow linking wifi components to chat</serversettingsallowwifichat>
+<filtersameversion>Same version</filtersameversion>
+<filterwhitelistedservers>Show whitelisted</filterwhitelistedservers>
+<giverankprompt>Are you sure you want to give the rank [rank] to [user]?</giverankprompt>
+<clearrankprompt>Are you sure you want to remove all special permissions from [user]?</clearrankprompt>
+<campaignstartfailedroundrunning>Could not start a new campaign. Please end the current round first.</campaignstartfailedroundrunning>
+<campaigncontinue>Continue</campaigncontinue>
+<returntoserverlobby>Server lobby</returntoserverlobby>
+<pausemenureturntoserverlobbyverification>Are you sure you want to return to the server lobby? All your unsaved progress will be lost.</pausemenureturntoserverlobbyverification>
+<purchasablesubmarines>Purchasable submarines</purchasablesubmarines>
+<teampreference.team1>Coalition</teampreference.team1>
+<teampreference.team2>Separatist</teampreference.team2>
+<teampreference.nopreference>No preference</teampreference.nopreference>
+<waitforsubmarinehashcalculations>Calculating submarine hashes (which are used for determining compatibility with clients) before starting the server. If you run into this warning often, you may want to uninstall some of your custom submarines.</waitforsubmarinehashcalculations>
+<disconnectmessage.mismatchedworkshopmod>The following content package is different from the server's: [incompatiblecontentpackage]. Either you or the server host may need to reinstall it in the Workshop menu.</disconnectmessage.mismatchedworkshopmod>
+<disconnectmessage.mismatchedworkshopmods>The following content packages are different from the server's: [incompatiblecontentpackages]. Either you or the server host may need to reinstall them in the Workshop menu.</disconnectmessage.mismatchedworkshopmods>
+<submarinevisibility>Submarine visibility</submarinevisibility>
+<visiblesubmarines>Visible</visiblesubmarines>
+<hiddensubmarines>Hidden</hiddensubmarines>
+<clicktowriteservermessage>Click here to write a server message</clicktowriteservermessage>
+<teampreference>Preferred team: [team]</teampreference>
+<jobpreference>Preferred job: [job]</jobpreference>
+<campaigndifficultydisabled>Difficulty cannot be adjusted in the campaign mode. The campaign follows a pre-defined difficulty curve.</campaigndifficultydisabled>
+<WaitingForStartGameFinalizeTakingTooLong>Starting the round seems to be taking unusually long. Do you want to stop waiting for a response from the server and return to the server lobby?</WaitingForStartGameFinalizeTakingTooLong>
+
+<!-- Server log -->
+<serverlog.filter>Filter</serverlog.filter>
+<serverlog.chatmessage>Chat message</serverlog.chatmessage>
+<serverlog.iteminteraction>Item interaction</serverlog.iteminteraction>
+<serverlog.inventoryusage>Inventory usage</serverlog.inventoryusage>
+<serverlog.attackdeath>Attack &amp; death</serverlog.attackdeath>
+<serverlog.spawning>Spawning</serverlog.spawning>
+<serverlog.servermessage>Server message</serverlog.servermessage>
+<serverlog.consoleusage>Console usage</serverlog.consoleusage>
+<serverlog.error>Error</serverlog.error>
+<serverlog.wiring>Wiring</serverlog.wiring>
+<serverlog.karma>Karma</serverlog.karma>
+<serverlog.talent>Talents</serverlog.talent>
+<serverlog.money>Money transfer</serverlog.money>
+<serverlog.dosprotection>DoS protection</serverlog.dosprotection>
+
+<!-- Server chat messages -->
+<servermessage.reason>Reason</servermessage.reason>
+<servermessage.joinedserver>[client] has joined the server.</servermessage.joinedserver>
+<servermessage.kickedfromserver>[client] has been kicked from the server.</servermessage.kickedfromserver>
+<servermessage.kickedbyvote>Kicked by vote.</servermessage.kickedbyvote>
+<servermessage.kickedbyvoteautoban>Kicked by vote (auto ban).</servermessage.kickedbyvoteautoban>
+<servermessage.youleftserver>You have left the server.</servermessage.youleftserver>
+<servermessage.clientleftserver>[client] has left the server.</servermessage.clientleftserver>
+<servermessage.hasvotedtokick>[initiator] has voted to kick [target].</servermessage.hasvotedtokick>
+<servermessage.kickedby>Kicked by [initiator].</servermessage.kickedby>
+<servermessage.bannedby>Banned by [initiator].</servermessage.bannedby>
+<servermessage.bannedfromserver>[client] has been banned from the server.</servermessage.bannedfromserver>
+<servermessage.hasdisconnected>[client] has disconnected.</servermessage.hasdisconnected>
+<servermessage.excessivedesync>You have been disconnected because of a networking error.</servermessage.excessivedesync>
+<servermessage.excessivedesyncoldevent>You have been disconnected because your client was expecting a very old network event.</servermessage.excessivedesyncoldevent>
+<servermessage.excessivedesyncremovedevent>You have been disconnected because your client was expecting a removed network event.</servermessage.excessivedesyncremovedevent>
+<servermessage.synctimeout>You have been disconnected because syncing your client with the server took too long.</servermessage.synctimeout>
+<servermessage.shuttleleaving>The shuttle will automatically return back to the outpost. Please leave the shuttle immediately.</servermessage.shuttleleaving>
+<servermessage.howtocommunicate>Press [chatbutton] to type in chat or [pttbutton] to talk when using push-to-talk mode. Use [switchbutton] to switch between local and radio chat.</servermessage.howtocommunicate>
+<servermessage.playernotfound>Player [player] not found!</servermessage.playernotfound>
+<servermessage.previousclientname>[client] previously used the name "[previousname]" on the server.</servermessage.previousclientname>
+<servermessage.privatemessagesnotallowed>Private messages are not allowed when the game is running and either you or the recipient is alive.</servermessage.privatemessagesnotallowed>
+<servermessage.namechangefailedsymbols>Could not change your name to [newname] (the name contains prohibited symbols).</servermessage.namechangefailedsymbols>
+<servermessage.namechangefailedservertoosimilar>Could not change your name to [newname] (too similar to the server's name).</servermessage.namechangefailedservertoosimilar>
+<servermessage.namechangefailedvotekick>Could not change your name to [newname] (a vote to kick has been initiated).</servermessage.namechangefailedvotekick>
+<servermessage.namechangefailedclienttoosimilar>Could not change your name to [newname] (too similar to the name of the client [takenname]).</servermessage.namechangefailedclienttoosimilar>
+<servermessage.namechangesuccessful>Player [oldname] has changed their name to [newname].</servermessage.namechangesuccessful>
+<ServerMessage.NameChangeFailedCooldownActive>You are not allowed to change your name this often. Please wait [seconds] seconds.</ServerMessage.NameChangeFailedCooldownActive>
+<ServerMessage.kickvotedisallowed>You need to stay in the server longer before you're allowed to vote for kicking someone.</ServerMessage.kickvotedisallowed>
+
+<!-- Client permissions -->
+<clientpermission.none>None</clientpermission.none>
+<clientpermission.all>All</clientpermission.all>
+<clientpermission.endround>End round</clientpermission.endround>
+<clientpermission.kick>Kick</clientpermission.kick>
+<clientpermission.ban>Ban</clientpermission.ban>
+<clientpermission.unban>Revoke ban</clientpermission.unban>
+<clientpermission.selectsub>Select sub</clientpermission.selectsub>
+<clientpermission.selectmode>Select mode</clientpermission.selectmode>
+<clientpermission.managecampaign>Manage campaign</clientpermission.managecampaign>
+<clientpermission.consolecommands>Console commands</clientpermission.consolecommands>
+<clientpermission.serverlog>Server log</clientpermission.serverlog>
+<clientpermission.manageround>Manage round</clientpermission.manageround>
+<clientpermission.managesettings>Manage settings</clientpermission.managesettings>
+<clientpermission.managepermissions>Manage permissions</clientpermission.managepermissions>
+<clientpermission.buyitems>Buy items</clientpermission.buyitems>
+<clientpermission.campaignstore>Campaign store</clientpermission.campaignstore>
+<clientpermission.managecampaign.description>Allowed to manage all aspects of the campaign (saving, loading, map, buying and selling, money, hires).</clientpermission.managecampaign.description>
+<clientpermission.karmaimmunity>Karma immunity</clientpermission.karmaimmunity>
+<clientpermission.karmaimmunity.description>Immune to the effects of the karma system.</clientpermission.karmaimmunity.description>
+<clientpermission.sellinventoryitems>Sell inventory items</clientpermission.sellinventoryitems>
+<clientpermission.sellinventoryitems.description>Sell items from your own inventory in the campaign stores.</clientpermission.sellinventoryitems.description>
+<clientpermission.sellsubitems>Sell submarine items</clientpermission.sellsubitems>
+<clientpermission.sellsubitems.description>Sell items from the submarine in the campaign stores.</clientpermission.sellsubitems.description>
+<clientpermission.managemap>Manage map</clientpermission.managemap>
+<clientpermission.managemap.description>Choose the destination and missions in the campaign mode.</clientpermission.managemap.description>
+<clientpermission.managemoney>Manage money</clientpermission.managemoney>
+<clientpermission.managemap.description>Access the crew's shared funds in the bank and distribute mission rewards to the crew in the campaign mode.</clientpermission.managemap.description>
+<clientpermission.managehires>Manage hires</clientpermission.managehires>
+<clientpermission.managehires.description>Hire new crewmembers or fire members of the current crew.</clientpermission.managehires.description>
+<clientpermission.managebottalents>Manage talents</clientpermission.managebottalents>
+<clientpermission.spamimmunity>Spam Protection Immunity</clientpermission.spamimmunity>
+<clientpermission.spamimmunity.description>Immune to being automatically kicked for sending too many network messages or spamming the chat.</clientpermission.spamimmunity.description>
+
+<!-- Permission presets -->
+<permissionpresetname.admin>Admin</permissionpresetname.admin>
+<permissionpresetdescription.admin>Allowed to ban and kick players, manage round settings, access server logs and use nearly all console commands.</permissionpresetdescription.admin>
+<permissionpresetname.moderator>Moderator</permissionpresetname.moderator>
+<permissionpresetdescription.moderator>Allowed to manage round settings, kick players and access server logs.</permissionpresetdescription.moderator>
+<permissionpresetname.none>None</permissionpresetname.none>
+<permissionpresetdescription.none>No special privileges.</permissionpresetdescription.none>
+
+<!-- Mission types -->
+<missiontype.none>None</missiontype.none>
+<missiontype.random>Random</missiontype.random>
+<missiontype.salvage>Salvage</missiontype.salvage>
+<missiontype.monster>Monster</missiontype.monster>
+<missiontype.cargo>Cargo</missiontype.cargo>
+<missiontype.combat>Combat</missiontype.combat>
+<missiontype.personneltransport>Personnel Transport</missiontype.personneltransport>
+<missiontype.swarm>Swarm</missiontype.swarm>
+<missiontype.prospect>Prospecting</missiontype.prospect>
+<missiontype.nest>Nest</missiontype.nest>
+<missiontype.mineral>Mining</missiontype.mineral>
+<missiontype.beacon>Beacon</missiontype.beacon>
+<missiontype.abandonedoutpost>Abandoned outpost</missiontype.abandonedoutpost>
+<missiontype.outpostdestroy>Destroy outpost</missiontype.outpostdestroy>
+<missiontype.outpostrescue>Outpost rescue</missiontype.outpostrescue>
+<missiontype.clearalienruins>Alien ruins</missiontype.clearalienruins>
+<missiontype.scanalienruins>Scan</missiontype.scanalienruins>
+<missiontype.escort>Escort</missiontype.escort>
+<missiontype.pirate>Pirate</missiontype.pirate>
+
+<!-- Mission descriptions -->
+<missionname.salvageskyholderartifactruins>Salvaging an artifact</missionname.salvageskyholderartifactruins>
+<missiondescription.salvageskyholderartifactruins>Researchers of [location1] have picked up an infrasonic signal highly similar to those emitted by alien artifacts previously discovered on Europa. Investigate the signal and retrieve the potential artifact.</missiondescription.salvageskyholderartifactruins>
+<missionsonarlabel.salvageskyholderartifactruins>Infrasonic signal</missionsonarlabel.salvageskyholderartifactruins>
+<missionsuccess.salvageskyholderartifactruins>The artifact has been successfully retrieved.</missionsuccess.salvageskyholderartifactruins>
+<missionfailure.salvageskyholderartifactruins>Retrieving the artifact failed.</missionfailure.salvageskyholderartifactruins>
+<missionheader0.salvageskyholderartifactruins>Artifact collected</missionheader0.salvageskyholderartifactruins>
+<missionmessage0.salvageskyholderartifactruins>The artifact is now on board. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.salvageskyholderartifactruins>
+<missionname.salvagethermalartifactruins>Salvaging an artifact</missionname.salvagethermalartifactruins>
+<missiondescription.salvagethermalartifactruins>Researchers of [location1] have picked up an infrasonic signal highly similar to those emitted by alien artifacts previously discovered on Europa. Investigate the signal and retrieve the potential artifact.</missiondescription.salvagethermalartifactruins>
+<missionsonarlabel.salvagethermalartifactruins>Infrasonic signal</missionsonarlabel.salvagethermalartifactruins>
+<missionsuccess.salvagethermalartifactruins>The artifact has been successfully retrieved.</missionsuccess.salvagethermalartifactruins>
+<missionfailure.salvagethermalartifactruins>Retrieving the artifact failed.</missionfailure.salvagethermalartifactruins>
+<missionheader0.salvagethermalartifactruins>Artifact collected</missionheader0.salvagethermalartifactruins>
+<missionmessage0.salvagethermalartifactruins>The artifact is now on board. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.salvagethermalartifactruins>
+<missionname.salvagethermalartifactcave>Salvaging an artifact</missionname.salvagethermalartifactcave>
+<missiondescription.salvagethermalartifactcave>Researchers of [location1] have picked up an infrasonic signal highly similar to those emitted by alien artifacts previously discovered on Europa. Investigate the signal and retrieve the potential artifact.</missiondescription.salvagethermalartifactcave>
+<missionsonarlabel.salvagethermalartifactcave>Infrasonic signal</missionsonarlabel.salvagethermalartifactcave>
+<missionsuccess.salvagethermalartifactcave>The artifact has been successfully retrieved.</missionsuccess.salvagethermalartifactcave>
+<missionfailure.salvagethermalartifactcave>Retrieving the artifact failed.</missionfailure.salvagethermalartifactcave>
+<missionheader0.salvagethermalartifactcave>Artifact collected</missionheader0.salvagethermalartifactcave>
+<missionmessage0.salvagethermalartifactcave>The artifact is now on board. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.salvagethermalartifactcave>
+<missionname.salvagenasonovartifactcave>Salvaging an artifact</missionname.salvagenasonovartifactcave>
+<missiondescription.salvagenasonovartifactcave>Researchers of [location1] have picked up an infrasonic signal highly similar to those emitted by alien artifacts previously discovered on Europa. Investigate the signal and retrieve the potential artifact.</missiondescription.salvagenasonovartifactcave>
+<missionsonarlabel.salvagenasonovartifactcave>Infrasonic signal</missionsonarlabel.salvagenasonovartifactcave>
+<missionsuccess.salvagenasonovartifactcave>The artifact has been successfully retrieved.</missionsuccess.salvagenasonovartifactcave>
+<missionfailure.salvagenasonovartifactcave>Retrieving the artifact failed.</missionfailure.salvagenasonovartifactcave>
+<missionheader0.salvagenasonovartifactcave>Artifact collected</missionheader0.salvagenasonovartifactcave>
+<missionmessage0.salvagenasonovartifactcave>The artifact is now on board. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.salvagenasonovartifactcave>
+<salvagetargetnotinsub>One of the mission targets is not in the submarine yet. The mission will fail if you depart from the outpost now.</salvagetargetnotinsub>
+<missionname.killmoloch>Killing a Moloch</missionname.killmoloch>
+<missiondescription.killmoloch>A particularly aggressive Moloch has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to those who kill the creature.</missiondescription.killmoloch>
+<missionsonarlabel.killmoloch>Moloch</missionsonarlabel.killmoloch>
+<missionsuccess.killmoloch>The Moloch has been killed.</missionsuccess.killmoloch>
+<missionheader0.killmoloch>Target terminated</missionheader0.killmoloch>
+<missionmessage0.killmoloch>The Moloch is dead. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killmoloch>
+<missionname.killtigerthresher>Killing a Tiger Thresher</missionname.killtigerthresher>
+<missiondescription.killtigerthresher>A particularly aggressive Tiger Thresher has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to those who kill the creature.</missiondescription.killtigerthresher>
+<missionsonarlabel.killtigerthresher>Tiger Thresher</missionsonarlabel.killtigerthresher>
+<missionsuccess.killtigerthresher>The Tiger Thresher has been killed.</missionsuccess.killtigerthresher>
+<missionheader0.killtigerthresher>Target terminated</missionheader0.killtigerthresher>
+<missionmessage0.killtigerthresher>The Thresher is dead. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killtigerthresher>
+<missionname.killcrawlerswarm1>Terminate a Swarm</missionname.killcrawlerswarm1>
+<missiondescription.killcrawlerswarm1>A small swarm of [monster] has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew that can neutralize it.</missiondescription.killcrawlerswarm1>
+<missionsonarlabel.killcrawlerswarm1>Swarm</missionsonarlabel.killcrawlerswarm1>
+<missionsuccess.killcrawlerswarm1>The swarm has been terminated.</missionsuccess.killcrawlerswarm1>
+<missionheader0.killcrawlerswarm1>Target terminated</missionheader0.killcrawlerswarm1>
+<missionmessage0.killcrawlerswarm1>The swarm is terminated. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killcrawlerswarm1>
+<missionname.killcrawlerswarm2>Terminate a Swarm</missionname.killcrawlerswarm2>
+<missiondescription.killcrawlerswarm2>A large swarm of [monster] has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew that can neutralize it.</missiondescription.killcrawlerswarm2>
+<missionsonarlabel.killcrawlerswarm2>Swarm</missionsonarlabel.killcrawlerswarm2>
+<missionsuccess.killcrawlerswarm2>The swarm has been terminated.</missionsuccess.killcrawlerswarm2>
+<missionheader0.killcrawlerswarm2>Target terminated</missionheader0.killcrawlerswarm2>
+<missionmessage0.killcrawlerswarm2>The swarm is terminated. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killcrawlerswarm2>
+<missionname.killendworm>Beast from the Abyss</missionname.killendworm>
+<missiondescription.killendworm>Seismic readings are indicating that something colossal has emerged from the depths of Europa into the passageway between [location1] and [location2]. All transports through the passageway have been canceled for now and a reward of [reward] has been promised to those who get rid of whatever is causing the seismic activity.</missiondescription.killendworm>
+<missionsonarlabel.killendworm>Target</missionsonarlabel.killendworm>
+<missionsuccess.killendworm>The Endworm is dead and the passageway is open for transport again.</missionsuccess.killendworm>
+<missionheader0.killendworm>Target terminated</missionheader0.killendworm>
+<missionmessage0.killendworm>The beast is dead. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killendworm>
+<missionname.salvagekillmoloch>Salvaging an artifact</missionname.salvagekillmoloch>
+<missiondescription.salvagekillmoloch>Researchers of [location1] have picked up an infrasonic signal highly similar to those emitted by alien artifacts previously discovered on Europa. Investigate the signal and retrieve the potential artifact.</missiondescription.salvagekillmoloch>
+<missionsonarlabel.salvagekillmoloch>Infrasonic signal</missionsonarlabel.salvagekillmoloch>
+<missionsuccess.salvagekillmoloch>It turns out the signal was emitted by a Moloch. The researchers of [location1] have agreed to pay you the reward nevertheless for getting rid of the Moloch.</missionsuccess.salvagekillmoloch>
+<missionheader0.salvagekillmoloch>Target terminated</missionheader0.salvagekillmoloch>
+<missionmessage0.salvagekillmoloch>Turns out the signal was emitted by a Moloch! You should navigate out of the cavern and inform the researchers.</missionmessage0.salvagekillmoloch>
+<missionname.cargocompoundn>Explosive cargo</missionname.cargocompoundn>
+<missionsuccess.cargocompoundn>The explosives have been successfully delivered.</missionsuccess.cargocompoundn>
+<missionname.cargochemicals>Chemical shipment</missionname.cargochemicals>
+<missiondescription.cargochemicals>Researchers of [location1] need someone to deliver some dangerous chemicals to [location2] for a reward of [reward] marks.</missiondescription.cargochemicals>
+<missionsuccess.cargochemicals>The chemicals have been successfully delivered.</missionsuccess.cargochemicals>
+<missionname.cargohuskeggs>Biohazard</missionname.cargohuskeggs>
+<missiondescription.cargohuskeggs>The Church of Husk is offering [reward] marks for delivering a shipment of husk parasite eggs to [location2].</missiondescription.cargohuskeggs>
+<missionsuccess.cargohuskeggs>The husk eggs have been successfully delivered.</missionsuccess.cargohuskeggs>
+<missionname.cargonitroglycerin>Handle with care</missionname.cargonitroglycerin>
+<missiondescription.cargonitroglycerin>Local researchers are offering [reward] marks for delivering a large amount of nitroglycerin to [location2].</missiondescription.cargonitroglycerin>
+<missionsuccess.cargonitroglycerin>The chemicals have been successfully delivered.</missionsuccess.cargonitroglycerin>
+<missionname.cargoclowngear>Praise the honkmother</missionname.cargoclowngear>
+<missiondescription.cargoclowngear>A local clown syndicate is offering [reward] marks for delivering a shipment of clowning supplies to [location2].</missiondescription.cargoclowngear>
+<missionsuccess.cargoclowngear>The clown gear has been successfully delivered.</missionsuccess.cargoclowngear>
+<missionname.cargoconstructionminerals>Mining outpost material transport</missionname.cargoconstructionminerals>
+<missiondescription.cargoconstructionminerals>A consignment of construction materials needs to be transported to [location2]. The crew chief here is prepared to pay [reward] marks for your trouble.</missiondescription.cargoconstructionminerals>
+<missionsuccess.cargoconstructionminerals>The materials have been successfully delivered.</missionsuccess.cargoconstructionminerals>
+<missionname.cargosecurityminerals>Mining outpost material transport</missionname.cargosecurityminerals>
+<missiondescription.cargosecurityminerals>The security team at [location2] needs to be resupplied with materials for weapon fabrication. There's [reward] marks for you if you get these supplies to them.</missiondescription.cargosecurityminerals>
+<missionsuccess.cargosecurityminerals>The materials have been successfully delivered.</missionsuccess.cargosecurityminerals>
+<missionname.cargomeditems>Medical item transport</missionname.cargomeditems>
+<missiondescription.cargomeditems>A consignment of medical items needs to be transported to [location2]. There's [reward] marks if you can get them there.</missiondescription.cargomeditems>
+<missionsuccess.cargomeditems>The materials have been successfully delivered.</missionsuccess.cargomeditems>
+<missionname.personneltransport>Personnel transport</missionname.personneltransport>
+<missiondescription.personneltransport>We have a crewmember here who needs to get to [location2] in a hurry. The payment is [reward] marks if you get them there in once piece.</missiondescription.personneltransport>
+<missionsuccess.personneltransport>The personnel have been successfully delivered.</missionsuccess.personneltransport>
+<missionname.cargomedemergency>Medical item transport</missionname.cargomedemergency>
+<missiondescription.cargomedemergency>A crewmember over at [location2] has gone and gotten themselves a nasty case of morbusine poisoning. They might stand a chance of survival if you can get a shipment of antidote to them ASAP... You'll be paid [reward] marks on delivery.</missiondescription.cargomedemergency>
+<missionsuccess.cargomedemergency>The antidote has been successfully delivered.</missionsuccess.cargomedemergency>
+<missionname.beacon>Beacon deployment</missionname.beacon>
+<missiondescription.beacon>Head over to [location2] and drop a beacon to begin the process of colonizing the area. Payment is [reward] marks when the beacon starts transmitting.</missiondescription.beacon>
+<missionsonarlabel.beacon>Beacon deployment location</missionsonarlabel.beacon>
+<missionsuccess.beacon>Beacon successfully deployed.</missionsuccess.beacon>
+<missionmessage0.combatmission>The Separatist vessel has been defeated by the Coalition crew!</missionmessage0.combatmission>
+<missionmessage1.combatmission>The Coalition vessel has been defeated by the Separatist crew!</missionmessage1.combatmission>
+<missionname.killhammerhead>Killing Hammerheads</missionname.killhammerhead>
+<missiondescription.killhammerhead>Particularly aggressive Hammerheads have been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to whoever kills the creatures.</missiondescription.killhammerhead>
+<missionsonarlabel.killhammerhead>Hammerheads</missionsonarlabel.killhammerhead>
+<missionsuccess.killhammerhead>The Hammerheads have been killed.</missionsuccess.killhammerhead>
+<missionheader0.killhammerhead>Targets terminated</missionheader0.killhammerhead>
+<missionmessage0.killhammerhead>The Hammerheads are dead. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killhammerhead>
+<missionname.killmatriarch1>Aggressive Hammerheads</missionname.killmatriarch1>
+<missiondescription.killmatriarch1>According to our sources, there is a group of Hammerheads blocking the route from [location1] to [location2]. Get rid of the creatures so that our vessels can continue traveling safely through the passage.</missiondescription.killmatriarch1>
+<missionsonarlabel.killmatriarch1>Hammerhead</missionsonarlabel.killmatriarch1>
+<missionsuccess.killmatriarch1>The Hammerheads have been neutralized. The route should be safe again.</missionsuccess.killmatriarch1>
+<missionheader0.killmatriarch1>Targets neutralized</missionheader0.killmatriarch1>
+<missionmessage0.killmatriarch1>The Hammerheads have been neutralized. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killmatriarch1>
+<missionname.killmatriarch2>Killing a Matriarch</missionname.killmatriarch2>
+<missiondescription.killmatriarch2>A large and hostile creature, a so-called "Hammerhead Matriarch," has taken residence in the passageway between [location1] and [location2] along with a swarm of smaller Hammerheads. Kill the creatures so that vessels can continue traveling safely through the route. This might not be the easiest task, but the reward is not small either!</missiondescription.killmatriarch2>
+<missionsonarlabel.killmatriarch2>Hammerhead</missionsonarlabel.killmatriarch2>
+<missionsuccess.killmatriarch2>The Matriarch has been killed. The route should be safe again.</missionsuccess.killmatriarch2>
+<missionheader0.killmatriarch2>Target terminated</missionheader0.killmatriarch2>
+<missionmessage0.killmatriarch2>The Matriarch and its minions have been taken care of. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killmatriarch2>
+<missionname.killhammerheadgold>Killing a Golden Hammerhead</missionname.killhammerheadgold>
+<missiondescription.killhammerheadgold>There have been several reports of an aggressive Golden Hammerhead assaulting vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to whoever gets rid of the creature.</missiondescription.killhammerheadgold>
+<missionsonarlabel.killhammerheadgold>Golden Hammerhead</missionsonarlabel.killhammerheadgold>
+<missionsuccess.killhammerheadgold>The Golden Hammerhead is dead.</missionsuccess.killhammerheadgold>
+<missionheader0.killhammerheadgold>Target terminated</missionheader0.killhammerheadgold>
+<missionmessage0.killhammerheadgold>The Golden Hammerhead is dead. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killhammerheadgold>
+<missionname.killthresherswarm1>Terminate a Thresher Swarm</missionname.killthresherswarm1>
+<missiondescription.killthresherswarm1>There have been several reports of a large swarm of threshers assaulting vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew who can get rid of them.</missiondescription.killthresherswarm1>
+<missionsonarlabel.killthresherswarm1>Thresher Swarm</missionsonarlabel.killthresherswarm1>
+<missionsuccess.killthresherswarm1>The swarm has been terminated.</missionsuccess.killthresherswarm1>
+<missionheader0.killthresherswarm1>Target terminated</missionheader0.killthresherswarm1>
+<missionmessage0.killthresherswarm1>The swarm is terminated. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killthresherswarm1>
+<missionname.salvagekillthalamus>Salvaging a derelict</missionname.salvagekillthalamus>
+<missiondescription.salvagekillthalamus>A small cargo vessel went missing approximately two months ago when transporting xenomaterials from [location1] to [location2]. The vessel was presumed to be taken by the Abyss, but now its emergency beacon seems to have been activated near [location2]. Find the vessel and recover the cargo.</missiondescription.salvagekillthalamus>
+<missionsonarlabel.salvagekillthalamus>Emergency signal</missionsonarlabel.salvagekillthalamus>
+<missionsuccess.salvagekillthalamus>The researchers of [location2] are eager to know all the details of the encounter, but seem hesitant to answer any questions regarding the vessel. They do however offer you 1,000 credits as reimbursement for your troubles.</missionsuccess.salvagekillthalamus>
+<missionheader0.salvagekillthalamus>Target destroyed</missionheader0.salvagekillthalamus>
+<missionmessage0.salvagekillthalamus>The missing vessel appears to have been taken over by some sort of parasitic growth, leading it to attack your submarine. It seems to be incapacitated now. You should report the incident to [location2].</missionmessage0.salvagekillthalamus>
+<missionname.salvagewreck1>Wreck salvage</missionname.salvagewreck1>
+<missiondescription.salvagewreck1>[location1] just received a fragmented distress call from a vessel that was thought to have been lost along with some highly sensitive encrypted data. Retrieve the captain's logbook as a priority and return it.</missiondescription.salvagewreck1>
+<missionsonarlabel.salvagewreck1>Wreck</missionsonarlabel.salvagewreck1>
+<missionsuccess.salvagewreck1>Logbook has been successfully retrieved.</missionsuccess.salvagewreck1>
+<missionfailure.salvagewreck1>Failed to retrieve the data.</missionfailure.salvagewreck1>
+<missionheader0.salvagewreck1>Data retrieved</missionheader0.salvagewreck1>
+<missionmessage0.salvagewreck1>The logbook containing the encrypted data has been retrieved. Bring it to [location2] to claim your reward.</missionmessage0.salvagewreck1>
+<missionname.salvagewreck2>Wreck salvage</missionname.salvagewreck2>
+<missiondescription.salvagewreck2>A Coalition sub has sunk nearby. Search the area for signs of its distress beacon and investigate the wreck for any information about what might have caused its sinking.</missiondescription.salvagewreck2>
+<missionsonarlabel.salvagewreck2>Wreck</missionsonarlabel.salvagewreck2>
+<missionsuccess.salvagewreck2>Evidence successfully retrieved.</missionsuccess.salvagewreck2>
+<missionfailure.salvagewreck2>Failed to retrieve any evidence of what caused the sinking.</missionfailure.salvagewreck2>
+<missionheader0.salvagewreck2>Evidence retrieved</missionheader0.salvagewreck2>
+<missionmessage0.salvagewreck2>You have a good idea of what might have caused the sub to sink. Bring the evidence to [location2] to claim your reward.</missionmessage0.salvagewreck2>
+<missionname.quartzcollection>Mining quartz</missionname.quartzcollection>
+<missiondescription.quartzcollection>There's been talk of deposits of quartz along the way from [location1] to [location2]. Bring back ten samples of quartz to verify these claims.</missiondescription.quartzcollection>
+<missionheader0.quartzcollection>Quartz mined</missionheader0.quartzcollection>
+<missionmessage0.quartzcollection>You have mined enough quartz. Bring it to an outpost to claim the reward.</missionmessage0.quartzcollection>
+<missionsuccess.quartzcollection>The existence of the quartz deposits has been successfully proven.</missionsuccess.quartzcollection>
+<missionsonarlabel.quartzcollection>Quartz</missionsonarlabel.quartzcollection>
+<missionname.pyromorphitecollection>Mining pyromorphite</missionname.pyromorphitecollection>
+<missiondescription.pyromorphitecollection>There's been talk of deposits of pyromorphite along the way from [location1] to [location2]. Bring back ten samples of pyromorphite to verify these claims.</missiondescription.pyromorphitecollection>
+<missionheader0.pyromorphitecollection>Pyromorphite mined</missionheader0.pyromorphitecollection>
+<missionmessage0.pyromorphitecollection>You have mined enough pyromorphite. Bring it to an outpost to claim the reward.</missionmessage0.pyromorphitecollection>
+<missionsuccess.pyromorphitecollection>The existence of the pyromorphite deposits has been successfully proven.</missionsuccess.pyromorphitecollection>
+<missionsonarlabel.pyromorphitecollection>Pyromorphite</missionsonarlabel.pyromorphitecollection>
+<missionname.uraniumcollection>Mining uranium</missionname.uraniumcollection>
+<missiondescription.uraniumcollection>There's been talk of deposits of uranium ore along the way from [location1] to [location2]. Bring back eight samples of uranium ore to verify these claims.</missiondescription.uraniumcollection>
+<missionheader0.uraniumcollection>Uranium ore mined</missionheader0.uraniumcollection>
+<missionmessage0.uraniumcollection>You have mined enough uranium ore. Bring it to an outpost to claim the reward.</missionmessage0.uraniumcollection>
+<missionsuccess.uraniumcollection>The existence of the uranium ore deposits has been successfully proven.</missionsuccess.uraniumcollection>
+<missionsonarlabel.uraniumcollection>Uranium</missionsonarlabel.uraniumcollection>
+<missionname.thorianitecollection>Mining thorianite</missionname.thorianitecollection>
+<missiondescription.thorianitecollection>There's been talk of deposits of thorianite along the way from [location1] to [location2]. Bring back six samples of thorianite to verify these claims.</missiondescription.thorianitecollection>
+<missionheader0.thorianitecollection>Thorianite mined</missionheader0.thorianitecollection>
+<missionmessage0.thorianitecollection>You have mined enough thorianite. Bring it to an outpost to claim the reward.</missionmessage0.thorianitecollection>
+<missionsuccess.thorianitecollection>The existence of the thorianite deposits has been successfully proven.</missionsuccess.thorianitecollection>
+<missionsonarlabel.thorianitecollection>Thorianite</missionsonarlabel.thorianitecollection>
+<missionname.titanitecollection>Mining titanite</missionname.titanitecollection>
+<missiondescription.titanitecollection>There's been talk of deposits of titanite along the way from [location1] to [location2]. Bring back six samples of titanite to verify these claims.</missiondescription.titanitecollection>
+<missionheader0.titanitecollection>Titanite mined</missionheader0.titanitecollection>
+<missionmessage0.titanitecollection>You have mined enough titanite. Bring it to an outpost to claim the reward.</missionmessage0.titanitecollection>
+<missionsuccess.titanitecollection>The existence of the titanite deposits has been successfully proven.</missionsuccess.titanitecollection>
+<missionsonarlabel.titanitecollection>Titanite</missionsonarlabel.titanitecollection>
+
+
+<missiontypedescription.salvage>Find and retrieve a specific item—for example, an artifact from an alien ruin, or sensitive cargo from a sunken submarine.</missiontypedescription.salvage>
+<missiontypedescription.monster>Terminate an aggressive creature (or a group of creatures) residing within the passageway.</missiontypedescription.monster>
+<missiontypedescription.cargo>Deliver cargo (such as explosives, dangerous chemicals or minerals) from one outpost to another.</missiontypedescription.cargo>
+<missiontypedescription.nest>Find and destroy a nest. Nests are usually located inside small caverns within the passageway.</missiontypedescription.nest>
+<missiontypedescription.beacon>Locate a beacon station and get it back online by repairing any damage to the station or its systems.</missiontypedescription.beacon>
+<missiontypedescription.mineral>There's been talk of valuable mineral clusters within the passageway. Locate the clusters and retrieve the minerals.</missiontypedescription.mineral>
+<missiontypedescription.abandonedoutpost>Eradicate aggressive creatures or bandit outlaws who have taken over an abandoned outpost, or rescue hostages from one.</missiontypedescription.abandonedoutpost>
+<missiontypedescription.clearalienruins>Clear an alien ruin of its guardians.</missiontypedescription.clearalienruins>
+<missiontypedescription.escort>Escort a number of personnel from outpost to another while ensuring their safety.</missiontypedescription.escort>
+<missiontypedescription.scanalienruins>Install scanners in the alien ruins. Retrieve the data by returning the scanners to the next outpost.</missiontypedescription.scanalienruins>
+<missiontypedescription.pirate>Find the pirate ship and destroy it, along with its crew.</missiontypedescription.pirate>
+<missionname.crawlernest>Destroy a crawler nest</missionname.crawlernest>
+<missiondescription.crawlernest>A crawler nest was recently discovered in a cave near [location1]. A reward of [reward] marks has been promised to any crew that can get rid of the nest.</missiondescription.crawlernest>
+<missionsonarlabel.crawlernest>Crawler nest</missionsonarlabel.crawlernest>
+<missionmessage0.crawlernest>The nest has been wiped out. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.crawlernest>
+<missionsuccess.crawlernest>The nest has been destroyed.</missionsuccess.crawlernest>
+<entityname.tigerthresheregg>Tiger Thresher Egg</entityname.tigerthresheregg>
+<missionname.tigerthreshernest>Destroy a Tiger Thresher nest</missionname.tigerthreshernest>
+<missiondescription.tigerthreshernest>A thresher nest was recently discovered in a cave near [location1]. A reward of [reward] marks has been promised to any crew that can get rid of the nest.</missiondescription.tigerthreshernest>
+<missionsonarlabel.tigerthreshernest>Tiger Thresher nest</missionsonarlabel.tigerthreshernest>
+<missionmessage0.tigerthreshernest>The nest has been wiped out. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.tigerthreshernest>
+<missionsuccess.tigerthreshernest>The nest has been destroyed.</missionsuccess.tigerthreshernest>
+<missionname.beaconmission>Activate beacon</missionname.beaconmission>
+<missiondescription.beaconmission>The beacon station between [location1] and [location2] is down—get in there, and get it back online and transmitting an active sonar signal.</missiondescription.beaconmission>
+<missionmessage0.beaconmission>The beacon station is back online. Make sure it stays transmitting, and navigate the submarine to [location2] to claim your reward.</missionmessage0.beaconmission>
+<missionsuccess.beaconmission>Beacon reactivated.</missionsuccess.beaconmission>
+
+<missionname.mudraptornest>Destroy a Mudraptor nest</missionname.mudraptornest>
+<missiondescription.mudraptornest>A mudraptor nest was recently discovered in a cave near [location1]. A reward of [reward] marks has been promised to any crew that can get rid of the nest.</missiondescription.mudraptornest>
+<missionsonarlabel.mudraptornest>Mudraptor nest</missionsonarlabel.mudraptornest>
+<missionmessage0.mudraptornest>The nest has been wiped out. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.mudraptornest>
+<missionsuccess.mudraptornest>The nest has been destroyed.</missionsuccess.mudraptornest>
+
+<missionname.pvpmission>Search and destroy</missionname.pvpmission>
+<missiondescriptionneutral.pvpmission>A Coalition vessel has been dispatched from [location1] to destroy a renegade vessel at the outskirts of [location2].</missiondescriptionneutral.pvpmission>
+<missiondescription1.pvpmission>A renegade vessel has been detected at the outskirts of [location2]. Treason against the Europa Coalition is punishable by death—eliminate the renegades by any means necessary.</missiondescription1.pvpmission>
+<missiondescription2.pvpmission>You're a member of the Jovian Separatists, a group opposing the Europa Coalition. According to your informants at [location1], a Coalition vessel has just been dispatched on a mission to take down your boat. Eliminate their crew by any means necessary.</missiondescription2.pvpmission>
+
+<missionname.abandonedoutposthumans>Outpost recovery</missionname.abandonedoutposthumans>
+<missiondescription.abandonedoutposthumans>Contact with [location1] was recently lost, and it's suspected to have been taken over by someone. Destroy the outpost's reactor to drive away any squatters and ensure they don't return.</missiondescription.abandonedoutposthumans>
+<missionsuccess.abandonedoutposthumans>The squatters were driven away from the outpost successfully.</missionsuccess.abandonedoutposthumans>
+<missionfailure.abandonedoutposthumans>Destroying the outpost's reactor failed.</missionfailure.abandonedoutposthumans>
+<missionheader0.abandonedoutposthumans>Reactor destroyed</missionheader0.abandonedoutposthumans>
+<missionmessage0.abandonedoutposthumans>The reactor has been destroyed. This should make sure squatters won't try to take over the outpost again. Undock from the outpost to complete the mission.</missionmessage0.abandonedoutposthumans>
+<missionname.abandonedoutpostmonsters>Outpost recovery</missionname.abandonedoutpostmonsters>
+<missiondescription.abandonedoutpostmonsters>Contact with [location1] was recently lost, and it's suspected that hostile fauna has built a nest inside it. Find any eggs inside the outpost and destroy them.</missiondescription.abandonedoutpostmonsters>
+<missionsuccess.abandonedoutpostmonsters>The nest inside the outpost has been successfully destroyed.</missionsuccess.abandonedoutpostmonsters>
+<missionfailure.abandonedoutpostmonsters>The outpost remains infested.</missionfailure.abandonedoutpostmonsters>
+<missionheader0.abandonedoutpostmonsters>Nest destroyed</missionheader0.abandonedoutpostmonsters>
+<missionmessage0.abandonedoutpostmonsters>The nest inside the outpost has been successfully destroyed. Undock from the outpost to complete the mission.</missionmessage0.abandonedoutpostmonsters>
+<missionname.abandonedoutpostassassinate>Outpost assassination</missionname.abandonedoutpostassassinate>
+<missiondescription.abandonedoutpostassassinate>Contact with [location1] was recently lost, and there have been reports about a notorious group of outlaws having claimed it as their base. There's a bounty on the head of the group's leader's—eliminate the leader to claim the reward.</missiondescription.abandonedoutpostassassinate>
+<missionsuccess.abandonedoutpostassassinate>The leader of the bandit group has been successfully eliminated.</missionsuccess.abandonedoutpostassassinate>
+<missionfailure.abandonedoutpostassassinate>Eliminating the leader of the bandit group failed.</missionfailure.abandonedoutpostassassinate>
+<missionheader0.abandonedoutpostassassinate>Bandit leader killed</missionheader0.abandonedoutpostassassinate>
+<missionmessage0.abandonedoutpostassassinate>The leader of the bandit group has been successfully eliminated. Undock from the outpost to complete the mission.</missionmessage0.abandonedoutpostassassinate>
+<missionname.abandonedoutpostrescue>Outpost rescue</missionname.abandonedoutpostrescue>
+<missiondescription.abandonedoutpostrescue>A bandit group that has claimed the abandoned [location1] recently sent out a message in which they demand a ransom for releasing a group of civilians they're holding hostage. The Coalition doesn't negotiate with terrorists, but has promised a considerable reward to anyone who manages to rescue the hostages.</missiondescription.abandonedoutpostrescue>
+<missionsuccess.abandonedoutpostrescue>The hostages were rescued successfully.</missionsuccess.abandonedoutpostrescue>
+<missionfailure.abandonedoutpostrescue>Rescuing the hostages failed.</missionfailure.abandonedoutpostrescue>
+<missionheader0.abandonedoutpostrescue>Hostages rescued</missionheader0.abandonedoutpostrescue>
+<missionmessage0.abandonedoutpostrescue>The hostages are now all safely on board the sub. Undock from the outpost to complete the mission.</missionmessage0.abandonedoutpostrescue>
+<hostageskilled>The mission has failed; one of the hostages has died.</hostageskilled>
+<missionname.abandonedoutposthusks>Outpost recovery</missionname.abandonedoutposthusks>
+<missiondescription.abandonedoutposthusks>Contact with [location1] was recently lost. It's suspected that an extremist branch of the Church of Husk is using it for one their ascension rituals. Get rid of the husks, and any eventual cultists.</missiondescription.abandonedoutposthusks>
+<missionsuccess.abandonedoutposthusks>The ritual inside the outpost has been successfully interrupted.</missionsuccess.abandonedoutposthusks>
+<missionfailure.abandonedoutposthusks>The outpost remains infested.</missionfailure.abandonedoutposthusks>
+<missionheader0.abandonedoutposthusks>Ritual interrupted</missionheader0.abandonedoutposthusks>
+<missionmessage0.abandonedoutposthusks>The husk ritual inside the outpost has been successfully foiled. Undock from the outpost to complete the mission.</missionmessage0.abandonedoutposthusks>
+<missionname.huntinggrounds>Hunting grounds</missionname.huntinggrounds>
+<missiondescription.huntinggrounds>A creature from the Abyss has made this passageway its hunting grounds. Until the beast is dead, new outposts won't be established in the adjacent locations, and existing outposts may get abandoned.</missiondescription.huntinggrounds>
+<missionsuccess.huntinggrounds>The Abyss creature is now dead and the passageway safer to traverse.</missionsuccess.huntinggrounds>
+<missionfailure.huntinggrounds>The Abyss creature remains a threat to nearby colonists.</missionfailure.huntinggrounds>
+<missionheader0.huntinggrounds>Target terminated</missionheader0.huntinggrounds>
+<missionmessage0.huntinggrounds>The Abyss creature is now dead and the passageway safer to traverse.</missionmessage0.huntinggrounds>
+<missionname.beaconnoreward>Activate beacon</missionname.beaconnoreward>
+<missiondescription.beaconnoreward>According to the onboard navigation system, there should be a run-down beacon station nearby. Getting it back online will make the passage easier for other vessels to traverse, and help colonies to spread further.</missiondescription.beaconnoreward>
+<missionmessage0.beaconnoreward>The beacon station is back online.</missionmessage0.beaconnoreward>
+<missionsuccess.beaconnoreward>Beacon reactivated.</missionsuccess.beaconnoreward>
+<missionfailure.beaconnoreward>The beacon remains inactive.</missionfailure.beaconnoreward>
+<missionname.killcrawlerbroodmother1>Crawler Mother</missionname.killcrawlerbroodmother1>
+<missiondescription.killcrawlerbroodmother1>There's been reports of a particularily large and hostile crawler terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to whoever kills the creature.</missiondescription.killcrawlerbroodmother1>
+<missionsonarlabel.killcrawlerbroodmother1>Crawler Broodmother</missionsonarlabel.killcrawlerbroodmother1>
+<missionsuccess.killcrawlerbroodmother1>The crawler broodmother has been killed.</missionsuccess.killcrawlerbroodmother1>
+<missionheader0.killcrawlerbroodmother1>Target terminated</missionheader0.killcrawlerbroodmother1>
+<missionmessage0.killcrawlerbroodmother1>The crawler broodmother is dead. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killcrawlerbroodmother1>
+<missionname.killgiantspineling1>Giant Spineling</missionname.killgiantspineling1>
+<missiondescription.killgiantspineling1>There's been reports of a particularily large and hostile Spineling terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to whoever kills the creature.</missiondescription.killgiantspineling1>
+<missionsonarlabel.killgiantspineling1>Giant Spineling</missionsonarlabel.killgiantspineling1>
+<missionsuccess.killgiantspineling1>The Giant Spineling has been killed.</missionsuccess.killgiantspineling1>
+<missionheader0.killgiantspineling1>Target terminated</missionheader0.killgiantspineling1>
+<missionmessage0.killgiantspineling1>The Giant Spineling is dead. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killgiantspineling1>
+<missionname.killmudraptors1>Getting rid of Mudraptors</missionname.killmudraptors1>
+<missiondescription.killmudraptors1>A pack of Mudraptors has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew that can neutralize it.</missiondescription.killmudraptors1>
+<missionsonarlabel.killmudraptors1>Mudraptors</missionsonarlabel.killmudraptors1>
+<missionsuccess.killmudraptors1>The Mudraptors have been terminated.</missionsuccess.killmudraptors1>
+<missionheader0.killmudraptors1>Targets terminated</missionheader0.killmudraptors1>
+<missionmessage0.killmudraptors1>The Mudraptors have been killed. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.killmudraptors1>
+<missionname.scanruin>Scan ruin</missionname.scanruin>
+<missiondescription.scanruin>To further their research, a group of scientists in [location1] have asked you to scan the nearby ruin. Venture into the ruin and scan the marked rooms using the provided scanner.</missiondescription.scanruin>
+<missionsuccess.scanruin>The ruins were succesfully scanned and the data was delivered.</missionsuccess.scanruin>
+<missionfailure.scanruin>The ruins remain unscanned and a mystery for the researchers.</missionfailure.scanruin>
+<missionheader0.scanruin>Ruin scanned</missionheader0.scanruin>
+<missionmessage0.scanruin>The ruins are scanned. Bring the scanner and its data to [location2].</missionmessage0.scanruin>
+<missionname.clearruin>Clear Ruin</missionname.clearruin>
+<missiondescription.clearruin>Destroy all guardians and their pods in the ruins near [location1].</missiondescription.clearruin>
+<missionmessage0.clearruin>Ruin guardians have been wiped out. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.clearruin>
+<missionsuccess.clearruin>Guardians have been wiped out.</missionsuccess.clearruin>
+<progressbar.scanning>Scanning...</progressbar.scanning>
+<missionsonarlabel.scantarget>Scan target</missionsonarlabel.scantarget>
+<missionname.stowawayescort1>Stowaway Transport</missionname.stowawayescort1>
+<missiondescription.stowawayescort1>A stowaway has sneaked on board. Transport them to a station where they can find their way back home.</missiondescription.stowawayescort1>
+<missionheader0.stowawayescort1>Stowaway died</missionheader0.stowawayescort1>
+<missionmessage0.stowawayescort1>The stowaway has died. The mission is a failure.</missionmessage0.stowawayescort1>
+<missionsuccess.stowawayescort1>Transport successful. The stowaway will find their way home from here.</missionsuccess.stowawayescort1>
+<missionfailure.stowawayescort1>The stowaway did not reach their destination.</missionfailure.stowawayescort1>
+<missionname.gotosubra>Find Jacov Subra</missionname.gotosubra>
+<missiondescription.gotosubra>Investigate the station and locate the fugitive Jacov Subra.</missiondescription.gotosubra>
+<missionsuccess.gotosubra>You have reached [location1]. Find Jacov Subra and bring him to justice.</missionsuccess.gotosubra>
+<missionname.subraescort>Personnel Transport</missionname.subraescort>
+<missiondescription.subraescort>Transport the dangerous criminal Jacov Subra to a nearby station.</missiondescription.subraescort>
+<missionheader0.subraescort>Prisoner died</missionheader0.subraescort>
+<missionmessage0.subraescort>The prisoner has died. The mission is a failure.</missionmessage0.subraescort>
+<missionsuccess.subraescort>Transport successful. Subra has been handed to the authorities</missionsuccess.subraescort>
+<missionfailure.subraescort>The prisoner did not reach their destination.</missionfailure.subraescort>
+<missionname.badvibrationsartifactruins>Salvaging an artifact</missionname.badvibrationsartifactruins>
+<missiondescription.badvibrationsartifactruins>A resident of [location1] has reported strange vibrations in their head after visiting a nearby ruin. Investigate the ruins and find the cause of these vibrations.</missiondescription.badvibrationsartifactruins>
+<missionsonarlabel.badvibrationsartifactruins>Infrasonic signal</missionsonarlabel.badvibrationsartifactruins>
+<missionsuccess.badvibrationsartifactruins>The artifact has been successfully retrieved.</missionsuccess.badvibrationsartifactruins>
+<missionfailure.badvibrationsartifactruins>Retrieving the artifact failed.</missionfailure.badvibrationsartifactruins>
+<missionheader0.badvibrationsartifactruins>Artifact collected</missionheader0.badvibrationsartifactruins>
+<missionmessage0.badvibrationsartifactruins>The artifact is now on board. Navigate the submarine out of the cavern to claim the reward.</missionmessage0.badvibrationsartifactruins>
+<missionname.raptorescort>Civilian Transport</missionname.raptorescort>
+<missiondescription.raptorescort>Transport a passenger and their companion to a nearby station.</missiondescription.raptorescort>
+<missionheader0.raptorescort>Passenger died</missionheader0.raptorescort>
+<missionmessage0.raptorescort>The passenger has died. The mission is a failure.</missionmessage0.raptorescort>
+<missionsuccess.raptorescort>Transport successful. The passenger and their dangerous companion are safely off your ship.</missionsuccess.raptorescort>
+<missionfailure.raptorescort>The passenger did not reach their destination.</missionfailure.raptorescort>
+<missionheader0.escort1>Personnel died</missionheader0.escort1>
+<missionmessage0.escort1>Too many of the escorted personnel have perished at sea. The mission is a failure.</missionmessage0.escort1>
+<missionsuccess.escort1>Personnel transport successful.</missionsuccess.escort1>
+<missionfailure.escort1>Escorted personnel did not reach their destination.</missionfailure.escort1>
+<missionheader0.escort2>Personnel died</missionheader0.escort2>
+<missionmessage0.escort2>Too many of the escorted personnel have perished at sea. The mission is a failure.</missionmessage0.escort2>
+<missionsuccess.escort2>VIP transport successful.</missionsuccess.escort2>
+<missionfailure.escort2>Escorted personnel did not reach their destination.</missionfailure.escort2>
+<missionname.escort3>Prisoner Transport</missionname.escort3>
+<missiondescription.escort3>A group of prisoners need to be transported to a high-security prison located in [location2] to be paid [reward] marks. Make sure these prisoners are well-guarded during your voyage, as they may try to escape. Do not let any of them die.</missiondescription.escort3>
+<missionheader0.escort3>Personnel died</missionheader0.escort3>
+<missionmessage0.escort3>Too many of the escorted personnel have perished at sea. The mission is a failure.</missionmessage0.escort3>
+<missionsuccess.escort3>Prisoner transport successful.</missionsuccess.escort3>
+<missionfailure.escort3>Escorted personnel did not reach their destination.</missionfailure.escort3>
+<missionname.escort4>Terrorist Stakeout</missionname.escort4>
+<missiondescription.escort4>Separatist terrorists have been hijacking ships in this sector. We believe some of them have snuck onto your ship alongside innocent passengers. Make sure the innocent civilians make it to [location2] alive, and deal with any terrorists that reveal themselves, and you'll be paid a reward of [reward] marks.</missiondescription.escort4>
+<missionsuccess.escort4>Personnel transport successful, and the terrorists have been dealt with.</missionsuccess.escort4>
+<missionfailure.escort4>Escorted personnel did not reach their destination, or the terrorists were not uncovered and neutralized.</missionfailure.escort4>
+<missionheader0.escort4>Personnel died</missionheader0.escort4>
+<missionmessage0.escort4>Too many of the escorted personnel have perished at sea. The mission is a failure.</missionmessage0.escort4>
+<missionheader1.escort4>Terrorists defeated</missionheader1.escort4>
+<missionmessage1.escort4>Looks like that was the last of the terrorists. Navigate the submarine to [location2] to claim your reward.</missionmessage1.escort4>
+<missionmessage0.pirate1>Neutralize the crew or sink the submarine to the bottom of the sea!</missionmessage0.pirate1>
+<missionmessage1.pirate1>Navigate the submarine to [location2] to claim your reward.</missionmessage1.pirate1>
+<missionname.killmopingjack>Kill Moping Jack</missionname.killmopingjack>
+<missiondescription.killmopingjack>Captain Hognose has recruited you to help him kill his old nemesis, Moping Jack the Hammerhead.</missiondescription.killmopingjack>
+<missionsonarlabel.killmopingjack>Moping Jack</missionsonarlabel.killmopingjack>
+<missionsuccess.killmopingjack>Moping Jack has been killed.</missionsuccess.killmopingjack>
+<missionheader0.killmopingjack>Target terminated</missionheader0.killmopingjack>
+<missionmessage0.killmopingjack>Moping Jack is dead. All that remains is to claim the reward.</missionmessage0.killmopingjack>
+<missionname.killcrawlerswarm1large>Terminate a Large Swarm</missionname.killcrawlerswarm1large>
+<missiondescription.killcrawlerswarm1large>A large swarm of crawlers has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew that can neutralize it.</missiondescription.killcrawlerswarm1large>
+<missionname.killcrawlerswarm1huge>Terminate a Huge Swarm</missionname.killcrawlerswarm1huge>
+<missiondescription.killcrawlerswarm1huge>A huge swarm of crawlers has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew that can neutralize it.</missiondescription.killcrawlerswarm1huge>
+<missionname.killspinelingswarm1>Terminate a Squadron of Spinelings</missionname.killspinelingswarm1>
+<missiondescription.killspinelingswarm1>A small swarm of Spinelings has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew that can neutralize it.</missiondescription.killspinelingswarm1>
+<missionname.killlargecrawler>Killing a large crawler</missionname.killlargecrawler>
+<missiondescription.killlargecrawler>An especially large crawler has been terrorizing vessels traveling between [location1] and [location2]. A reward of [reward] marks has been promised to any crew that can neutralize it.</missiondescription.killlargecrawler>
+<missionsonarlabel.killlargecrawler>Crawler</missionsonarlabel.killlargecrawler>
+<missionsuccess.killlargecrawler>The crawler has been terminated.</missionsuccess.killlargecrawler>
+<missionmessage0.killlargecrawler>The crawler is terminated. Reach the next station to claim the reward.</missionmessage0.killlargecrawler>
+<missionname.miningmission1>Mining [resourcename1]</missionname.miningmission1>
+<missiondescription.miningmission1>There's been talk of deposits of [resourcename1] along the way from [location1] to [location2]. Bring back [resourcequantity1] samples of [resourcename1] to verify these claims. You are expected to hand over [handoverpercentage].</missiondescription.miningmission1>
+<missionmessage0.miningmission1>You have mined enough [resourcename1]. Bring it to an outpost to claim the reward.</missionmessage0.miningmission1>
+<missionsuccess.miningmission1>The existence of the [resourcename1] deposits has been successfully proven.</missionsuccess.miningmission1>
+<missionheader0.miningmission1>Minerals mined</missionheader0.miningmission1>
+<missionsonarlabel.miningmission1>[resourcename1]</missionsonarlabel.miningmission1>
+<missionname.miningmission2>Mining minerals</missionname.miningmission2>
+<missiondescription.miningmission2>There's been talk of deposits of [resourcename1] and [resourcename2] along the way from [location1] to [location2]. Bring back [resourcequantity1] samples of [resourcename1] and [resourcename2] to verify these claims. You are expected to hand over [handoverpercentage].</missiondescription.miningmission2>
+<missionmessage0.miningmission2>You have mined enough [resourcename1] and [resourcename2]. Bring it to an outpost to claim the reward.</missionmessage0.miningmission2>
+<missionsuccess.miningmission2>The existence of the [resourcename1] and [resourcename2] deposits has been successfully proven.</missionsuccess.miningmission2>
+<missionheader0.miningmission2>Minerals mined</missionheader0.miningmission2>
+<missionsonarlabel.miningmission2>Mineral</missionsonarlabel.miningmission2>
+<missionname.miningmission1_abyss>Abyss diving for [resourcename1]</missionname.miningmission1_abyss>
+<missiondescription.miningmission1_abyss>There's been talk of deposits of [resourcename1] in the abyssal depths between [location1] and [location2]. Bring back [resourcequantity1] samples of [resourcename1] to verify these claims. You are expected to hand over [handoverpercentage].</missiondescription.miningmission1_abyss>
+<missionmessage0.miningmission1_abyss>You have mined enough [resourcename1]. Bring it to an outpost to claim the reward.</missionmessage0.miningmission1_abyss>
+<missionsuccess.miningmission1_abyss>The existence of the rare [resourcename1] deposits has been successfully proven.</missionsuccess.miningmission1_abyss>
+<missionheader0.miningmission1_abyss>Minerals mined</missionheader0.miningmission1_abyss>
+<missionsonarlabel.miningmission1_abyss>[resourcename1]</missionsonarlabel.miningmission1_abyss>
+
+<!-- Entity subcategories -->
+<subcategory>Subcategory</subcategory>
+<subcategories>Subcategories</subcategories>
+<subcategory.thalamus>Thalamus</subcategory.thalamus>
+<subcategory.abandoned>Abandoned Outposts</subcategory.abandoned>
+<subcategory.abandonedhuman>Abandoned Outpost (Human)</subcategory.abandonedhuman>
+<subcategory.abandonedmonster>Abandoned Outpost (Monster)</subcategory.abandonedmonster>
+<subcategory.exteriorsubwalls>Exterior submarine walls</subcategory.exteriorsubwalls>
+<subcategory.exteriorshuttle>Exterior shuttle pieces</subcategory.exteriorshuttle>
+<subcategory.labels>Labels</subcategory.labels>
+<subcategory.backgroundwall>Background wall</subcategory.backgroundwall>
+<subcategory.outpost>Outpost</subcategory.outpost>
+
+<!-- Mission misc -->
+<missionteam1.pvpmission>Coalition</missionteam1.pvpmission>
+<missionteam2.pvpmission>Jovian Separatists</missionteam2.pvpmission>
+<missionsuccess.pvpmission>The [loser] vessel has been defeated by the [winner] crew!</missionsuccess.pvpmission>
+<missionfailure.pvpmission>Both crews have perished.</missionfailure.pvpmission>
+<missionfailed>Mission failed</missionfailed>
+<missioncompleted>Completed</missioncompleted>
+<missionunlocked>Mission unlocked: [missionname]</missionunlocked>
+<beaconstationsonarlabel>Beacon station</beaconstationsonarlabel>
+<sonarmineralscanner>Mineral scanner</sonarmineralscanner>
+<missions>Missions</missions>
+<missionsonarlabel.target>Target</missionsonarlabel.target>
+<missionsonarlabel.nest>Nest</missionsonarlabel.nest>
+<sideobjective>Side objective</sideobjective>
+<beaconstationactivetooltip>There's an active ‖color:gui.orange‖beacon station‖end‖ in this passageway, which helps human habitation spread into nearby locations.</beaconstationactivetooltip>
+<beaconstationinactivetooltip>There's an inactive ‖color:gui.orange‖beacon station‖end‖ in this passageway. Getting it back online will make it easier for human habitation to spread into nearby locations.</beaconstationinactivetooltip>
+<huntinggroundstooltip>A creature from the Abyss has made this passageway its ‖color:gui.orange‖hunting grounds‖end‖. Until the beast is dead, new outposts won't be established in the adjacent locations, and existing outposts may get abandoned.</huntinggroundstooltip>
+<enteremptylocation>Select a destination and leave the passageway</enteremptylocation>
+<undockingdisabledbymission>You cannot undock from the outpost before the mission is completed.</undockingdisabledbymission>
+<hostagesdiscovered>The hostages have been located, but still need to be escorted out of the outpost safely. You may want to take their handcuffs off and order them to follow you.</hostagesdiscovered>
+
+<!-- Entity categories -->
+<mapentitycategory.all>All</mapentitycategory.all>
+<mapentitycategory.structure>Structure</mapentitycategory.structure>
+<mapentitycategory.machine>Machine</mapentitycategory.machine>
+<mapentitycategory.equipment>Equipment</mapentitycategory.equipment>
+<mapentitycategory.electrical>Electrical</mapentitycategory.electrical>
+<mapentitycategory.material>Material</mapentitycategory.material>
+<mapentitycategory.misc>Misc</mapentitycategory.misc>
+<mapentitycategory.alien>Alien</mapentitycategory.alien>
+<mapentitycategory.itemassembly>ItemAssembly</mapentitycategory.itemassembly>
+<mapentitycategory.legacy>Legacy</mapentitycategory.legacy>
+<mapentitycategory.decorative>Decorative</mapentitycategory.decorative>
+<mapentitycategory.wall>Wall</mapentitycategory.wall>
+<mapentitycategory.wrecked>Wrecked</mapentitycategory.wrecked>
+<mapentitycategory.thalamus>Thalamus</mapentitycategory.thalamus>
+<mapentitycategory.medical>Medical</mapentitycategory.medical>
+<mapentitycategory.weapon>Weapon</mapentitycategory.weapon>
+<mapentitycategory.diving>Diving</mapentitycategory.diving>
+<mapentitycategory.fuel>Fuel</mapentitycategory.fuel>
+<ItemAssemblies>Item assemblies</ItemAssemblies>
+
+<!-- Display names -->
+<displayname.oxygentankempty>Oxygen Tank (empty)</displayname.oxygentankempty>
+<displayname.weldingfueltankempty>Welding Fuel Tank (empty)</displayname.weldingfueltankempty>
+<displayname.scrapsavantitem>[itemname] (Scrap Savant)</displayname.scrapsavantitem>
+<displayname.recycleitem>[itemname] (recycle)</displayname.recycleitem>
+<displayname.emptyitem>[itemname] (empty)</displayname.emptyitem>
+
+<!-- Doors -->
+<entityname.door>Custom Door</entityname.door>
+<entitydescription.door>A sliding door with no integrated buttons—has to be wired manually.</entitydescription.door>
+<entityname.windoweddoor>Custom Windowed Door</entityname.windoweddoor>
+<entitydescription.windoweddoor>A sliding door with a window. No integrated buttons—has to be wired manually.</entitydescription.windoweddoor>
+<entityname.hatch>Custom Hatch</entityname.hatch>
+<entitydescription.hatch>A door, but on the horizontal axis. No integrated buttons—has to be wired manually.</entitydescription.hatch>
+<entityname.doorwbuttons>Door with Buttons</entityname.doorwbuttons>
+<entitydescription.doorwbuttons>A sliding door with two integrated buttons.</entitydescription.doorwbuttons>
+<entityname.windoweddoorwbuttons>Windowed Door with Buttons</entityname.windoweddoorwbuttons>
+<entitydescription.windoweddoorwbuttons>A sliding door with a window and two integrated buttons.</entitydescription.windoweddoorwbuttons>
+<entityname.hatchwbuttons>Hatch with Buttons</entityname.hatchwbuttons>
+<entitydescription.hatchwbuttons>A door, but on the horizontal axis. Two integrated buttons.</entitydescription.hatchwbuttons>
+
+<!-- Machine -->
+<entityname.navterminal>Navigation Terminal</entityname.navterminal>
+<entitydescription.navterminal>Usable device for setting the course of the sub.</entitydescription.navterminal>
+<entityname.shuttlenavterminal>Shuttle Navigation Terminal</entityname.shuttlenavterminal>
+<entitydescription.shuttlenavterminal>Usable device for setting the course of the shuttle.</entitydescription.shuttlenavterminal>
+<entityname.sonarmonitor>Sonar Monitor</entityname.sonarmonitor>
+<entitydescription.sonarmonitor>Usable device for observing the sub's sonar. Non-interactive.</entitydescription.sonarmonitor>
+<entityname.statusmonitor>Status Monitor</entityname.statusmonitor>
+<entitydescription.statusmonitor>Usable device for viewing a schematic of the sub as well as the status of each room.</entitydescription.statusmonitor>
+<entityname.sonartransducer>Sonar Transducer</entityname.sonartransducer>
+<entitydescription.sonartransducer>Sonar generator, allowing the sonar monitors and navigation terminals to receive a sonar signal other than the default one (useful for drones and remote-controlled shuttles).</entitydescription.sonartransducer>
+<entityname.engine>Engine</entityname.engine>
+<entitydescription.engine>Usable device for generating motion on the X axis.</entitydescription.engine>
+<entityname.largeengine>Large Engine</entityname.largeengine>
+<entitydescription.largeengine>Usable device for generating motion on the X axis.</entitydescription.largeengine>
+<entityname.shuttleengine>Shuttle Engine</entityname.shuttleengine>
+<entitydescription.shuttleengine>Usable device for generating motion on the X axis.</entitydescription.shuttleengine>
+<entityname.fabricator>Fabricator</entityname.fabricator>
+<entitydescription.fabricator>A machine capable of manufacturing a wide range of items out of basic raw materials.</entitydescription.fabricator>
+<entityname.medicalfabricator>Medical Fabricator</entityname.medicalfabricator>
+<entitydescription.medicalfabricator>A machine that can be used to manufacture various medicines.</entitydescription.medicalfabricator>
+<entityname.deconstructor>Deconstructor</entityname.deconstructor>
+<entitydescription.deconstructor>Disassembles and breaks down items to reusable components and material bars.</entitydescription.deconstructor>
+<entityname.oxygenerator>Oxygen Generator</entityname.oxygenerator>
+<entitydescription.oxygenerator>Usable device for oxygen generation—must be linked to vents to work. Also recharges oxygen tanks.</entitydescription.oxygenerator>
+<entityname.shuttleoxygenerator>Shuttle Oxygen Generator</entityname.shuttleoxygenerator>
+<entitydescription.shuttleoxygenerator>Usable device for oxygen generation—must be linked to vents to work. Also recharges oxygen tanks.</entitydescription.shuttleoxygenerator>
+<entityname.vent>Vent</entityname.vent>
+<entitydescription.vent>Oxygen output point. Must be linked to an oxygen generator to work.</entitydescription.vent>
+<entityname.pump>Pump</entityname.pump>
+<entitydescription.pump>Usable device for moving water.</entitydescription.pump>
+<entityname.smallpump>Small Pump</entityname.smallpump>
+<entitydescription.smallpump>Usable device for moving water.</entitydescription.smallpump>
+<entityname.searchlight>Searchlight</entityname.searchlight>
+<entitydescription.searchlight>Aimable lighting.</entitydescription.searchlight>
+<entityname.reactor1>Nuclear Reactor</entityname.reactor1>
+<entitydescription.reactor1>Usable device for generating electrical power.</entitydescription.reactor1>
+<entityname.coilgun>Coilgun</entityname.coilgun>
+<entitydescription.coilgun>A rapid-firing turret that propels metal bolts using electromagnets. Generally not very effective against large or heavily armored targets, but ideal for taking down smaller enemies.</entitydescription.coilgun>
+<entityname.coilgunloader>Coilgun Loader</entityname.coilgunloader>
+<entitydescription.coilgunloader>Feeds coilgun ammunition into a linked coilgun.</entitydescription.coilgunloader>
+<entityname.depthchargetube>Depth Charge Tube</entityname.depthchargetube>
+<entitydescription.depthchargetube>Deploys a depth charge or decoy.</entitydescription.depthchargetube>
+<entityname.depthchargeloader>Depth Charge Loader</entityname.depthchargeloader>
+<entitydescription.depthchargeloader>Feeds depth charges and decoys into a linked depth charge tube.</entitydescription.depthchargeloader>
+<entityname.dischargecoil>Electrical Discharge Coil</entityname.dischargecoil>
+<entitydescription.dischargecoil>Produces a harmful localized electrical shock across a portion of the adjacent hull.</entitydescription.dischargecoil>
+<entityname.railgun>Railgun</entityname.railgun>
+<entitydescription.railgun>A heavy turret that uses electromagnetic force to launch shells at very high velocities. Requires very large surges of power (usually supplied by supercapacitors) and has a low rate of fire, and as such it's most often used against large and heavily armored targets.</entitydescription.railgun>
+<entityname.periscope>Periscope</entityname.periscope>
+<entitydescription.periscope>A device that can be used to observe the outside of the sub by connecting it to a camera, or to control weapons such as the railgun and coilgun.</entitydescription.periscope>
+<entityname.railgunloader>Railgun Loader</entityname.railgunloader>
+<entitydescription.railgunloader>Feeds railgun ammunition into a linked railgun.</entitydescription.railgunloader>
+<entityname.railgunloadersinglevertical>Railgun Loader Single Vertical</entityname.railgunloadersinglevertical>
+<entitydescription.railgunloadersinglevertical>Feeds railgun ammunition into a linked railgun. Single shot version.</entitydescription.railgunloadersinglevertical>
+<entityname.railgunloadersinglehorizontal>Railgun Loader Single Horizontal</entityname.railgunloadersinglehorizontal>
+<entitydescription.railgunloadersinglehorizontal>Feeds railgun ammunition into a linked railgun. Single shot version.</entitydescription.railgunloadersinglehorizontal>
+<entityname.miningmachines>Mining Machine</entityname.miningmachines>
+<entityname.coilgunammoshelf>Ammunition Shelf</entityname.coilgunammoshelf>
+<entitydescription.coilgunammoshelf>A way to neatly stow ammunition boxes.</entitydescription.coilgunammoshelf>
+<entityname.turrethardpoint>Turret Hardpoint</entityname.turrethardpoint>
+<entitydescription.turrethardpoint>An empty weapon station turrets can be installed on.</entitydescription.turrethardpoint>
+<entityname.blankperiscope>Periscope Base</entityname.blankperiscope>
+<entityname.blankloader>Loader Base</entityname.blankloader>
+<entityname.railguncanistershell>Canister Shell</entityname.railguncanistershell>
+<entitydescription.railguncanistershell>A reloadable burst-type munition for the railgun.</entitydescription.railguncanistershell>
+<entityname.railguncanistershellpellet>Canister Shell Pellet</entityname.railguncanistershellpellet>
+<entitydescription.railguncanistershellpellet>A pellet fired out of a canister shell.</entitydescription.railguncanistershellpellet>
+<entityname.pulselaser>Pulse Laser</entityname.pulselaser>
+<entitydescription.pulselaser>A large pulsed chemical laser attached to a turret, capable of firing intense beams of energy after charging up. Inflicts extreme burns on anything it hits.</entitydescription.pulselaser>
+<entityname.pulselaserammobox>Pulse Laser Fuel Box</entityname.pulselaserammobox>
+<entitydescription.pulselaserammobox>A box of arranged chemicals and a focusing lens, useful for inducing intense bursts of energy. Used as ammo by the Pulse Laser.</entitydescription.pulselaserammobox>
+<entityname.pulselaserbolt>Pulse Laser Bolt</entityname.pulselaserbolt>
+<entityname.pulselaserloader>Pulse Laser Loader</entityname.pulselaserloader>
+<entityname.chaingun>Chaingun</entityname.chaingun>
+<entitydescription.chaingun>A powerful multiple-barrel turreted weapon, based on coilgun technology. Though somewhat unwieldy and slow to wind up to its firing state, its capability to deliver a hail of high-velocity metal at any would-be foe is unparalleled.</entitydescription.chaingun>
+<entityname.chaingunammobox>Chaingun Ammunition Box</entityname.chaingunammobox>
+<entityname.chaingunloader>Chaingun Loader</entityname.chaingunloader>
+<entitydescription.chaingunammobox>A heavy box of ammo for the Chaingun.</entitydescription.chaingunammobox>
+<entityname.chaingunbolt>Chaingun Bolt</entityname.chaingunbolt>
+<entityname.largeturrethardpoint>Large Turret Hardpoint</entityname.largeturrethardpoint>
+<entitydescription.largeturrethardpoint>An empty weapon station large turrets can be installed on.</entitydescription.largeturrethardpoint>
+<entityname.doublecoilgun>Double Coilgun</entityname.doublecoilgun>
+<entitydescription.doublecoilgun>A double-barreled version of the coilgun.</entitydescription.doublecoilgun>
+<entityname.flakcannon>Flak Cannon</entityname.flakcannon>
+<entitydescription.flakcannon>A large cannon, designed to fire shells that explode into sharp shrapnel fragments.</entitydescription.flakcannon>
+<entityname.flakcannonloader>Flak Cannon Loader</entityname.flakcannonloader>
+<entityname.flakcannonammobox>Spreader Flak Shells Box</entityname.flakcannonammobox>
+<entitydescription.flakcannonammobox>A heavy box of wide-spread shrapnel ammo for the flak cannon. Good against swarms.</entitydescription.flakcannonammobox>
+<entityname.flakbolt>Flak Shell</entityname.flakbolt>
+<entityname.flakshrapnel>Flak Fragment</entityname.flakshrapnel>
+<entityname.flakcannondirectionalammobox>Focused Flak Shells Box</entityname.flakcannondirectionalammobox>
+<entitydescription.flakcannondirectionalammobox>A heavy box of low spread ammo for the flak cannon. Good against single targets.</entitydescription.flakcannondirectionalammobox>
+<entityname.flakboltdirectional>Flak Shell (Choked)</entityname.flakboltdirectional>
+<entityname.flakshrapneldirectional>Heavy Flak Fragment</entityname.flakshrapneldirectional>
+<entityname.flakcannonammoboxphysicorium>Physicorium Flak Shells Box</entityname.flakcannonammoboxphysicorium>
+<entitydescription.flakcannonammoboxphysicorium>A backbreakingly heavy box of ammo for the flak cannon, utilizing Physicorium as its main material.</entitydescription.flakcannonammoboxphysicorium>
+<entityname.flakboltphysicorium>Physicorium Flak Shell</entityname.flakboltphysicorium>
+<entityname.flakshrapnelphysicorium>Physicorium Flak Fragment</entityname.flakshrapnelphysicorium>
+<entityname.flakcannonammoboxexplosive>Explosive Flak Shells Box</entityname.flakcannonammoboxexplosive>
+<entitydescription.flakcannonammoboxexplosive>A heavy box of ammo for the flak cannon, loaded with high explosive materials.</entitydescription.flakcannonammoboxexplosive>
+<entityname.flakboltexplosive>Explosive Flak Shell</entityname.flakboltexplosive>
+<entityname.flakshrapnelexplosive>Explosive Flak Fragment</entityname.flakshrapnelexplosive>
+
+<!-- Equipment -->
+<entityname.idcard>ID Card</entityname.idcard>
+<entitydescription.idcard>Allows limited access to areas of the sub.</entitydescription.idcard>
+<entityname.alienpistol>Alien Pistol</entityname.alienpistol>
+<entitydescription.alienpistol>A handgun powered by alien power cells.</entitydescription.alienpistol>
+<entityname.captainscap>Captain's Cap</entityname.captainscap>
+<entitydescription.captainscap>A token of the captain's unquestionable authority.</entitydescription.captainscap>
+<entityname.captainsuniform>Captain's Uniform</entityname.captainsuniform>
+<entitydescription.captainsuniform>Makes you look like you might be in charge.</entitydescription.captainsuniform>
+<entityname.healthscanner>Health Scanner HUD</entityname.healthscanner>
+<entitydescription.healthscanner>A heads-up display that shows information about the vital signs and status of nearby humans.</entitydescription.healthscanner>
+<entityname.doctorsuniform2>Doctor's Uniform</entityname.doctorsuniform2>
+<entitydescription.doctorsuniform2>Makes you look like you might be useful in a medical emergency.</entitydescription.doctorsuniform2>
+<entityname.orangejumpsuit>Orange Jumpsuit</entityname.orangejumpsuit>
+<entitydescription.orangejumpsuit>The fire-resistant fabric offers some protection against fires.</entitydescription.orangejumpsuit>
+<entityname.bluejumpsuit>Blue Jumpsuit</entityname.bluejumpsuit>
+<entitydescription.bluejumpsuit>The fire-resistant fabric offers some protection against fires.</entitydescription.bluejumpsuit>
+<entityname.toolbox>Storage Container</entityname.toolbox>
+<entitydescription.toolbox>A portable container for storing tools and supplies.</entitydescription.toolbox>
+<entityname.headset>Headset</entityname.headset>
+<entitydescription.headset>Allows remote communication among the crew.</entitydescription.headset>
+<entityname.clownmask>Clown Mask</entityname.clownmask>
+<entitydescription.clownmask>Praise the honkmother.</entitydescription.clownmask>
+<entityname.clowncostume>Clown Costume</entityname.clowncostume>
+<entitydescription.clowncostume>Praise the honkmother.</entitydescription.clowncostume>
+<entityname.assistantclothes>Assistant Clothes</entityname.assistantclothes>
+<entitydescription.assistantclothes>Even the assistant needs clothing.</entitydescription.assistantclothes>
+<entityname.watchmanclothes>Watchman Clothes</entityname.watchmanclothes>
+<entitydescription.watchmanclothes>Makes you look like you might offer a mission to a passerby at any moment.</entitydescription.watchmanclothes>
+<entityname.vipoutfit>VIP Outfit</entityname.vipoutfit>
+<entityname.prisonerclothes>Prisoner Outfit</entityname.prisonerclothes>
+<entityname.securityuniform2>Security Officer's Uniform</entityname.securityuniform2>
+<entitydescription.securityuniform2>Obey my authority!</entitydescription.securityuniform2>
+<entityname.bodyarmor>Body Armor</entityname.bodyarmor>
+<entitydescription.bodyarmor>While the body armor won't offer adequate protection against most of the inhabitants of the subsurface ocean, it can be extremely useful if there are traitors on board.</entitydescription.bodyarmor>
+<entityname.ballistichelmet1>Ballistic Helmet</entityname.ballistichelmet1>
+<entitydescription.ballistichelmet1>While the helmet won't offer adequate protection against most of the inhabitants of the subsurface ocean, it can be extremely useful if there are traitors on board.</entitydescription.ballistichelmet1>
+<entityname.handcuffs>Handcuffs</entityname.handcuffs>
+<entitydescription.handcuffs>Useful for restraining problem players.</entitydescription.handcuffs>
+<entityname.riotshield>Riot Shield</entityname.riotshield>
+<entitydescription.riotshield>Blocks projectiles and prevents creatures or people from passing.</entitydescription.riotshield>
+<entityname.divingmask>Diving Mask</entityname.divingmask>
+<entitydescription.divingmask>Small enough to carry around in case it's needed, but won't protect you from the water pressure in the event of a full-blown hull breach.</entitydescription.divingmask>
+<entityname.divingsuit>Diving Suit</entityname.divingsuit>
+<entitydescription.divingsuit>An atmospheric diving suit capable of withstanding the immense pressure under Europa's crust. Only offers adequate protection up to the depth of 4,000 meters—beyond this point, an Abyss or Combat suit is required.</entitydescription.divingsuit>
+<entityname.underwaterscooter>Underwater Scooter</entityname.underwaterscooter>
+<entitydescription.underwaterscooter>A battery-powered underwater propulsion device.</entitydescription.underwaterscooter>
+<entityname.antibleeding1>Bandage</entityname.antibleeding1>
+<entitydescription.antibleeding1>Basic bandages, useful in the treatment of bleeding wounds and burns.</entitydescription.antibleeding1>
+<entityname.antibleeding2>Plastiseal</entityname.antibleeding2>
+<entitydescription.antibleeding2>A synthetic skin with hemostatic properties, able to quickly seal most wounds.</entitydescription.antibleeding2>
+<entityname.antibleeding3>Antibiotic Glue</entityname.antibleeding3>
+<entitydescription.antibleeding3>An antibiotic glue with hemostatic properties. Seals bleeding wounds almost immediately and treats burns very effectively. Use with care as it may cause mobile clots in the bloodstream.</entitydescription.antibleeding3>
+<entityname.weldingtool>Welding Tool</entityname.weldingtool>
+<entitydescription.weldingtool>One of the most crucial tools on board the submarine. Also works underwater.</entitydescription.weldingtool>
+<entityname.plasmacutter>Plasma Cutter</entityname.plasmacutter>
+<entitydescription.plasmacutter>Cuts through various materials using a jet of ionized oxygen.</entitydescription.plasmacutter>
+<entityname.weldingfueltank>Welding Fuel Tank</entityname.weldingfueltank>
+<entitydescription.weldingfueltank>Fuel for the welding tool.</entitydescription.weldingfueltank>
+<entityname.oxygentank>Oxygen Tank</entityname.oxygentank>
+<entitydescription.oxygentank>Portable oxygen container.</entitydescription.oxygentank>
+<entityname.extinguisher>Fire Extinguisher</entityname.extinguisher>
+<entitydescription.extinguisher>A handheld carbon dioxide extinguisher.</entitydescription.extinguisher>
+<entityname.screwdriver>Screwdriver</entityname.screwdriver>
+<entitydescription.screwdriver>Makes electrical repairs and rewiring possible.</entitydescription.screwdriver>
+<entityname.wrench>Wrench</entityname.wrench>
+<entitydescription.wrench>Makes mechanical repairs possible.</entitydescription.wrench>
+<entityname.crowbar>Crowbar</entityname.crowbar>
+<entitydescription.crowbar>Forces doors and hatches open. Also a blunt weapon.</entitydescription.crowbar>
+<entityname.handheldsonar>Handheld Sonar</entityname.handheldsonar>
+<entitydescription.handheldsonar>Portable sonar, handy for exploration.</entitydescription.handheldsonar>
+<entityname.sonarbeacon>Sonar Beacon</entityname.sonarbeacon>
+<entitydescription.sonarbeacon>Produces a localized signal that can be detected by a sonar monitor, handheld sonar, or navigation terminal.</entitydescription.sonarbeacon>
+<sonarbeacon.beaconactive>Beacon active</sonarbeacon.beaconactive>
+<sonarbeacon.beaconsignal>Beacon signal</sonarbeacon.beaconsignal>
+<entityname.flashlight>Flashlight</entityname.flashlight>
+<entitydescription.flashlight>Handheld light.</entitydescription.flashlight>
+<entityname.flare>Flare</entityname.flare>
+<entitydescription.flare>Temporary handheld light. Useful for marking a path while exploring outside the sub.</entitydescription.flare>
+<entityname.alienflare>Alien Flare</entityname.alienflare>
+<entitydescription.alienflare>Temporary handheld light. Useful for marking a path while exploring outside the sub. Burns for longer than a regular flare.</entitydescription.alienflare>
+<entityname.coilgunammobox>Coilgun Ammunition Box</entityname.coilgunammobox>
+<entitydescription.coilgunammobox>Ammunition for the coilgun.</entitydescription.coilgunammobox>
+<entityname.coilgunammoboxexplosive>Exploding Ammunition Box</entityname.coilgunammoboxexplosive>
+<entitydescription.coilgunammoboxexplosive>Ammunition for the coilgun. Explodes on impact.</entitydescription.coilgunammoboxexplosive>
+<entityname.coilgunammoboxpiercing>Piercing Ammunition Box</entityname.coilgunammoboxpiercing>
+<entitydescription.coilgunammoboxpiercing>Coilgun ammo that has piercing capabilities.</entitydescription.coilgunammoboxpiercing>
+<entityname.chaingunammoboxphysicorium>Physicorium Chaingun Ammunition Box</entityname.chaingunammoboxphysicorium>
+<entitydescription.chaingunammoboxphysicorium>A backbreakingly heavy box of ammunition for the chaingun, utilizing Physicorium as its main material. These rounds have enough stopping power to occasionally stun any foe they hit.</entitydescription.chaingunammoboxphysicorium>
+<entityname.pulselaserammoboxtrilaser>Pulse Tri-Laser Fuel Box</entityname.pulselaserammoboxtrilaser>
+<entitydescription.pulselaserammoboxtrilaser>A box of containing a special concoction of chemicals and rare materials. The lens used splits the laser in three, allowing the laser to hit multiple targets at once.</entitydescription.pulselaserammoboxtrilaser>
+<entityname.coilgunboltexplosive>Exploding Coilgun Bolt</entityname.coilgunboltexplosive>
+<entitydescription.coilgunboltexplosive>Ammunition for the coilgun. Explodes on impact.</entitydescription.coilgunboltexplosive>
+<entityname.coilgunboltpiercing>Piercing Coilgun Bolt</entityname.coilgunboltpiercing>
+<entitydescription.coilgunboltpiercing>Coilgun ammo that has piercing capabilities.</entitydescription.coilgunboltpiercing>
+<entityname.uex>UEX</entityname.uex>
+<entitydescription.uex>A simple explosive compound made of sodium and phosphorus.</entitydescription.uex>
+<entityname.c4block>C-4 Block</entityname.c4block>
+<entitydescription.c4block>A stable explosive compound.</entitydescription.c4block>
+<entityname.compoundn>Compound N</entityname.compoundn>
+<entitydescription.compoundn>A stable explosive compound.</entitydescription.compoundn>
+<entityname.volatilecompoundn>Volatile Compound N</entityname.volatilecompoundn>
+<entitydescription.volatilecompoundn>An unstable explosive compound.</entitydescription.volatilecompoundn>
+<entityname.ic4block>IC-4 Block</entityname.ic4block>
+<entitydescription.ic4block>A compound made of C-4 and incendium.</entitydescription.ic4block>
+<entityname.detonator>Detonator</entityname.detonator>
+<entitydescription.detonator>A device that detonates any contained explosive when receiving a signal.</entitydescription.detonator>
+<entityname.spear>Harpoon</entityname.spear>
+<entitydescription.spear>A harpoon for the harpoon gun.</entitydescription.spear>
+<entityname.alienspear>Physicorium Harpoon</entityname.alienspear>
+<entitydescription.alienspear>A harpoon for the harpoon gun, made of alien material.</entitydescription.alienspear>
+<entityname.explosivespear>Explosive Harpoon</entityname.explosivespear>
+<entitydescription.explosivespear>A harpoon for the harpoon gun.</entitydescription.explosivespear>
+<entityname.harpoongun>Harpoon Gun</entityname.harpoongun>
+<entitydescription.harpoongun>Launches harpoons, explosive harpoons, and alien harpoons.</entitydescription.harpoongun>
+<entityname.syringegun>Syringe Gun</entityname.syringegun>
+<entitydescription.syringegun>Launches syrettes containing drugs or poisons.</entitydescription.syringegun>
+<entityname.revolverround>Revolver Round</entityname.revolverround>
+<entitydescription.revolverround>.38 caliber. Might stop a person...</entitydescription.revolverround>
+<entityname.revolver>Revolver</entityname.revolver>
+<entitydescription.revolver>.38 caliber.</entitydescription.revolver>
+<entityname.stungrenade>Stun Grenade</entityname.stungrenade>
+<entitydescription.stungrenade>Produces bright light and a loud sound on detonation, which stuns nearby characters.</entitydescription.stungrenade>
+<entityname.empgrenade>EMP Grenade</entityname.empgrenade>
+<entitydescription.empgrenade>Damages electrical equipment.</entitydescription.empgrenade>
+<entityname.fraggrenade>Frag Grenade</entityname.fraggrenade>
+<entitydescription.fraggrenade>General purpose fragmentation grenade. Use carefully.</entitydescription.fraggrenade>
+<entityname.incendiumgrenade>Incendium Grenade</entityname.incendiumgrenade>
+<entitydescription.incendiumgrenade>Incendiary grenade. Use very carefully.</entitydescription.incendiumgrenade>
+<entityname.stunbaton>Stun Baton</entityname.stunbaton>
+<entitydescription.stunbaton>If verbal orders are insufficient, a high-voltage shock from a stun baton may be enough to beat an unruly crewmember into submission.</entitydescription.stunbaton>
+<entityname.divingknife>Diving Knife</entityname.divingknife>
+<entitydescription.divingknife>Stabs, pokes, cuts and slashes.</entitydescription.divingknife>
+<entityname.bikehorn>Bike Horn</entityname.bikehorn>
+<entitydescription.bikehorn>HONK!</entitydescription.bikehorn>
+<entityname.oxygenitetank>Oxygenite Tank</entityname.oxygenitetank>
+<entitydescription.oxygenitetank>A tank containing liquid Oxygenite.</entitydescription.oxygenitetank>
+<entityname.batterycell>Battery Cell</entityname.batterycell>
+<entitydescription.batterycell>Used as a power source for various handheld devices. Most submarines have several stationary backup batteries with recharge docks for battery cells.</entitydescription.batterycell>
+<entityname.fulguriumbatterycell>Fulgurium Battery Cell</entityname.fulguriumbatterycell>
+<entitydescription.fulguriumbatterycell>A battery cell constructed of the rare and poorly understood compound Fulgurium.</entitydescription.fulguriumbatterycell>
+<entityname.alienarmor>Physicorium Body Armor</entityname.alienarmor>
+<entitydescription.alienarmor>A body armor fabricated from an alien metamaterial.</entitydescription.alienarmor>
+<entityname.alienhelmet>Physicorium Helmet</entityname.alienhelmet>
+<entitydescription.alienhelmet>A helmet fabricated from an alien metamaterial.</entitydescription.alienhelmet>
+<entityname.flamer>Flamer</entityname.flamer>
+<entitydescription.flamer>An incendiary weapon that fires a stream of burning welding fuel.</entitydescription.flamer>
+<entityname.smg>SMG</entityname.smg>
+<entitydescription.smg>A .45 caliber submachine gun.</entitydescription.smg>
+<entityname.smgmagazine>SMG Magazine</entityname.smgmagazine>
+<entitydescription.smgmagazine>A magazine for .45 caliber SMG rounds.</entitydescription.smgmagazine>
+<entityname.smground>SMG Round</entityname.smground>
+<entitydescription.smground>A .45 caliber submachine gun round.</entitydescription.smground>
+<entityname.grenadelauncher>Grenade Launcher</entityname.grenadelauncher>
+<entitydescription.grenadelauncher>A portable grenade launcher for 40mm grenades.</entitydescription.grenadelauncher>
+<entityname.40mmgrenade>40mm Grenade</entityname.40mmgrenade>
+<entitydescription.40mmgrenade>Ammunition for grenade launcher.</entitydescription.40mmgrenade>
+<entityname.40mmstungrenade>40mm Stun Grenade</entityname.40mmstungrenade>
+<entitydescription.40mmstungrenade>Ammunition for grenade launcher. Non-lethal.</entitydescription.40mmstungrenade>
+<entityname.shotgun>Riot Shotgun</entityname.shotgun>
+<entitydescription.shotgun>A shotgun designed for crowd control.</entitydescription.shotgun>
+<entityname.shotgunshell>Shotgun Shell</entityname.shotgunshell>
+<entitydescription.shotgunshell>Ammunition for a shotgun. Lethal.</entitydescription.shotgunshell>
+<entityname.stungun>Stun Gun</entityname.stungun>
+<entitydescription.stungun>A device for firing electrified darts.</entitydescription.stungun>
+<entityname.stungundart>Stun Gun Dart</entityname.stungundart>
+<entitydescription.stungundart>Causes electric shock to incapacitate a target. Non-lethal.</entitydescription.stungundart>
+<entityname.toyhammer>Toy Hammer</entityname.toyhammer>
+<entitydescription.toyhammer>Non-lethal but extremely annoying.</entitydescription.toyhammer>
+<entityname.crawlermask>Crawler Mask</entityname.crawlermask>
+<entitydescription.crawlermask>Protects wearer's identity. Fun at certain parties.</entitydescription.crawlermask>
+<entityname.huskstinger>Husk Stinger</entityname.huskstinger>
+<entitydescription.huskstinger>A makeshift stabbing tool.</entitydescription.huskstinger>
+<entityname.shellshield>Moloch Shell Fragment</entityname.shellshield>
+<entitydescription.shellshield>A sturdy piece of a moloch's shell.</entitydescription.shellshield>
+<entityname.mudraptorshell>Mudraptor Shell</entityname.mudraptorshell>
+<entitydescription.mudraptorshell>A protective shell of a mudraptor.</entitydescription.mudraptorshell>
+<entityname.accordion>Accordion</entityname.accordion>
+<entitydescription.accordion>An old handmade accordion.</entitydescription.accordion>
+<entityname.bongodrums>Bongo Drums</entityname.bongodrums>
+<entitydescription.bongodrums>An old handmade pair of bongo drums.</entitydescription.bongodrums>
+<entityname.captainspipe>Captain's Pipe</entityname.captainspipe>
+<entitydescription.captainspipe>For calming the nerves when the sea is stormy.</entitydescription.captainspipe>
+<entityname.incendiumfueltank>Incendium Fuel Tank</entityname.incendiumfueltank>
+<entityname.physicoriumammobox>Physicorium Ammunition Box</entityname.physicoriumammobox>
+<entitydescription.physicoriumammobox>Coilgun ammunition made of alien material.</entitydescription.physicoriumammobox>
+<entityname.physicoriumbolt>Physicorium Bolt</entityname.physicoriumbolt>
+<entityname.orangejumpsuit1>Hazmat Suit</entityname.orangejumpsuit1>
+<entitydescription.orangejumpsuit1>Has a protective lead shielding against radiation.</entitydescription.orangejumpsuit1>
+<entityname.orangejumpsuit2>Engineer's Jumpsuit</entityname.orangejumpsuit2>
+<entityname.bluejumpsuit1>Boiler Suit</entityname.bluejumpsuit1>
+<entityname.bluejumpsuit2>Mechanic's Jumpsuit</entityname.bluejumpsuit2>
+<entityname.captainscap1>Veteran's Cap</entityname.captainscap1>
+<entitydescription.captainscap1>A well-worn cap that has seen many ports.</entitydescription.captainscap1>
+<entityname.captainsuniform1>Veteran's Jacket</entityname.captainsuniform1>
+<entitydescription.captainsuniform1>A warm jacket to protect its wearer against the cold depths.</entitydescription.captainsuniform1>
+<entityname.captainscap2>Renegade's Hat</entityname.captainscap2>
+<entitydescription.captainscap2>Strikes fear into the hearts of the Coalition.</entitydescription.captainscap2>
+<entityname.captainsuniform2>Renegade's Jacket</entityname.captainsuniform2>
+<entitydescription.captainsuniform2>Indicates who is in charge.</entitydescription.captainsuniform2>
+<entityname.captainscap3>Admiral's Hat</entityname.captainscap3>
+<entityname.captainsuniform3>Admiral's Uniform</entityname.captainsuniform3>
+<entityname.securityuniform1>Commando's Fatigues</entityname.securityuniform1>
+<entitydescription.securityuniform1>I ain't got time to bleed.</entitydescription.securityuniform1>
+<entityname.securityuniform3>Gunner's Uniform</entityname.securityuniform3>
+<entitydescription.securityuniform3>A standard issue gunner's uniform.</entitydescription.securityuniform3>
+<entityname.ballistichelmet2>Gunner's Helmet</entityname.ballistichelmet2>
+<entitydescription.ballistichelmet2>A bit lighter than a regular ballistic helmet; designed not to get in the way when one is operating a periscope.</entitydescription.ballistichelmet2>
+<entityname.ballistichelmet3>Riot Helmet</entityname.ballistichelmet3>
+<entitydescription.ballistichelmet3>Designed for crowd control but equally useful against alien invaders.</entitydescription.ballistichelmet3>
+<entityname.doctorsuniform1>Medic's Fatigues</entityname.doctorsuniform1>
+<entitydescription.doctorsuniform1>For frontline medics. Offers some protection against enemies.</entitydescription.doctorsuniform1>
+<entityname.baseballcap>Baseball Cap</entityname.baseballcap>
+<entitydescription.baseballcap>Every self-respecting mechanic should have one.</entitydescription.baseballcap>
+<entityname.duffelbag>Duffel Bag</entityname.duffelbag>
+<entitydescription.duffelbag>The traditional way of storing a deceased seafarer's belongings until they can be delivered to their next of kin (or stolen or sold).</entitydescription.duffelbag>
+<entityname.outpostoutfit1>Outpost Dweller's Attire</entityname.outpostoutfit1>
+<entitydescription.outpostoutfit1>Not much to look at, but pretty warm and comfortable.</entitydescription.outpostoutfit1>
+<entityname.stationadminoutfit>Station Administrator's Outfit</entityname.stationadminoutfit>
+<entityname.crewchiefoutfit>Crew Chief's Outfit</entityname.crewchiefoutfit>
+<entityname.securitypatroloutfit>Outpost Security Uniform</entityname.securitypatroloutfit>
+<entityname.medicalofficeroutfit>Medical Officer's Outfit</entityname.medicalofficeroutfit>
+<entityname.quartermasteroutfit>Quartermaster's Outfit</entityname.quartermasteroutfit>
+<entityname.researcheroutfit>Researcher's Outfit</entityname.researcheroutfit>
+<entityname.mineroutfit>Miner's Overalls</entityname.mineroutfit>
+<entityname.minerhelmet>Mining Helmet</entityname.minerhelmet>
+<entityname.sprayer>Sprayer</entityname.sprayer>
+<entitydescription.sprayer>Cleans or paints walls by spraying liquid on them.</entitydescription.sprayer>
+<entityname.shotgununique>Boom Stick</entityname.shotgununique>
+<entitydescription.shotgununique>Barrels of fun.</entitydescription.shotgununique>
+<entityname.spearunique>Ahab's Spear</entityname.spearunique>
+<entitydescription.spearunique>An antique spear named after a legendary captain.</entitydescription.spearunique>
+<entityname.divingknifeunique>Europan Handshake</entityname.divingknifeunique>
+<entitydescription.divingknifeunique>For friends and enemies alike. Mostly enemies.</entitydescription.divingknifeunique>
+<entityname.smgunique>Deadeye Carbine</entityname.smgunique>
+<entitydescription.smgunique>A tactical weapon, available in black and slightly darker black.</entitydescription.smgunique>
+<entityname.flamerunique>Prototype Steam Cannon</entityname.flamerunique>
+<entitydescription.flamerunique>Gets rid of pests like nothing else. Patent pending.</entitydescription.flamerunique>
+<entityname.clownmaskunique>Mother's Countenance</entityname.clownmaskunique>
+<entitydescription.clownmaskunique>Nothing remains hidden under mother's gaze.</entitydescription.clownmaskunique>
+<entityname.clownsuitunique>Mother's Providence</entityname.clownsuitunique>
+<entitydescription.clownsuitunique>Nothing can escape mother's warm embrace.</entitydescription.clownsuitunique>
+<entityname.toolbelt>Toolbelt</entityname.toolbelt>
+<entitydescription.toolbelt>A wearable container for storing tools and supplies.</entitydescription.toolbelt>
+<entityname.chitinhelmet>Chitin Helmet</entityname.chitinhelmet>
+<entitydescription.chitinhelmet>A tough helmet made of chitin.</entitydescription.chitinhelmet>
+<entityname.glowstick>Glowstick</entityname.glowstick>
+<entitydescription.glowstick>Temporary handheld light. Useful for marking a path while exploring outside the sub.</entitydescription.glowstick>
+<entityname.abyssdivingsuit>Abyss Diving Suit</entityname.abyssdivingsuit>
+<entitydescription.abyssdivingsuit>A heavy suit designed for deep sea exploration. Protects against damage and high pressure all the way down to 10,000 meters, reduces oxygen usage, but at a cost of reduced movement speed.</entitydescription.abyssdivingsuit>
+<entityname.combatdivingsuit>Combat Diving Suit</entityname.combatdivingsuit>
+<entitydescription.combatdivingsuit>An agile, lightweight suit designed for combat. Offers some protection against damage and withstands pressure up to the depth of 6,000 meters.</entitydescription.combatdivingsuit>
+<entityname.pressurestabilizer>Pressure Stabilizer</entityname.pressurestabilizer>
+<entitydescription.pressurestabilizer>A special drug that gives the user an immunity to pressure and removes their need for oxygen for a short duration.</entitydescription.pressurestabilizer>
+<entityname.endocrinebooster>Endocrine Booster</entityname.endocrinebooster>
+<entitydescription.endocrinebooster>This medical contraption, when used, bestows the user with permanent performance enhancement.</entitydescription.endocrinebooster>
+<entityname.slipsuit>Slipsuit</entityname.slipsuit>
+<entitydescription.slipsuit>A modified Combat Diving Suit with additional diving fins that aid the user when moving in water. Sadly, the fins also make it difficult to walk on solid ground.</entitydescription.slipsuit>
+<entityname.bandolier>Bandolier</entityname.bandolier>
+<entitydescription.bandolier>A light combat rig, capable of carrying ammunition and other useful items. Thanks to improved ergonomics, increases combat effectiveness with ranged weapons and turrets.</entitydescription.bandolier>
+<entityname.repairpack>Repair Pack</entityname.repairpack>
+<entitydescription.repairpack>A handheld contraption, capable of quickly correcting mechanical and electrical problems. Consumed on use.</entitydescription.repairpack>
+<entityname.autoinjectorheadset>Auto-Injector Headset</entityname.autoinjectorheadset>
+<entitydescription.autoinjectorheadset>A modifed headset utilizing an integrated battery, capable of injecting medicine placed within once the user's vitals drop to a certain level.</entitydescription.autoinjectorheadset>
+<entityname.depletedfuel>Depleted Fuel</entityname.depletedfuel>
+<entitydescription.depletedfuel>A heavy, hard material derived from processing a spent fuel rod. Can be further fabricated into tools and munitions.</entitydescription.depletedfuel>
+<entityname.wrenchhardened>Hardened Wrench</entityname.wrenchhardened>
+<entitydescription.wrenchhardened>A wrench that has gone through a process of hardening using depleted fuel. The strengthened material allows for more efficient repairs and heavier swings.</entitydescription.wrenchhardened>
+<entityname.screwdriverhardened>Hardened Screwdriver</entityname.screwdriverhardened>
+<entitydescription.screwdriverhardened>A screwdriver that has gone through a process of hardening using depleted fuel. The strengthened material allows for more efficient repairs and heavier swings.</entitydescription.screwdriverhardened>
+<entityname.crowbarhardened>Hardened Crowbar</entityname.crowbarhardened>
+<entitydescription.crowbarhardened>A crowbar that has gone through a process of hardening using depleted fuel. The strengthened material makes it easier to pry open doors and bash open heads.</entitydescription.crowbarhardened>
+<entityname.divingknifehardened>Hardened Diving Knife</entityname.divingknifehardened>
+<entitydescription.divingknifehardened>A diving knife that has gone through a process of hardening using depleted fuel. The strengthened material allows for deeper slashes and stabs.</entitydescription.divingknifehardened>
+<entityname.revolverrounddepletedfuel>Depleted Fuel Revolver Round</entityname.revolverrounddepletedfuel>
+<entitydescription.revolverrounddepletedfuel>A .38 round for the revolver, fashioned out of depleted fuel. Along with increased penetration, the ammo has been special-made to also inflict radiation sickness on the target.</entitydescription.revolverrounddepletedfuel>
+<entityname.smgmagazinedepletedfuel>Depleted Fuel SMG Magazine</entityname.smgmagazinedepletedfuel>
+<entitydescription.smgmagazinedepletedfuel>A .45 caliber magazine for the SMG, containing rounds of depleted fuel ammo. Along with increased penetration, the ammo has been special-made to also inflict radiation sickness on the target.</entitydescription.smgmagazinedepletedfuel>
+<entityname.smgrounddepletedfuel>Depleted Fuel SMG Round</entityname.smgrounddepletedfuel>
+<entityname.coilgunammoboxdepletedfuel>Depleted Fuel Coilgun Ammunition Box</entityname.coilgunammoboxdepletedfuel>
+<entitydescription.coilgunammoboxdepletedfuel>A heavy box of depleted fuel ammunition for the coilgun. Along with increased penetration, the ammo has been special-made to also inflict radiation sickness on the target.</entitydescription.coilgunammoboxdepletedfuel>
+<entityname.depletedfuelbolt>Depleted Fuel Bolt</entityname.depletedfuelbolt>
+<entityname.handheldelectricalmonitor>Handheld Electrical Monitor</entityname.handheldelectricalmonitor>
+<entitydescription.handheldelectricalmonitor>A small handheld device that gives the user remote access to information regarding the ship's electrical systems.</entitydescription.handheldelectricalmonitor>
+<entityname.handheldstatusmonitor>Handheld Status Monitor</entityname.handheldstatusmonitor>
+<entitydescription.handheldstatusmonitor>A small handheld device with a screen displaying the current status of the ship, informing the user of any breaches remotely.</entitydescription.handheldstatusmonitor>
+<entityname.electriciansgoggles>Electrician's Goggles</entityname.electriciansgoggles>
+<entitydescription.electriciansgoggles>A device that remotely detects and visualizes electrical fields, allowing an engineer to detect power and signals traveling through wires and to read the values of the signals from a device's connection panel.</entitydescription.electriciansgoggles>
+<entityname.autoshotgun>Autoshotgun</entityname.autoshotgun>
+<entitydescription.autoshotgun>A roughly engineered automatic shotgun with a vast ammo capacity. Its size and heft makes it a bit cumbersome to lug around.</entitydescription.autoshotgun>
+<entityname.handcannon>Handcannon</entityname.handcannon>
+<entitydescription.handcannon>A humongous beast of a revolver, designed to better deal with the large alien threats on Europa than typical firearms.</entitydescription.handcannon>
+<entityname.handcannonround>Handcannon Round</entityname.handcannonround>
+<entitydescription.handcannonround>An exceedingly large .61 revolver round. The unique alloy of materials allows for high penetration and stopping power.</entitydescription.handcannonround>
+<entityname.coalitioncommendation>Commendation</entityname.coalitioncommendation>
+<entitydescription.coalitioncommendation>A small medal fashioned out of copper, originally created by the Coalition. When applied to another crewmember's body, it instantly bestows them with a sum of experience.</entitydescription.coalitioncommendation>
+<entityname.coalitionmedal>Medal</entityname.coalitionmedal>
+<entitydescription.coalitionmedal>A small medal fashioned out of bronze, originally created by the Coalition. When applied to another crewmember's body, it instantly bestows them with a large sum of experience.</entitydescription.coalitionmedal>
+<entityname.assaultrifle>Assault Rifle</entityname.assaultrifle>
+<entitydescription.assaultrifle>An assault rifle chambering 6.8mm cartridges. Though banned by the Coalition, the schematics for these rifles are still passed around Europa as they present a premier option for submarine defense, or as the Separatists would prefer, societal revolution.</entitydescription.assaultrifle>
+<entityname.assaultriflemagazine>Assault Rifle Magazine</entityname.assaultriflemagazine>
+<entitydescription.assaultriflemagazine>A magazine designed for holding 6.8mm cartridges.</entitydescription.assaultriflemagazine>
+<entityname.rifle>Rifle</entityname.rifle>
+<entitydescription.rifle>A .30 caliber rifle with a manual reload mechanism. Slow rate of fire for unskilled users.</entitydescription.rifle>
+<entityname.riflebullet>Rifle Round</entityname.riflebullet>
+<entitydescription.riflebullet>A .30 caliber round for the rifle.</entitydescription.riflebullet>
+<entityname.hmg>HMG</entityname.hmg>
+<entitydescription.hmg>Heavy Machine Gun, capable of dealing a lot of damage, provided the user is skilled enough to handle the recoil.</entitydescription.hmg>
+<entityname.hmgmagazine>HMG Magazine</entityname.hmgmagazine>
+<entitydescription.hmgmagazine>A magazine of 5.56mm rounds for the HMG</entitydescription.hmgmagazine>
+<entityname.hmground>HMG Round</entityname.hmground>
+<entitydescription.hmground>Round of a Heavy Machine Gun</entitydescription.hmground>
+<entityname.harpooncoilrifle>Harpoon Coil-Rifle</entityname.harpooncoilrifle>
+<entitydescription.harpooncoilrifle>An advanced harpoon gun, powered by an energy source to launch harpoons at high velocities.</entitydescription.harpooncoilrifle>
+<entityname.machinepistol>Machine Pistol</entityname.machinepistol>
+<entitydescription.machinepistol>A high rate of fire automatic weapon, using .45 (SMG) caliber magazines. Hard to aim.</entitydescription.machinepistol>
+<entityname.heavywrench>Heavy Wrench</entityname.heavywrench>
+<entitydescription.heavywrench>A large and heavy titanium wrench. Can only be properly swung by very burly mechanics.</entitydescription.heavywrench>
+<entityname.arcemitter>Arc Emitter</entityname.arcemitter>
+<entitydescription.arcemitter>A handheld weapon based on electric discharge coil technology. Fires a high-voltage electrical arc.</entitydescription.arcemitter>
+<entityname.makeshiftarmor>Makeshift Armor</entityname.makeshiftarmor>
+<entitydescription.makeshiftarmor>A bulky and unwieldy set of iron plates, fashioned into something that resembles armor.</entitydescription.makeshiftarmor>
+<entityname.ironhelmet>Iron Helmet</entityname.ironhelmet>
+<entitydescription.ironhelmet>A very simple and very heavy helmet that covers the entire face.</entitydescription.ironhelmet>
+<entityname.scrapcannon>Scrap Cannon</entityname.scrapcannon>
+<entitydescription.scrapcannon>A battery-powered makeshift weapon that fires metal shrapnels. Wildly inaccurate, but not too picky when it comes to ammo—any piece of unprocessed iron or steel will do.</entitydescription.scrapcannon>
+<entityname.exosuit>Exosuit</entityname.exosuit>
+<entitydescription.exosuit>A heavy powered suit originally designed for underwater construction work. Well-armored and capable of carrying substantial loads.</entitydescription.exosuit>
+<entityname.advancedsyringegun>Advanced Syringe Gun</entityname.advancedsyringegun>
+<entitydescription.advancedsyringegun>Launches syrettes containing drugs or poisons. Has a higher capacity and integrated health scanner.</entitydescription.advancedsyringegun>
+<entityname.clowncrate>Clown Crate</entityname.clowncrate>
+<entitydescription.clowncrate>A crate large enough to fit a prankster inside.</entitydescription.clowncrate>
+<entityname.europabrew>Europabrew</entityname.europabrew>
+<entitydescription.europabrew>A reagent that drastically increases the effect of acid burns.</entitydescription.europabrew>
+<entityname.sulphuricacidsyringe>Sulphuric Acid Syringe</entityname.sulphuricacidsyringe>
+<entitydescription.sulphuricacidsyringe>A strong acid that causes burns when in contact with skin. Contained in a syringe.</entitydescription.sulphuricacidsyringe>
+<entityname.chemgrenade>Acid Grenade</entityname.chemgrenade>
+<entitydescription.chemgrenade>A grenade filled with acid, causing acid burns when it explodes.</entitydescription.chemgrenade>
+<entityname.40mmchemgrenade>40mm Acid Grenade</entityname.40mmchemgrenade>
+<entitydescription.40mmchemgrenade>Ammunition for grenade launcher. Filled with acid, causing acid burns when it explodes.</entitydescription.40mmchemgrenade>
+<entityname.rum>Rum</entityname.rum>
+<entitydescription.rum>A fine liquor made from raptor bane juice. Some purists insist real rum is made from sugarcane — good luck finding any of that on Europa.</entitydescription.rum>
+<entityname.handhelditemfinder>Handheld Itemfinder</entityname.handhelditemfinder>
+<entitydescription.handhelditemfinder>A small handheld device with a screen, capable of easily finding items within the submarine.</entitydescription.handhelditemfinder>
+<entityname.makeshiftshelf>Makeshift Shelves</entityname.makeshiftshelf>
+<entitydescription.makeshiftshelf>Crate storage shelves that can be manually installed on a submarine.</entitydescription.makeshiftshelf>
+<entityname.ceremonialsword>Ceremonial Sword</entityname.ceremonialsword>
+<entitydescription.ceremonialsword>A sharp sword to commemorate graduating. It takes varied skills to use it to it's highest potential.</entitydescription.ceremonialsword>
+<entityname.shotgunslugexplosive>Explosive Slug</entityname.shotgunslugexplosive>
+<entitydescription.shotgunslugexplosive>A shotgun slug containing explosive material. Powerful, but still somewhat inaccurate on account of being fired out of a shotgun.</entitydescription.shotgunslugexplosive>
+<entityname.boardingaxe>Boarding Axe</entityname.boardingaxe>
+<entitydescription.boardingaxe>A hand axe, meant to be wielded with both hands.</entitydescription.boardingaxe>
+<entityname.skillbooksailorsguide>The Sailor's Guide</entityname.skillbooksailorsguide>
+<entitydescription.skillbooksailorsguide>A small handbook that covers all the tasks associated with underwater sailing, though in limited scope.</entitydescription.skillbooksailorsguide>
+<entityname.skillbooksubmarinewarfare>Art of Submarine Warfare</entityname.skillbooksubmarinewarfare>
+<entitydescription.skillbooksubmarinewarfare>A small handbook with useful information pertaining to all things submarine warfare, with detailed pictures of elaborate tactical manuevers and proper firearms discipline.</entitydescription.skillbooksubmarinewarfare>
+<entityname.skillbookhandyseaman>The Handy Seaman</entityname.skillbookhandyseaman>
+<entitydescription.skillbookhandyseaman>A small handbook containing detailed information on the most-often-encountered technical problems on board the submarines of Europa, with simple-to-understand instructions for dealing with them.</entitydescription.skillbookhandyseaman>
+<entityname.skillbookeuropanmedicine>Europan Medicine</entityname.skillbookeuropanmedicine>
+<entitydescription.skillbookeuropanmedicine>A small handbook seeking to educate its reader on the proper conduct with treating the wounded and the sick using limited medical resources. The word "triage" appears to be mentioned a lot.</entitydescription.skillbookeuropanmedicine>
+<entityname.thermalgoggles>Thermal Goggles</entityname.thermalgoggles>
+<entitydescription.thermalgoggles>A thermal imaging device that makes it easier to distinguish living targets in poor lighting conditions, even through solid obstacles.</entitydescription.thermalgoggles>
+<entityname.reactorpda>Reactor PDA</entityname.reactorpda>
+<entitydescription.reactorpda>A handheld device that can be used to remotely control the submarine's reactor.</entitydescription.reactorpda>
+<entityname.dirtybomb>Dirty Bomb</entityname.dirtybomb>
+<entitydescription.dirtybomb>An explosive compound mixed with highly radioactive material. Though the explosive payload is low, the ensuing fallout will catastrophically irradiate the area.</entitydescription.dirtybomb>
+<entityname.fulguriumfuelrodvolatile>Volatile Fulgurium Fuel Rod</entityname.fulguriumfuelrodvolatile>
+<entitydescription.fulguriumfuelrodvolatile>A Fulgurium fuel rod that has been further refined to supply power for much longer than normal. However, its radiation shielding can only partially limit the emitted ambient radiation, so the rod must be handled with care.</entitydescription.fulguriumfuelrodvolatile>
+<entityname.nucleargun>Rapid Fissile Accelerator</entityname.nucleargun>
+<entitydescription.nucleargun>A prototype energy weapon built using the unique alien materials on Europa. The weapon induces a type of fission reaction at the end of the barrel, and releases it in a powerful beam once it is too violent to contain.</entitydescription.nucleargun>
+<entityname.cargoscooter>Cargo Scooter</entityname.cargoscooter>
+<entitydescription.cargoscooter>An underwater scooter special-made to transport material underwater. While the scooter is too large to be stored in one's inventory, its inherent buoyancy means the scooter will stay where you leave it.</entitydescription.cargoscooter>
+<entityname.clowndivingmask>Clown Diving Mask</entityname.clowndivingmask>
+<entitydescription.clowndivingmask>A clown mask combined with a diving mask, allowing the user to both clown around and breathe underwater.</entitydescription.clowndivingmask>
+<entityname.safetyharness>Safety Harness</entityname.safetyharness>
+<entitydescription.safetyharness>A special harness made to reduce workplace related injuries incurred on Europan submarines. The harness also dampens the effects of rushing water, stabilizing the user in the event of a hull breach.</entitydescription.safetyharness>
+<entityname.pucs>PUCS</entityname.pucs>
+<entitydescription.pucs>The Protective Universal Crisis Suit, or PUCS for short, bestows its user with immense resistances to environmental hazards such as radiation and fire. The built-in air-filtration system allows the suit to utilize hull oxygen when possible, and the built-in computer injects the user with whatever medicine is placed inside the suit. Withstands pressure up to a depth of 6,000 meters.</entitydescription.pucs>
+<entityname.cigar>Cigar</entityname.cigar>
+<entitydescription.cigar>A submariner's life is mentally taxing, but perhaps this exquisitely crafted cigar can help you soothe your nerves a bit.</entitydescription.cigar>
+<entityname.stungundartfulgurium>Fulgurium Stun Gun Dart</entityname.stungundartfulgurium>
+<entitydescription.stungundartfulgurium>A highly potent stun gun dart that will drop any would-be creep like a sack of potatoes.</entitydescription.stungundartfulgurium>
+<entityname.fixfoamgrenade>Fixfoam Grenade</entityname.fixfoamgrenade>
+<entitydescription.fixfoamgrenade>Emits a cloud of chemical sealant that quickly seals off leaks.</entitydescription.fixfoamgrenade>
+<entityname.portablepump>Portable Pump</entityname.portablepump>
+<entitydescription.portablepump>A small battery-powered pump that can be installed on walls. Pumps out water very fast, but consumes a lot of power.</entitydescription.portablepump>
+<entityname.combatstimulantsyringe>Combat Stimulant</entityname.combatstimulantsyringe>
+<entitydescription.combatstimulantsyringe>A highly advanced stimulant that makes the user rapidly recover from physical injuries and bloodloss.</entitydescription.combatstimulantsyringe>
+<entityname.explosiveslug>Explosive Slug</entityname.explosiveslug>
+<entitydescription.explosiveslug>Explosive ammunition for a shotgun.</entitydescription.explosiveslug>
+<entityname.wrenchdementonite>Dementonite Wrench</entityname.wrenchdementonite>
+<entityname.screwdriverdementonite>Dementonite Screwdriver</entityname.screwdriverdementonite>
+<entityname.crowbardementonite>Dementonite Crowbar</entityname.crowbardementonite>
+<entityname.divingknifedementonite>Dementonite Diving Knife</entityname.divingknifedementonite>
+<entitydescription.dementonitetool>Fabricated from the poorly understood alien material dementonite. Holding it evokes a strange sense of unease.</entitydescription.dementonitetool>
+<entityname.taintedgeneticmaterial>Tainted [geneticmaterialname]</entityname.taintedgeneticmaterial>
+<entityname.geneticmaterial>Genetic Material ([type])</entityname.geneticmaterial>
+<entityname.unidentifiedgeneticmaterial>Unidentified Genetic Material</entityname.unidentifiedgeneticmaterial>
+<entitydescription.unidentifiedgeneticmaterial>A mass of alien genetic material. Use a research station to identify the material and to process it into something that can be inserted into a gene splicer.</entitydescription.unidentifiedgeneticmaterial>
+<entitydescription.geneticmaterialcrawler>Increases swimming speed by [value]%.</entitydescription.geneticmaterialcrawler>
+<entitydescription.geneticmaterialmudraptor>Causes the subject to grow a mudraptor-like beak.</entitydescription.geneticmaterialmudraptor>
+<entitydescription.geneticmaterialmoloch>Increases resistance to physical damage by [value]%</entitydescription.geneticmaterialmoloch>
+<entitydescription.geneticmaterialthresher>Decreases the subject's oxygen consumption by [value]%.</entitydescription.geneticmaterialthresher>
+<entitydescription.geneticmaterialmantis>Increases movement speed on land by [value]%.</entitydescription.geneticmaterialmantis>
+<entitydescription.geneticmaterialhammerhead>Allows the subject to to do [value]% more damage with melee weapons.</entitydescription.geneticmaterialhammerhead>
+<entitydescription.geneticmaterialhammerheadmatriarch>Makes the subject's physical injuries heal at a rate of [value]% per minute.</entitydescription.geneticmaterialhammerheadmatriarch>
+<entitydescription.geneticmaterialspineling>Causes the subject to grow spineling-like bony protrusions out of their back.</entitydescription.geneticmaterialspineling>
+<entitydescription.geneticmaterialhusk>Prevents husk infections from advancing to the point where the parasite takes control of the host.</entitydescription.geneticmaterialhusk>
+<character.mollusc>Mollusc</character.mollusc>
+<entitydescription.geneticmaterialmollusc>Receiving physical damage makes the subject gain [value]% vigor.</entitydescription.geneticmaterialmollusc>
+<character.skitter>Skitter</character.skitter>
+<entitydescription.geneticmaterialskitter>Receiving physical damage makes the subject gain [value]% hyperactivity.</entitydescription.geneticmaterialskitter>
+<character.hunter>Hunter</character.hunter>
+<entitydescription.geneticmaterialhunter>Receiving physical damage makes the subject gain a [value]% boost to melee weapon damage.</entitydescription.geneticmaterialhunter>
+<entityname.genesplicer>Gene Splicer</entityname.genesplicer>
+<entitydescription.genesplicer>A device used to splice alien genes into a human. Equip the splicer in the health interface and insert genetic materials in the splicer to activate the genes. Once spliced onto a living subject, genetic material cannot be removed without destroying it.</entitydescription.genesplicer>
+<entityname.advancedgenesplicer>Advanced Gene Splicer</entityname.advancedgenesplicer>
+<entitydescription.advancedgenesplicer>A more advanced form of the gene splicer, capable of activating two types of genetic materials at the same time.</entitydescription.advancedgenesplicer>
+<entityname.energydrink>Energy Drink</entityname.energydrink>
+<entitydescription.energydrink>Mantis Energy keeps you skittering from dawn till dusk!</entitydescription.energydrink>
+<entityname.proteinbar>Protein Bar</entityname.proteinbar>
+<entitydescription.proteinbar>May contain traces of galena.</entitydescription.proteinbar>
+<entityname.chaingunammoboxshredder>Shredder Chaingun Ammunition Box</entityname.chaingunammoboxshredder>
+<entitydescription.chaingunammoboxshredder>A heavy box of ammunition for the chaingun. Designed to shred through flesh and armor of any enemy.</entitydescription.chaingunammoboxshredder>
+<entityname.shotgunshellblunt>Shotgun Rubber Shell</entityname.shotgunshellblunt>
+<entitydescription.shotgunshellblunt>Ammunition for a shotgun. Less lethal.</entitydescription.shotgunshellblunt>
+<entityname.respawndivingsuit>Disposable Diving Suit</entityname.respawndivingsuit>
+<entitydescription.respawndivingsuit>A disposable diving suit capable of withstanding the immense pressure under Europa's crust.</entitydescription.respawndivingsuit>
+
+<!-- Electrical -->
+<entityname.junctionbox>Junction Box</entityname.junctionbox>
+<entitydescription.junctionbox>Serves as a hub for power distribution and relaying signals between devices.</entitydescription.junctionbox>
+<entityname.battery>Battery</entityname.battery>
+<entitydescription.battery>Generally used for storing backup power in case of a reactor failure.</entitydescription.battery>
+<entityname.shuttlebattery>Shuttle Battery</entityname.shuttlebattery>
+<entitydescription.shuttlebattery>Generally used for storing backup power in case of a reactor failure.</entitydescription.shuttlebattery>
+<entityname.supercapacitor>Supercapacitor</entityname.supercapacitor>
+<entitydescription.supercapacitor>Can output huge surges of power, but has a much lower capacity than batteries. Recharging the capacitors also takes much more power than batteries.</entitydescription.supercapacitor>
+<entityname.chargingdock>Charging Dock</entityname.chargingdock>
+<entitydescription.chargingdock>A wall-mounted battery cell charging dock.</entitydescription.chargingdock>
+<entityname.fpgacircuit>FPGA Circuit</entityname.fpgacircuit>
+<entitydescription.fpgacircuit>Field-programmable gate array—a multipurpose circuit that can be reconfigured for use in a large variety of electrical devices.</entitydescription.fpgacircuit>
+<entityname.andcomponent>And Component</entityname.andcomponent>
+<entitydescription.andcomponent>Sends a signal when both inputs receive a signal within a set period of each other.</entitydescription.andcomponent>
+<entityname.addercomponent>Adder Component</entityname.addercomponent>
+<entitydescription.addercomponent>Outputs the sum of the received signals.</entitydescription.addercomponent>
+<entityname.orcomponent>Or Component</entityname.orcomponent>
+<entitydescription.orcomponent>Sends a signal if either of the inputs receives a signal.</entitydescription.orcomponent>
+<entityname.notcomponent>Not Component</entityname.notcomponent>
+<entitydescription.notcomponent>Sends a signal when the input is NOT receiving a signal.</entitydescription.notcomponent>
+<entityname.relaycomponent>Relay Component</entityname.relaycomponent>
+<entitydescription.relaycomponent>When switched on, forwards all received signals from the input connections to the outputs.</entitydescription.relaycomponent>
+<entityname.delaycomponent>Delay Component</entityname.delaycomponent>
+<entitydescription.delaycomponent>Delays all received signals for a specific amount of time.</entitydescription.delaycomponent>
+<entityname.equalscomponent>Equals Component</entityname.equalscomponent>
+<entitydescription.equalscomponent>Sends a signal when both inputs receive the same signal.</entitydescription.equalscomponent>
+<entityname.greatercomponent>Greater Component</entityname.greatercomponent>
+<entitydescription.greatercomponent>Sends a signal if the value the signal_in1 input is larger than the signal_in2 input.</entitydescription.greatercomponent>
+<entityname.colorcomponent>Color Component</entityname.colorcomponent>
+<entitydescription.colorcomponent>Outputs a combined color signal for light control.</entitydescription.colorcomponent>
+<entityname.subtractcomponent>Subtract Component</entityname.subtractcomponent>
+<entitydescription.subtractcomponent>Outputs the subtracted value of the received signals.</entitydescription.subtractcomponent>
+<entityname.multiplycomponent>Multiply Component</entityname.multiplycomponent>
+<entitydescription.multiplycomponent>Outputs the product of the received signals.</entitydescription.multiplycomponent>
+<entityname.dividecomponent>Divide Component</entityname.dividecomponent>
+<entitydescription.dividecomponent>Outputs the divided value of the received signals.</entitydescription.dividecomponent>
+<entityname.xorcomponent>Xor Component</entityname.xorcomponent>
+<entitydescription.xorcomponent>Sends a signal if either of the inputs, but not both, receives a signal.</entitydescription.xorcomponent>
+<entityname.memorycomponent>Memory Component</entityname.memorycomponent>
+<entitydescription.memorycomponent>Outputs a stored value that can be updated from other sources. Use the signal_in connection to set the stored value, and the signal_store input to toggle whether the received signals should be stored.</entitydescription.memorycomponent>
+<entityname.oxygendetector>Oxygen Detector</entityname.oxygendetector>
+<entitydescription.oxygendetector>Sends out a value between 0-100 depending on the quality of the surrounding air.</entitydescription.oxygendetector>
+<entityname.waterdetector>Water Detector</entityname.waterdetector>
+<entitydescription.waterdetector>Sends out a signal when the detector is submerged.</entitydescription.waterdetector>
+<entityname.smokedetector>Smoke Detector</entityname.smokedetector>
+<entitydescription.smokedetector>Sends out a signal when it senses smoke.</entitydescription.smokedetector>
+<entityname.motiondetector>Motion Detector</entityname.motiondetector>
+<entitydescription.motiondetector>Sends out a signal when it detects movement.</entitydescription.motiondetector>
+<entityname.signalcheckcomponent>Signal Check Component</entityname.signalcheckcomponent>
+<entitydescription.signalcheckcomponent>Sends a signal when a signal matching a specific value is received.</entitydescription.signalcheckcomponent>
+<entityname.regexcomponent>RegEx Find Component</entityname.regexcomponent>
+<entitydescription.regexcomponent>Sends a signal if the received signal matches a specific regular expression pattern.</entitydescription.regexcomponent>
+<entityname.oscillator>Oscillator Component</entityname.oscillator>
+<entitydescription.oscillator>Sends out a periodic, oscillating signal.</entitydescription.oscillator>
+<entityname.wificomponent>Wifi Component</entityname.wificomponent>
+<entitydescription.wificomponent>Allows remote communication between other wifi components that are using the same channel.</entitydescription.wificomponent>
+<entityname.camera>Camera</entityname.camera>
+<entitydescription.camera>Typically used in photonics masts to provide the crew with a high-resolution view of the area outside the sub.</entitydescription.camera>
+<entityname.button>Button</entityname.button>
+<entitydescription.button>Produces a signal that can be used to toggle the state of equipment and doors.</entitydescription.button>
+<entityname.switch>Switch</entityname.switch>
+<entitydescription.switch>Produces a constant signal that can be used to change the state of equipment and doors.</entitydescription.switch>
+<entityname.lamp>Lamp</entityname.lamp>
+<entitydescription.lamp>Wall-mounted lighting.</entitydescription.lamp>
+<entityname.emergencylight>Emergency Light</entityname.emergencylight>
+<entitydescription.emergencylight>Wall-mounted lighting. Requires no electrical input.</entitydescription.emergencylight>
+<entityname.wire>Wire</entityname.wire>
+<entitydescription.wire>Connects an output from one piece of equipment to an input on another.</entitydescription.wire>
+<entityname.redwire>Red Wire</entityname.redwire>
+<entitydescription.redwire>Connects an output from one piece of equipment to an input on another.</entitydescription.redwire>
+<entityname.bluewire>Blue Wire</entityname.bluewire>
+<entitydescription.bluewire>Connects an output from one piece of equipment to an input on another.</entitydescription.bluewire>
+<entityname.orangewire>Orange Wire</entityname.orangewire>
+<entitydescription.orangewire>Connects an output from one piece of equipment to an input on another.</entitydescription.orangewire>
+<entityname.greenwire>Green Wire</entityname.greenwire>
+<entitydescription.greenwire>Connects an output from one piece of equipment to an input on another.</entitydescription.greenwire>
+<entityname.blackwire>Black Wire</entityname.blackwire>
+<entitydescription.blackwire>Connects an output from one piece of equipment to an input on another.</entitydescription.blackwire>
+<entityname.brownwire>Brown Wire</entityname.brownwire>
+<entitydescription.brownwire>Connects an output from one piece of equipment to an input on another.</entitydescription.brownwire>
+<entityname.lightcomponent>Light Component</entityname.lightcomponent>
+<entitydescription.lightcomponent>General purpose lighting. Requires no electrical input.</entitydescription.lightcomponent>
+<entityname.emergencysiren>Emergency Siren</entityname.emergencysiren>
+<entitydescription.emergencysiren>Can be triggered to make a terrible noise.</entitydescription.emergencysiren>
+<entityname.alarmbuzzer>Alarm Buzzer</entityname.alarmbuzzer>
+<entitydescription.alarmbuzzer>Can be triggered to make a terrible noise.</entitydescription.alarmbuzzer>
+<entityname.beacon>Beacon</entityname.beacon>
+<entitydescription.beacon>When deployed and activated in the correct location, it will signal colonists to come and set up an outpost.</entitydescription.beacon>
+<entityname.sincomponent>Sin Component</entityname.sincomponent>
+<entitydescription.sincomponent>Outputs the sine of the input.</entitydescription.sincomponent>
+<entityname.coscomponent>Cos Component</entityname.coscomponent>
+<entitydescription.coscomponent>Outputs the cosine of the input.</entitydescription.coscomponent>
+<entityname.tancomponent>Tan Component</entityname.tancomponent>
+<entitydescription.tancomponent>Outputs the tangent of the input.</entitydescription.tancomponent>
+<entityname.asincomponent>Asin Component</entityname.asincomponent>
+<entitydescription.asincomponent>Outputs the angle whose sine is equal to the input.</entitydescription.asincomponent>
+<entityname.acoscomponent>Acos Component</entityname.acoscomponent>
+<entitydescription.acoscomponent>Outputs the angle whose cosine is equal to the input.</entitydescription.acoscomponent>
+<entityname.atancomponent>Atan Component</entityname.atancomponent>
+<entitydescription.atancomponent>Outputs the angle whose tangent is equal to the input. If the "signal_in_x" and "signal_in_y" connections are used, the input is interpreted as a vector and the angle calculated using Atan2.</entitydescription.atancomponent>
+<entityname.modulocomponent>Modulo Component</entityname.modulocomponent>
+<entitydescription.modulocomponent>Outputs the remainder when the input is divided by a specific number.</entitydescription.modulocomponent>
+<entityname.roundcomponent>Round Component</entityname.roundcomponent>
+<entitydescription.roundcomponent>Rounds a numerical input to the nearest integer value.</entitydescription.roundcomponent>
+<entityname.ceilcomponent>Ceil Component</entityname.ceilcomponent>
+<entitydescription.ceilcomponent>Outputs the smallest integer value that is bigger than or equal to the input.</entitydescription.ceilcomponent>
+<entityname.floorcomponent>Floor Component</entityname.floorcomponent>
+<entitydescription.floorcomponent>Outputs the greatest integer value that is less than or equal to the input.</entitydescription.floorcomponent>
+<entityname.factorialcomponent>Factorial Component</entityname.factorialcomponent>
+<entitydescription.factorialcomponent>Outputs the factorial of the input.</entitydescription.factorialcomponent>
+<entityname.squarerootcomponent>Square Root Component</entityname.squarerootcomponent>
+<entitydescription.squarerootcomponent>Outputs the square root of the input.</entitydescription.squarerootcomponent>
+<entityname.abscomponent>Abs Component</entityname.abscomponent>
+<entitydescription.abscomponent>Outputs the absolute value of the input.</entitydescription.abscomponent>
+<entityname.powcomponent>Exponentiation Component</entityname.powcomponent>
+<entitydescription.powcomponent>Outputs the input raised to a given power.</entitydescription.powcomponent>
+<entityname.terminal>Terminal</entityname.terminal>
+<entitydescription.terminal>Outputs a user-submitted string.</entitydescription.terminal>
+<entityname.lever>Lever</entityname.lever>
+<entitydescription.lever>Produces a constant signal that can be used to change the state of equipment and doors.</entitydescription.lever>
+<entityname.concatcomponent>Concatenation Component</entityname.concatcomponent>
+<entitydescription.concatcomponent>Joins the inputs together and outputs the joined value (for example, the inputs "mud" and "raptor" would output "mudraptor").</entitydescription.concatcomponent>
+
+<!-- Material -->
+<entityname.alienblood>Alien Blood</entityname.alienblood>
+<entitydescription.alienblood>Blood extracted from a Europan lifeform. Can be further processed into a blood substitute for the treatment of blood loss.</entitydescription.alienblood>
+<entityname.huskeggs>Calyx Extract</entityname.huskeggs>
+<entitydescription.huskeggs>The Velonaceps calyx or "husk parasite" likes to bind itself to calcium, regardless of whether it's inside human bones or neatly packed inside a syringe.</entitydescription.huskeggs>
+<entityname.molochbone>Moloch Bone</entityname.molochbone>
+<entitydescription.molochbone>Piece of a Moloch bone. Considered an expensive luxury item by colony dwellers; can be sold at a high price.</entitydescription.molochbone>
+<entityname.huskeggsbasic>Velonaceps calyx Eggs</entityname.huskeggsbasic>
+<entitydescription.huskeggsbasic>Dormant eggs of the Europan lifeform colloquially referred to as "husk parasite."</entitydescription.huskeggsbasic>
+<entityname.aliencircuitry>Alien Circuitry</entityname.aliencircuitry>
+<entitydescription.aliencircuitry>Advanced looking circuitry, typically found within the inorganic guardians of the alien ruins.</entitydescription.aliencircuitry>
+<entityname.diversremains>Diver's Remains</entityname.diversremains>
+<entitydescription.diversremains>The less easily digested remains of the poor soul that met their untimely demise.</entitydescription.diversremains>
+<entityname.hammerheadribs>Hammerhead Ribs</entityname.hammerheadribs>
+<entitydescription.hammerheadribs>The ribs and fleshy remains of a Hammerhead. Can fetch a decent price in colonies.</entitydescription.hammerheadribs>
+<entityname.endwormshell>Endworm Shell Fragment</entityname.endwormshell>
+<entitydescription.endwormshell>A sturdy piece of an endworm's shell.</entitydescription.endwormshell>
+<entityname.watchershell>Watcher Shell Fragment</entityname.watchershell>
+<entitydescription.watchershell>A sturdy piece of a watcher's shell.</entitydescription.watchershell>
+<entityname.carbon>Carbon</entityname.carbon>
+<entitydescription.carbon>Most commonly used in the manufacture of steel and plastic.</entitydescription.carbon>
+<entityname.iron>Iron</entityname.iron>
+<entitydescription.iron>Can be used in the manufacture of simple tools, or refined into steel by mixing it with carbon.</entitydescription.iron>
+<entityname.tin>Tin</entityname.tin>
+<entitydescription.tin>Most commonly used in the manufacture of various electrical components.</entitydescription.tin>
+<entityname.lead>Lead</entityname.lead>
+<entitydescription.lead>Most commonly used in the manufacture of various types of ammunition.</entitydescription.lead>
+<entityname.phosphorus>Phosphorus</entityname.phosphorus>
+<entitydescription.phosphorus>Used in the manufacture of lamps, explosives and some medical compounds.</entitydescription.phosphorus>
+<entityname.copper>Copper</entityname.copper>
+<entitydescription.copper>Most commonly used in the manufacture of electrical wiring.</entitydescription.copper>
+<entityname.zinc>Zinc</entityname.zinc>
+<entitydescription.zinc>Most commonly used in the manufacture of batteries and tonic liquid.</entitydescription.zinc>
+<entityname.sodium>Sodium</entityname.sodium>
+<entitydescription.sodium>Medical fabricators can combine sodium and chloride to create a saline solution, which can be used as a treatment for blood loss or as an ingredient for more complex medicine. Reacts violently when coming into contact with water.</entitydescription.sodium>
+<entityname.silicon>Silicon</entityname.silicon>
+<entitydescription.silicon>Used as an ingredient in aluminum alloys, plastic and various electrical components.</entitydescription.silicon>
+<entityname.uranium>Uranium</entityname.uranium>
+<entitydescription.uranium>Can be refined in a fabricator to create fuel rods for a nuclear reactor, or used in the manufacture of nuclear weapons.</entitydescription.uranium>
+<entityname.potassium>Potassium</entityname.potassium>
+<entitydescription.potassium>Used in the manufacture of explosives and medical compounds. Reacts violently when in contact with water.</entitydescription.potassium>
+<entityname.magnesium>Magnesium</entityname.magnesium>
+<entitydescription.magnesium>Used in the manufacture of explosives and medical compounds.</entitydescription.magnesium>
+<entityname.lithium>Lithium</entityname.lithium>
+<entitydescription.lithium>Most commonly used in the manufacture of batteries and antipsychotic drugs. Reacts violently when in contact with water.</entitydescription.lithium>
+<entityname.chlorine>Chlorine</entityname.chlorine>
+<entitydescription.chlorine>Most commonly used in saline, a common treatment for blood loss, and chloral hydrate, a powerful sedative.</entitydescription.chlorine>
+<entityname.slimebacteria>Slime Bacteria</entityname.slimebacteria>
+<entitydescription.slimebacteria>A colony of myxobacteria. Can be processed into antibiotics.</entitydescription.slimebacteria>
+<entityname.titanite>Titanite</entityname.titanite>
+<entitydescription.titanite>A mineral containing titanium and iron.</entitydescription.titanite>
+<entityname.brockite>Brockite</entityname.brockite>
+<entitydescription.brockite>A mineral containing thorium and phosphorus.</entitydescription.brockite>
+<entityname.thorianite>Thorianite</entityname.thorianite>
+<entitydescription.thorianite>A rare mineral containing thorium.</entitydescription.thorianite>
+<entityname.amblygonite>Amblygonite</entityname.amblygonite>
+<entitydescription.amblygonite>A mineral composed of lithium, aluminum and sodium.</entitydescription.amblygonite>
+<entityname.sphalerite>Sphalerite</entityname.sphalerite>
+<entitydescription.sphalerite>A mineral consisting largely of zinc in crystalline form.</entitydescription.sphalerite>
+<entityname.pyromorphite>Pyromorphite</entityname.pyromorphite>
+<entitydescription.pyromorphite>A mineral composed of chlorine.</entitydescription.pyromorphite>
+<entityname.quartz>Quartz</entityname.quartz>
+<entitydescription.quartz>A crystalline mineral composed of silicon.</entitydescription.quartz>
+<entityname.diamond>Diamond</entityname.diamond>
+<entitydescription.diamond>A crystal composed of solid carbon.</entitydescription.diamond>
+<entityname.hydroxyapatite>Hydroxyapatite</entityname.hydroxyapatite>
+<entitydescription.hydroxyapatite>A mineral composed of calcium and phosphorus.</entitydescription.hydroxyapatite>
+<entityname.uraniumore>Uranium Ore</entityname.uraniumore>
+<entitydescription.uraniumore>A mineral containing large concentrations of uranium.</entitydescription.uraniumore>
+<entityname.ilmenite>Ilmenite</entityname.ilmenite>
+<entitydescription.ilmenite>A mineral containing titanium.</entitydescription.ilmenite>
+<entityname.stannite>Stannite</entityname.stannite>
+<entitydescription.stannite>A mineral composed of copper, iron and tin.</entitydescription.stannite>
+<entityname.chalcopyrite>Chalcopyrite</entityname.chalcopyrite>
+<entitydescription.chalcopyrite>A mineral containing copper.</entitydescription.chalcopyrite>
+<entityname.esperite>Esperite</entityname.esperite>
+<entitydescription.esperite>A mineral composed of zinc and lead.</entitydescription.esperite>
+<entityname.galena>Galena</entityname.galena>
+<entitydescription.galena>A mineral mostly consisting of lead.</entitydescription.galena>
+<entityname.triphylite>Triphylite</entityname.triphylite>
+<entitydescription.triphylite>A mineral containing lithium.</entitydescription.triphylite>
+<entityname.langbeinite>Langbeinite</entityname.langbeinite>
+<entitydescription.langbeinite>A mineral consisting of potassium and magnesium.</entitydescription.langbeinite>
+<entityname.chamosite>Chamosite</entityname.chamosite>
+<entitydescription.chamosite>A mineral consisting of iron and aluminum.</entitydescription.chamosite>
+<entityname.ironore>Iron Ore</entityname.ironore>
+<entitydescription.ironore>A mineral containing large amounts of iron.</entitydescription.ironore>
+<entityname.polyhalite>Polyhalite</entityname.polyhalite>
+<entitydescription.polyhalite>A mineral consisting of potassium and calcium.</entitydescription.polyhalite>
+<entityname.graphite>Graphite</entityname.graphite>
+<entitydescription.graphite>Carbon in crystalline form.</entitydescription.graphite>
+<entityname.sylvite>Sylvite</entityname.sylvite>
+<entitydescription.sylvite>A mineral containing potassium and sodium.</entitydescription.sylvite>
+<entityname.lazulite>Lazulite</entityname.lazulite>
+<entitydescription.lazulite>A mineral containing phosphorus and iron.</entitydescription.lazulite>
+<entityname.bornite>Bornite</entityname.bornite>
+<entitydescription.bornite>A mineral containing copper.</entitydescription.bornite>
+<entityname.cassiterite>Cassiterite</entityname.cassiterite>
+<entitydescription.cassiterite>A mineral consisting of tin.</entitydescription.cassiterite>
+<entityname.cryolite>Cryolite</entityname.cryolite>
+<entitydescription.cryolite>A mineral containing sodium.</entitydescription.cryolite>
+<entityname.aragonite>Aragonite</entityname.aragonite>
+<entitydescription.aragonite>A mineral containing calcium.</entitydescription.aragonite>
+<entityname.chrysoprase>Chrysoprase</entityname.chrysoprase>
+<entitydescription.chrysoprase>A mineral containing silicon.</entitydescription.chrysoprase>
+<entityname.opium>Opium</entityname.opium>
+<entitydescription.opium>A relatively mild opioid obtained from aquatic poppy. Most commonly used to manufacture morphine and fentanyl.</entitydescription.opium>
+<entityname.antibiotics>Broad-spectrum Antibiotics</entityname.antibiotics>
+<entitydescription.antibiotics>A mild antibiotic that acts against a wide range of disease-causing bacteria, though with the side effect of minor organ damage. Used as an ingredient in many medical compounds.</entitydescription.antibiotics>
+<entityname.stabilozine>Stabilozine</entityname.stabilozine>
+<entitydescription.stabilozine>Used as an ingredient in the manufacture of various medicines. On its own, can be used to slow down the effects of most toxins.</entitydescription.stabilozine>
+<entityname.ethanol>Ethanol</entityname.ethanol>
+<entitydescription.ethanol>Medical alcohol used as an ingredient in the manufacture of various medicines. Drinking while on duty is not advised.</entitydescription.ethanol>
+<entityname.sulphuricacid>Sulphuric Acid</entityname.sulphuricacid>
+<entitydescription.sulphuricacid>A strong acid that causes burns when in contact with skin. Used as an ingredient in several poisons.</entitydescription.sulphuricacid>
+<entityname.antidama1>Morphine</entityname.antidama1>
+<entitydescription.antidama1>A powerful opiate for treating pain associated with internal injuries, but will cause shortness of breath and eventual dependency with overuse.</entitydescription.antidama1>
+<entityname.antidama2>Fentanyl</entityname.antidama2>
+<entitydescription.antidama2>A powerful opiate for treating pain associated with internal injuries, but will cause shortness of breath and eventual dependency with overuse.</entitydescription.antidama2>
+<entityname.antibloodloss1>Saline</entityname.antibloodloss1>
+<entitydescription.antibloodloss1>A sodium chloride infusion mildly useful in the treatment of blood loss.</entitydescription.antibloodloss1>
+<entityname.antibloodloss2>Blood Pack</entityname.antibloodloss2>
+<entitydescription.antibloodloss2>A pack of blood substitute for the treatment of blood loss.</entitydescription.antibloodloss2>
+<entityname.deusizine>Deusizine</entityname.deusizine>
+<entitydescription.deusizine>A highly potent stimulant effective in the treatment of internal damage, oxygen deprivation and, to a lesser extent, blood loss. Produces mild burns as a side effect.</entitydescription.deusizine>
+<entityname.calyxanide>Calyxanide</entityname.calyxanide>
+<entitydescription.calyxanide>An antiparasitic drug used in the treatment of husk parasite infections. Might require higher dosage to cure the infection at later stages.</entitydescription.calyxanide>
+<entityname.antipsychosis>Haloperidol</entityname.antipsychosis>
+<entitydescription.antipsychosis>A strong antipsychotic drug.</entitydescription.antipsychosis>
+<entityname.antinarc>Naloxone</entityname.antinarc>
+<entitydescription.antinarc>An opioid antagonist for the treatment of opiate-based withdrawal and overdose.</entitydescription.antinarc>
+<entityname.morbusineantidote>Morbusine Antidote</entityname.morbusineantidote>
+<entitydescription.morbusineantidote>An antidote for acute morbusine poisoning.</entitydescription.morbusineantidote>
+<entityname.cyanideantidote>Cyanide Antidote</entityname.cyanideantidote>
+<entitydescription.cyanideantidote>An antidote for acute cyanide poisoning.</entitydescription.cyanideantidote>
+<entityname.sufforinantidote>Sufforin Antidote</entityname.sufforinantidote>
+<entitydescription.sufforinantidote>An antidote for acute sufforin poisoning.</entitydescription.sufforinantidote>
+<entityname.deliriumineantidote>Deliriumine Antidote</entityname.deliriumineantidote>
+<entitydescription.deliriumineantidote>An antidote for acute deliriumine poisoning.</entitydescription.deliriumineantidote>
+<entityname.antirad>Antirad</entityname.antirad>
+<entitydescription.antirad>Slows down cellular degradation caused by radiation.</entitydescription.antirad>
+<entityname.liquidoxygenite>Liquid Oxygenite</entityname.liquidoxygenite>
+<entitydescription.liquidoxygenite>A mildly toxic solution that slowly releases oxygen into the bloodstream when injected. Avoid dropping.</entitydescription.liquidoxygenite>
+<entityname.tonicliquid>Tonic Liquid</entityname.tonicliquid>
+<entitydescription.tonicliquid>A medical solution that's mildly effective as a treatment for internal damage, but most commonly used as an ingredient in more complex medical compounds.</entitydescription.tonicliquid>
+<entityname.meth>Methamphetamine</entityname.meth>
+<entitydescription.meth>A potent nervous system stimulant.</entitydescription.meth>
+<entityname.steroids>Anabolic Steroids</entityname.steroids>
+<entitydescription.steroids>Temporarily increases muscular strength and physical performance.</entitydescription.steroids>
+<entityname.hyperzine>Hyperzine</entityname.hyperzine>
+<entitydescription.hyperzine>An extremely potent muscle stimulant for those moments when you gotta go fast.</entitydescription.hyperzine>
+<entityname.morbusine>Morbusine</entityname.morbusine>
+<entitydescription.morbusine>A highly potent neurotoxin that causes an eventual shutdown of lungs and muscles, greatly hindering movement.</entitydescription.morbusine>
+<entityname.chloralhydrate>Chloral Hydrate</entityname.chloralhydrate>
+<entitydescription.chloralhydrate>A sedative that can be used to knock someone out for a short period of time.</entitydescription.chloralhydrate>
+<entityname.cyanide>Cyanide</entityname.cyanide>
+<entitydescription.cyanide>A highly toxic chemical that causes a rapid death once a sufficiently large dose has been administered.</entitydescription.cyanide>
+<entityname.radiotoxin>Radiotoxin</entityname.radiotoxin>
+<entitydescription.radiotoxin>A highly radioactive substance that causes radiation sickness and eventual liquefaction of inner organs.</entitydescription.radiotoxin>
+<entityname.sufforin>Sufforin</entityname.sufforin>
+<entitydescription.sufforin>A stealthy neurotoxin, undetectable in early stages. Causes a loss of vision and, ultimately, death.</entitydescription.sufforin>
+<entityname.deliriumine>Deliriumine</entityname.deliriumine>
+<entitydescription.deliriumine>A psychosis-inducing toxin.</entitydescription.deliriumine>
+<entityname.nitroglycerin>Nitroglycerin</entityname.nitroglycerin>
+<entitydescription.nitroglycerin>A highly unstable liquid that may explode when subjected to heat or physical shock.</entitydescription.nitroglycerin>
+<entityname.calcium>Calcium</entityname.calcium>
+<entitydescription.calcium>A silvery-white powder. Used to fabricate Tonic Liquid.</entitydescription.calcium>
+<entityname.aluminium>Aluminum</entityname.aluminium>
+<entitydescription.aluminium>A soft, lightweight metal. Used in the manufacture of diving equipment and some military applications.</entitydescription.aluminium>
+<entityname.titanium>Titanium</entityname.titanium>
+<entitydescription.titanium>A hard and strong metal. Used for creating the durable Titanium-Aluminium alloy, as well as military applications.</entitydescription.titanium>
+<entityname.thorium>Thorium</entityname.thorium>
+<entitydescription.thorium>A weakly radioactive, silvery metal. Can be refined to create longer lasting fuel rods.</entitydescription.thorium>
+<entityname.steel>Steel Bar</entityname.steel>
+<entitydescription.steel>A strong metal alloy of iron and carbon. Used in fuel rod manufacturing, as well as many military applications.</entitydescription.steel>
+<entityname.titaniumaluminiumalloy>Titanium-Aluminum Alloy</entityname.titaniumaluminiumalloy>
+<entitydescription.titaniumaluminiumalloy>A very tough metal alloy. Used in durable diving gear and advanced weaponry.</entitydescription.titaniumaluminiumalloy>
+<entityname.plastic>Plastic</entityname.plastic>
+<entitydescription.plastic>An easily shaped, synthetic material. Contains Silicon and Carbon. Used in circuitry and various equipment.</entitydescription.plastic>
+<entityname.ballisticfiber>Ballistic Fiber</entityname.ballisticfiber>
+<entitydescription.ballisticfiber>Strong fiber strung from plastic and titanium. Used in the manufacture of armor.</entitydescription.ballisticfiber>
+<entityname.organicfiber>Organic Fiber</entityname.organicfiber>
+<entitydescription.organicfiber>Fiber created from plants. Used in the manufacture of clothing and bandages.</entitydescription.organicfiber>
+<entityname.rubber>Rubber</entityname.rubber>
+<entitydescription.rubber>A tough and elastic substance. Used in the manufacture of diving gear and other equipment.</entitydescription.rubber>
+<entityname.flashpowder>Flash Powder</entityname.flashpowder>
+<entitydescription.flashpowder>A quick burning powder, composed of magnesium and potassium. Used in flares and explosives.</entitydescription.flashpowder>
+<entityname.fiberplant>Fiber Plant</entityname.fiberplant>
+<entitydescription.fiberplant>This plant has the texture of a coconut and its fibers move on their own under your fingers unnervingly. Can be processed into organic fiber.</entitydescription.fiberplant>
+<entityname.elastinplant>Elastin Plant</entityname.elastinplant>
+<entitydescription.elastinplant>The foliage of this plant cannot be torn, only stretched. Can be processed into elastin.</entitydescription.elastinplant>
+<entityname.aquaticpoppy>Aquatic Poppy</entityname.aquaticpoppy>
+<entitydescription.aquaticpoppy>It's warm to the touch. Can be processed into opium.</entitydescription.aquaticpoppy>
+<entityname.yeastshroom>Sea Yeast Shroom</entityname.yeastshroom>
+<entitydescription.yeastshroom>The smell is beyond belief, like rotting meat on a hot day. Can be processed into ethanol.</entitydescription.yeastshroom>
+<entityname.elastin>Elastin</entityname.elastin>
+<entitydescription.elastin>A highly elastic, naturally occurring protein. Can be used to stem bleeding or heal burns once processed to medical items.</entitydescription.elastin>
+<entityname.adrenaline>Adrenaline</entityname.adrenaline>
+<entitydescription.adrenaline>A naturally occurring hormone. Used to manufacture medicine or combat stimulants.</entitydescription.adrenaline>
+<entityname.paralyxis>Paralyxis</entityname.paralyxis>
+<entitydescription.paralyxis>A strange substance that numbs when touched. Used to create a powerful paralyzing agent.</entitydescription.paralyxis>
+<entityname.paralyzant>Paralyzant</entityname.paralyzant>
+<entitydescription.paralyzant>Causes paralysis.</entitydescription.paralyzant>
+<entityname.antiparalysis>Anaparalyzant</entityname.antiparalysis>
+<entitydescription.antiparalysis>A cure for paralysis. Beware: Excessive use may cause psychosis.</entitydescription.antiparalysis>
+<entityname.mucusball>Mucus Ball</entityname.mucusball>
+<entitydescription.mucusball>A sticky ball of mucus.</entitydescription.mucusball>
+<entityname.chitin>Chitin Chunk</entityname.chitin>
+<entitydescription.chitin>A tough piece of chitin.</entitydescription.chitin>
+<entityname.hallucinogenicbufotoxin>Hallucinogenic Bufotoxin</entityname.hallucinogenicbufotoxin>
+<entitydescription.hallucinogenicbufotoxin>Hallucinogenic toxin secreted by some Europan species. Serves as an antiparalysant in a pinch.</entitydescription.hallucinogenicbufotoxin>
+<fabricationdescription.munition_propulsion>Munition propulsion materials.</fabricationdescription.munition_propulsion>
+<fabricationdescription.munition_core>Core munition material. High-density metals.</fabricationdescription.munition_core>
+<fabricationdescription.munition_jacket>Munition jacket material. Softer metals.</fabricationdescription.munition_jacket>
+<fabricationdescription.advmunition_tip>Advanced bullet tip material. Hardened metals.</fabricationdescription.advmunition_tip>
+<fabricationdescription.advmunition_core>Advanced core munition material. High-density metals.</fabricationdescription.advmunition_core>
+<fabricationdescription.advmunition_jacket>Advanced munition jacket material. Softer metals.</fabricationdescription.advmunition_jacket>
+
+<!-- Pets -->
+<entityname.petnametag>Pet Name Tag</entityname.petnametag>
+<entitydescription.petnametag>Allows the naming of pets.</entitydescription.petnametag>
+<entityname.poop>Poop</entityname.poop>
+<entitydescription.poop>A pile of poop.</entitydescription.poop>
+<entityname.petegg>Strange Egg</entityname.petegg>
+<entitydescription.petegg>A strange egg. Try injecting it with saline.</entitydescription.petegg>
+<entityname.food>Pet Food</entityname.food>
+<entitydescription.food>The best food for your slimy friend.</entitydescription.food>
+<entityname.defensebotspawner>Defense Bot</entityname.defensebotspawner>
+<entitydescription.defensebotspawner>Build a deadly machine to look after you.</entitydescription.defensebotspawner>
+<entityname.defensebotammobox>Defense Bot Ammunition Rounds</entityname.defensebotammobox>
+<entitydescription.defensebotammobox>Ammunition rounds for Defense Bot</entitydescription.defensebotammobox>
+<entityname.petraptoregg>Petraptor egg</entityname.petraptoregg>
+<entitydescription.petraptoregg>A slimy, pulsating mudraptor egg. Hard to believe that this one is friendly. Drop it on the floor and feed it with saline, maybe?</entitydescription.petraptoregg>
+
+<!-- Misc -->
+<entityname.swimbladder>Swim Bladder</entityname.swimbladder>
+<entitydescription.swimbladder>Many Europan lifeforms have a swim bladder containing tissue fluids that can be easily processed into stabilozine and saline.</entitydescription.swimbladder>
+<entityname.adrenalinegland>Adrenaline Gland</entityname.adrenalinegland>
+<entitydescription.adrenalinegland>Contains large amounts of adrenaline, which can be extracted using a deconstructor.</entitydescription.adrenalinegland>
+<entityname.guitar>Guitar</entityname.guitar>
+<entitydescription.guitar>An old acoustic guitar.</entitydescription.guitar>
+<entityname.harmonica>Harmonica</entityname.harmonica>
+<entitydescription.harmonica>An old handmade harmonica.</entitydescription.harmonica>
+<entityname.bgrock1>Background Rock 1</entityname.bgrock1>
+<entityname.bgrock2>Background Rock 2</entityname.bgrock2>
+<entityname.bgrock3>Background Rock 3</entityname.bgrock3>
+<entityname.bgrock4>Background Rock 4</entityname.bgrock4>
+<entityname.suppliescabinet>Supplies Cabinet</entityname.suppliescabinet>
+<entitydescription.suppliescabinet>Storage for small- and medium-sized items.</entitydescription.suppliescabinet>
+<entityname.mediumsteelcabinet>Medium Steel Cabinet</entityname.mediumsteelcabinet>
+<entitydescription.mediumsteelcabinet>Storage for small- and medium-sized items.</entitydescription.mediumsteelcabinet>
+<entityname.mediumwindowedsteelcabinet>Medium Windowed Steel Cabinet</entityname.mediumwindowedsteelcabinet>
+<entitydescription.mediumwindowedsteelcabinet>Storage for small- and medium-sized items.</entitydescription.mediumwindowedsteelcabinet>
+<entityname.steelcabinet>Large Steel Cabinet</entityname.steelcabinet>
+<entitydescription.steelcabinet>Storage for small- and medium-sized items.</entitydescription.steelcabinet>
+<entityname.securesteelcabinet>Secure Steel Cabinet</entityname.securesteelcabinet>
+<entitydescription.securesteelcabinet>Lockable storage for small- and medium-sized items.</entitydescription.securesteelcabinet>
+<entityname.railgunshellrack>Railgun Shell Rack</entityname.railgunshellrack>
+<entitydescription.railgunshellrack>A way to neatly stow railgun shells.</entitydescription.railgunshellrack>
+<entityname.medcabinet>Medicine Cabinet</entityname.medcabinet>
+<entitydescription.medcabinet>Stow meds here.</entitydescription.medcabinet>
+<entityname.toxcabinet>Toxin Cabinet</entityname.toxcabinet>
+<entitydescription.toxcabinet>Stow poisons here.</entitydescription.toxcabinet>
+<entityname.divingsuitlocker>Diving Suit Locker</entityname.divingsuitlocker>
+<entitydescription.divingsuitlocker>A diving suit locker with one dive-ready suit.</entitydescription.divingsuitlocker>
+<entityname.divingsuitlocker2>Large Diving Suit Locker</entityname.divingsuitlocker2>
+<entitydescription.divingsuitlocker2>Neatly stores multiple diving suits.</entitydescription.divingsuitlocker2>
+<entityname.oxygentankshelf>Oxygen Tank Shelf</entityname.oxygentankshelf>
+<entitydescription.oxygentankshelf>Neatly stores multiple oxygen tanks.</entitydescription.oxygentankshelf>
+<entityname.metalcrate>Metal Crate</entityname.metalcrate>
+<entitydescription.metalcrate>A vessel in which items may be stored.</entitydescription.metalcrate>
+<entityname.securemetalcrate>Secure Metal Crate</entityname.securemetalcrate>
+<entitydescription.securemetalcrate>A secure vessel in which items may be stored.</entitydescription.securemetalcrate>
+<entityname.explosivecrate>Explosive Crate</entityname.explosivecrate>
+<entitydescription.explosivecrate>A vessel in which explosives may be stored.</entitydescription.explosivecrate>
+<entityname.chemicalcrate>Chemical Crate</entityname.chemicalcrate>
+<entitydescription.chemicalcrate>A vessel in which chemicals may be stored.</entitydescription.chemicalcrate>
+<entityname.extinguisherbracket>Fire Extinguisher Bracket</entityname.extinguisherbracket>
+<entitydescription.extinguisherbracket>Holds a fire extinguisher to the wall.</entitydescription.extinguisherbracket>
+<entityname.weaponholder>Weapon Holder</entityname.weaponholder>
+<entitydescription.weaponholder>A place to stow your weapons neatly.</entitydescription.weaponholder>
+<entityname.dockingport>Docking Port</entityname.dockingport>
+<entitydescription.dockingport>A vertically aligned docking interface. Locks to another docking port to form a watertight seal and allow passage between subs, shuttles and locations.</entitydescription.dockingport>
+<entityname.dockinghatch>Docking Hatch</entityname.dockinghatch>
+<entitydescription.dockinghatch>A horizontally aligned docking interface. Locks to another docking hatch to form a watertight seal and allow passage between subs, shuttles and locations.</entitydescription.dockinghatch>
+<entityname.ductblock>Duct Block</entityname.ductblock>
+<entitydescription.ductblock>A mechanically operated vent that may be opened or closed to allow the passage of water.</entitydescription.ductblock>
+<entityname.label>Label</entityname.label>
+<entitydescription.label>Decorative text label.</entitydescription.label>
+<entityname.textdisplay>Text Display</entityname.textdisplay>
+<entitydescription.textdisplay>A scrolling text display.</entitydescription.textdisplay>
+<entityname.ladder>Ladder</entityname.ladder>
+<entitydescription.ladder>Allows for vertical locomotion.</entitydescription.ladder>
+<entityname.fuelrod>Fuel Rod</entityname.fuelrod>
+<entitydescription.fuelrod>A bar of enriched uranium, for use within a reactor.</entitydescription.fuelrod>
+<entityname.fulguriumfuelrod>Fulgurium Fuel Rod</entityname.fulguriumfuelrod>
+<entitydescription.fulguriumfuelrod>A bar of enriched fulgurium, for use within a reactor. Generates significantly more heat and lasts longer than uranium fuel rods.</entitydescription.fulguriumfuelrod>
+<entityname.thoriumfuelrod>Thorium Fuel Rod</entityname.thoriumfuelrod>
+<entitydescription.thoriumfuelrod>A thorium bar, for use within a reactor. Generates slightly more heat and lasts longer than uranium fuel rods.</entitydescription.thoriumfuelrod>
+<entityname.coilgunbolt>Coilgun Bolt</entityname.coilgunbolt>
+<entitydescription.coilgunbolt>For firing from a coilgun.</entitydescription.coilgunbolt>
+<entityname.depthchargeshell>Depth Charge Shell</entityname.depthchargeshell>
+<entitydescription.depthchargeshell>A barrel of explosives. Will sink and then explode.</entitydescription.depthchargeshell>
+<entityname.nucleardepthcharge>Nuclear Depth Charge</entityname.nucleardepthcharge>
+<entitydescription.nucleardepthcharge>A barrel of really big explosives. Will sink and then explode.</entitydescription.nucleardepthcharge>
+<entityname.depthdecoyshell>Depth Decoy Shell</entityname.depthdecoyshell>
+<entitydescription.depthdecoyshell>A decoy that can be deployed via the depth charge launcher. Will sink while producing a loud acoustic signal to attract attention away from the sub.</entitydescription.depthdecoyshell>
+<entityname.nucleardepthdecoy>Nuclear Depth Decoy</entityname.nucleardepthdecoy>
+<entitydescription.nucleardepthdecoy>A decoy that can be deployed via the depth charge launcher. Will sink while producing a loud acoustic signal to attract attention away from the sub.</entitydescription.nucleardepthdecoy>
+<entityname.railgunshell>Railgun Shell</entityname.railgunshell>
+<entitydescription.railgunshell>For firing from a railgun.</entitydescription.railgunshell>
+<entityname.nuclearshell>Nuclear Shell</entityname.nuclearshell>
+<entitydescription.nuclearshell>A nuclear shell for use with a railgun.</entitydescription.nuclearshell>
+<entityname.alienshell>Physicorium Shell</entityname.alienshell>
+<entitydescription.alienshell>For firing from a railgun.</entitydescription.alienshell>
+<entityname.mudraptoregg>Mudraptor Egg</entityname.mudraptoregg>
+<entitydescription.mudraptoregg>A slimy, pulsating mudraptor egg. The gaping maw on top of the egg seems to be grasping for something to eat.</entitydescription.mudraptoregg>
+<entityname.loosevent>Loose Vent</entityname.loosevent>
+<entitydescription.loosevent>A place to stash things of dubious nature.</entitydescription.loosevent>
+<entityname.loosepanel>Loose Panel</entityname.loosepanel>
+<entitydescription.loosepanel>A place to stash things of dubious nature.</entitydescription.loosepanel>
+<entityname.thalamusbrain1>Thalamus Brain</entityname.thalamusbrain1>
+<entityname.fleshgun1>Fleshgun</entityname.fleshgun1>
+<entityname.fleshgunloader1>Fleshgun Ammo Sack</entityname.fleshgunloader1>
+<entityname.fleshguntendon1>Fleshgun Tendon</entityname.fleshguntendon1>
+<entityname.fleshspike1>Flesh Spike</entityname.fleshspike1>
+<entityname.cellspawnorgan1>Cell Spawn Organ</entityname.cellspawnorgan1>
+<entityname.thalamuswire>Thalamus Vein</entityname.thalamuswire>
+<entityname.thalamus_wall_vertical_decorative_1>Thalamus Decorative Vertical Wall 1</entityname.thalamus_wall_vertical_decorative_1>
+<entityname.thalamus_wall_horizontal_decorative_1>Thalamus Decorative Horizontal Wall 1</entityname.thalamus_wall_horizontal_decorative_1>
+<entityname.thalamus_wall_vertical_1>Thalamus Vertical Wall 1</entityname.thalamus_wall_vertical_1>
+<entityname.thalamus_wall_horizontal_1>Thalamus Horizontal Wall 1</entityname.thalamus_wall_horizontal_1>
+<entityname.thalamus_background_1>Thalamus Background 1</entityname.thalamus_background_1>
+<entityname.storageorgan1>Organ</entityname.storageorgan1>
+<entityname.handheldterminal>Logbook</entityname.handheldterminal>
+<entitydescription.handheldterminal>A handheld device used for storing messages.</entitydescription.handheldterminal>
+<entityname.idcardwreck>Shipwreck ID Card</entityname.idcardwreck>
+<entitydescription.idcardwreck>This ID card allows access to most of the wreck, provided the door isn't rusted shut.</entitydescription.idcardwreck>
+<entityname.crateshelf>Crate Shelf</entityname.crateshelf>
+<entityname.op_lighttower>Light Tower</entityname.op_lighttower>
+<entityname.op_lightbox1>Lightbox</entityname.op_lightbox1>
+<entityname.op_hologramdisplay1>Hologram Display</entityname.op_hologramdisplay1>
+<entityname.opdeco_container>Shop Display</entityname.opdeco_container>
+<entityname.opdeco_shopsuit1>Diving Suit Display</entityname.opdeco_shopsuit1>
+<entityname.op_researchcontainmenttank1>Research Containment Tank</entityname.op_researchcontainmenttank1>
+<entityname.op_researchtable>Research Table</entityname.op_researchtable>
+<entityname.op_vendingmachine1>Vending Machine</entityname.op_vendingmachine1>
+<entityname.op_workbenchlamp>Workbench Lamp</entityname.op_workbenchlamp>
+<entityname.opdeco_heater>Heater</entityname.opdeco_heater>
+<entityname.opdeco_bunkbeds>Military Bunk</entityname.opdeco_bunkbeds>
+<entityname.opbg_tunnel3>Outpost Tunnel Background 3</entityname.opbg_tunnel3>
+<entityname.opdeco_officechair>Office Chair</entityname.opdeco_officechair>
+<entityname.medicalmonitor>Medical Monitor</entityname.medicalmonitor>
+<entityname.medicalcompartment>Medical Compartment</entityname.medicalcompartment>
+<entityname.opdeco_surgicallights>Surgical Lights</entityname.opdeco_surgicallights>
+<entityname.opdeco_xrayscreen>X-Ray Screen</entityname.opdeco_xrayscreen>
+<entityname.op_researchterminal>Research Station</entityname.op_researchterminal>
+<entityname.opdeco_medcurtain>Medical Curtain</entityname.opdeco_medcurtain>
+<entityname.outpostterminal>Outpost Terminal</entityname.outpostterminal>
+<entitydescription.outpostterminal>Allows access to the outpost's digital services.</entitydescription.outpostterminal>
+<entityname.sealedsupplycrate>Sealed Supply Crate</entityname.sealedsupplycrate>
+<entitydescription.sealedsupplycrate>A box of various in-demand supplies. Fetches a high price at outposts.</entitydescription.sealedsupplycrate>
+<entityname.redpaint>Red Paint</entityname.redpaint>
+<entityname.greenpaint>Green Paint</entityname.greenpaint>
+<entityname.bluepaint>Blue Paint</entityname.bluepaint>
+<entityname.lightredpaint>Light Red Paint</entityname.lightredpaint>
+<entityname.lightgreenpaint>Light Green Paint</entityname.lightgreenpaint>
+<entityname.lightbluepaint>Light Blue Paint</entityname.lightbluepaint>
+<entityname.darkredpaint>Dark Red Paint</entityname.darkredpaint>
+<entityname.darkgreenpaint>Dark Green Paint</entityname.darkgreenpaint>
+<entityname.darkbluepaint>Dark Blue Paint</entityname.darkbluepaint>
+<entityname.blackpaint>Black Paint</entityname.blackpaint>
+<entityname.whitepaint>White Paint</entityname.whitepaint>
+<entityname.opdeco_trashcan>Trash Can</entityname.opdeco_trashcan>
+<entityname.opdeco_cabinetsdorm>Cabinets</entityname.opdeco_cabinetsdorm>
+<entityname.opdeco_screen>Monitor Screen</entityname.opdeco_screen>
+<entityname.minemineral>Mineral Deposit</entityname.minemineral>
+<entityname.icedebris>Ice Debris</entityname.icedebris>
+<entityname.supportbeamhorizontal>Support Beam Horizontal</entityname.supportbeamhorizontal>
+<entityname.supportbeamvertical>Support Beam Vertical</entityname.supportbeamvertical>
+<entityname.scrap>Scrap</entityname.scrap>
+<entitydescription.scrap>A pile of possibly useful material.</entitydescription.scrap>
+<entityname.spinelingspike>Spineling's Spike</entityname.spinelingspike>
+<entitydescription.spinelingspike>A detached bone spike that once belonged to a Spineling.</entitydescription.spinelingspike>
+<entityname.toothspike>Latcher's tooth</entityname.toothspike>
+<entityname.tonguetendon>Latcher's tongue</entityname.tonguetendon>
+<entityname.piezocrystal>Piezo Crystal</entityname.piezocrystal>
+<entityname.crawleregg>Crawler Egg</entityname.crawleregg>
+<entityname.mediccrate>Medic Crate</entityname.mediccrate>
+<entitydescription.mediccrate>A box for medical items and ingredients.</entitydescription.mediccrate>
+<entityname.rustdecal>Rust Decal</entityname.rustdecal>
+<entitydescription.rustdecal>Decorative decal for walls and machines</entitydescription.rustdecal>
+<entityname.monsterscums>Monster Scum</entityname.monsterscums>
+<entityname.humanitems>Bandit Prop</entityname.humanitems>
+<entityname.stairsrightshort>Stairs Right Short</entityname.stairsrightshort>
+<entityname.stairsleftshort>Stairs Left Short</entityname.stairsleftshort>
+<entityname.stairsrightlong>Stairs Right Long</entityname.stairsrightlong>
+<entityname.stairsleftlong>Stairs Left Long</entityname.stairsleftlong>
+<entityname.banditoutfit>Bandit Outfit</entityname.banditoutfit>
+<entityname.metalwalls>Metal Wall</entityname.metalwalls>
+<entityname.metalbox>Metal Box</entityname.metalbox>
+<entityname.ff_wall_airlock1>Airlock</entityname.ff_wall_airlock1>
+<entityname.unitloaddevice>Unit Load Device</entityname.unitloaddevice>
+<entitydescription.unitloaddevice>A container that can hold a large quantity of crates.</entitydescription.unitloaddevice>
+<entityname.streetlight>Street Light</entityname.streetlight>
+<entityname.neonlighta>Neon Light A</entityname.neonlighta>
+<entityname.neonlightb>Neon Light B</entityname.neonlightb>
+<entityname.neonlightc>Neon Light C</entityname.neonlightc>
+<entityname.neonlightd>Neon Light D</entityname.neonlightd>
+<entityname.neonlighte>Neon Light E</entityname.neonlighte>
+<entityname.neonlightf>Neon Light F</entityname.neonlightf>
+<entityname.neonlightg>Neon Light G</entityname.neonlightg>
+<entityname.neonlighth>Neon Light H</entityname.neonlighth>
+<entityname.neonlighti>Neon Light I</entityname.neonlighti>
+<entityname.neonlightj>Neon Light J</entityname.neonlightj>
+<entityname.neonlightk>Neon Light K</entityname.neonlightk>
+<entityname.neonlightl>Neon Light L</entityname.neonlightl>
+<entityname.neonlightm>Neon Light M</entityname.neonlightm>
+<entityname.neonlightn>Neon Light N</entityname.neonlightn>
+<entityname.neonlighto>Neon Light O</entityname.neonlighto>
+<entityname.neonlightp>Neon Light P</entityname.neonlightp>
+<entityname.neonlightq>Neon Light Q</entityname.neonlightq>
+<entityname.neonlightr>Neon Light R</entityname.neonlightr>
+<entityname.neonlights>Neon Light S</entityname.neonlights>
+<entityname.neonlightt>Neon Light T</entityname.neonlightt>
+<entityname.neonlightu>Neon Light U</entityname.neonlightu>
+<entityname.neonlightv>Neon Light V</entityname.neonlightv>
+<entityname.neonlightw>Neon Light W</entityname.neonlightw>
+<entityname.neonlightx>Neon Light X</entityname.neonlightx>
+<entityname.neonlighty>Neon Light Y</entityname.neonlighty>
+<entityname.neonlightz>Neon Light Z</entityname.neonlightz>
+<entityname.neonlight0>Neon Light 0</entityname.neonlight0>
+<entityname.neonlight1>Neon Light 1</entityname.neonlight1>
+<entityname.neonlight2>Neon Light 2</entityname.neonlight2>
+<entityname.neonlight3>Neon Light 3</entityname.neonlight3>
+<entityname.neonlight4>Neon Light 4</entityname.neonlight4>
+<entityname.neonlight5>Neon Light 5</entityname.neonlight5>
+<entityname.neonlight6>Neon Light 6</entityname.neonlight6>
+<entityname.neonlight7>Neon Light 7</entityname.neonlight7>
+<entityname.neonlight8>Neon Light 8</entityname.neonlight8>
+<entityname.neonlight9>Neon Light 9</entityname.neonlight9>
+<entityname.neonlightplanet>Neon Light Planet</entityname.neonlightplanet>
+<entityname.neonlightkiss>Neon Light Kiss</entityname.neonlightkiss>
+<entityname.neonlightarrow>Neon Light Arrow</entityname.neonlightarrow>
+<entityname.neonlightgarden>Neon Light Garden</entityname.neonlightgarden>
+<entityname.neonlightgear>Neon Light Gear</entityname.neonlightgear>
+<entityname.neonlightsubmarine>Neon Light Submarine</entityname.neonlightsubmarine>
+<entityname.neonlightfood>Neon Light Food</entityname.neonlightfood>
+<entityname.neonlightframe>Neon Light Frame</entityname.neonlightframe>
+<entityname.neonlightwire1>Neon Light Wire 1</entityname.neonlightwire1>
+<entityname.neonlightwire2>Neon Light Wire 2</entityname.neonlightwire2>
+<entityname.neonlightwire3>Neon Light Wire 3</entityname.neonlightwire3>
+<entityname.neonlightwire4>Neon Light Wire 4</entityname.neonlightwire4>
+
+<!-- Alien -->
+<entityname.skyholderartifact>Sky Alien Artifact</entityname.skyholderartifact>
+<entitydescription.skyholderartifact>Artifact found in alien ruins.</entitydescription.skyholderartifact>
+<entityname.thermalartifact>Thermal Alien Artifact</entityname.thermalartifact>
+<entitydescription.thermalartifact>Artifact found in alien ruins.</entitydescription.thermalartifact>
+<entityname.faradayartifact>Faraday Alien Artifact</entityname.faradayartifact>
+<entitydescription.faradayartifact>Artifact found in alien ruins.</entitydescription.faradayartifact>
+<entityname.nasonovartifact>Nasonov Alien Artifact</entityname.nasonovartifact>
+<entitydescription.nasonovartifact>Artifact found in alien ruins.</entitydescription.nasonovartifact>
+<entityname.psychosisartifact>Psychosis Alien Artifact</entityname.psychosisartifact>
+<entitydescription.psychosisartifact>Artifact found in alien ruins.</entitydescription.psychosisartifact>
+<entityname.alientrinket1>Alien Trinket</entityname.alientrinket1>
+<entitydescription.alientrinket1>Minor artifact found in alien ruins.</entitydescription.alientrinket1>
+<entityname.alientrinket2>Alien Curio</entityname.alientrinket2>
+<entitydescription.alientrinket2>Minor artifact found in alien ruins.</entitydescription.alientrinket2>
+<entityname.alientrinket3>Alien Ornament</entityname.alientrinket3>
+<entitydescription.alientrinket3>Minor artifact found in alien ruins.</entitydescription.alientrinket3>
+<entityname.oxygeniteshard>Oxygenite Shard</entityname.oxygeniteshard>
+<entitydescription.oxygeniteshard>An alien mineral.</entitydescription.oxygeniteshard>
+<entityname.sulphuriteshard>Sulphurite Shard</entityname.sulphuriteshard>
+<entitydescription.sulphuriteshard>An alien mineral.</entitydescription.sulphuriteshard>
+<entityname.ancientweapon>Ancient Weapon</entityname.ancientweapon>
+<entitydescription.ancientweapon>A weapon with powerful capabilities.</entitydescription.ancientweapon>
+<entityname.alienhatch>Alien Hatch</entityname.alienhatch>
+<entitydescription.alienhatch>A horizontal hatch for alien ruins.</entitydescription.alienhatch>
+<entityname.aliendoor>Alien Door</entityname.aliendoor>
+<entitydescription.aliendoor>A vertical door for alien ruins.</entitydescription.aliendoor>
+<entityname.alienmotionsensor>Alien Motion Sensor</entityname.alienmotionsensor>
+<entitydescription.alienmotionsensor>A motion detector used by aliens.</entitydescription.alienmotionsensor>
+<entityname.artifactholder>Artifact Holder</entityname.artifactholder>
+<entitydescription.artifactholder>For holding major artifacts.</entitydescription.artifactholder>
+<entityname.aliengenerator>Alien Generator</entityname.aliengenerator>
+<entitydescription.aliengenerator>Converts alien power cells to electricity.</entitydescription.aliengenerator>
+<entityname.alienpowercell>Alien Power Cell</entityname.alienpowercell>
+<entitydescription.alienpowercell>An alien power source.</entitydescription.alienpowercell>
+<entityname.alienpump>Alien Pump</entityname.alienpump>
+<entitydescription.alienpump>Used to pump water in and out of ruins.</entitydescription.alienpump>
+<entityname.alienbutton>Alien Button</entityname.alienbutton>
+<entitydescription.alienbutton>Sends a signal to alien mechanisms.</entitydescription.alienbutton>
+<entityname.alienturret>Alien Turret</entityname.alienturret>
+<entitydescription.alienturret>A stationary turret found in alien ruins.</entitydescription.alienturret>
+<entityname.alienturretammo>Alien Projectile</entityname.alienturretammo>
+<entitydescription.alienturretammo>Fired from alien turrets.</entitydescription.alienturretammo>
+<entityname.aliencoil>Alien Coil</entityname.aliencoil>
+<entitydescription.aliencoil>Discharges electricity; used in alien ruins.</entitydescription.aliencoil>
+<entityname.alienvent>Alien Vent</entityname.alienvent>
+<entitydescription.alienvent>Emits gases in alien ruins.</entitydescription.alienvent>
+<entityname.alienitemcontainersmall>Small Alien Chest</entityname.alienitemcontainersmall>
+<entitydescription.alienitemcontainersmall>Small alien item container.</entitydescription.alienitemcontainersmall>
+<entityname.alienitemcontainerlarge>Large Alien Chest</entityname.alienitemcontainerlarge>
+<entitydescription.alienitemcontainerlarge>Large alien item container.</entitydescription.alienitemcontainerlarge>
+<entityname.alienlightcomponent>Alien Light Component</entityname.alienlightcomponent>
+<entitydescription.alienlightcomponent>Emits light; used in alien ruins.</entitydescription.alienlightcomponent>
+<entityname.alienterminal>Alien Terminal</entityname.alienterminal>
+<entitydescription.alienterminal>Sends signals if the required item is contained.</entitydescription.alienterminal>
+<entityname.artifacttransportcase>Artifact Transport Case</entityname.artifacttransportcase>
+<entitydescription.artifacttransportcase>A case to ease the transportation of alien artifacts.</entitydescription.artifacttransportcase>
+<entityname.aliendoorwbuttons>Alien Door with Buttons</entityname.aliendoorwbuttons>
+<entityname.alienhatchwbuttons>Alien Hatch with Buttons</entityname.alienhatchwbuttons>
+<entityname.ruindecal1>Ruin Decal</entityname.ruindecal1>
+<entityname.incubationbubble>Incubation Bubble</entityname.incubationbubble>
+<entitydescription.incubationbubble>Container for alien genetic material.</entitydescription.incubationbubble>
+<entityname.gravitysphere>Gravity Sphere</entityname.gravitysphere>
+<entitydescription.gravitysphere>Generates a strong, artificial gravity field.</entitydescription.gravitysphere>
+<entityname.ruinwallcorner1>Ruin Wall Corner Piece</entityname.ruinwallcorner1>
+<entitydescription.ruinwallcorner1>A basic wall with collision for alien ruins.</entitydescription.ruinwallcorner1>
+<entityname.guardianpod>Guardian Pod</entityname.guardianpod>
+<entitydescription.guardianpod>Protective pod for Fractal Guardians.</entitydescription.guardianpod>
+<entityname.ruinscanner>Ruin Scanner</entityname.ruinscanner>
+<entitydescription.ruinscanner>A device that uses sonar waves to map ruins.</entitydescription.ruinscanner>
+<entityname.ruinvent>Ruin Vent</entityname.ruinvent>
+<entitydescription.ruinvent>A vent that might emit harmful spores or gas.</entitydescription.ruinvent>
+<entityname.guardiancutter>Guardian Cutter</entityname.guardiancutter>
+<entitydescription.guardiancutter>Fractal Guardian Weaponry</entitydescription.guardiancutter>
+<entityname.guardiansteamcannon>Guardian Steam Cannon</entityname.guardiansteamcannon>
+<entityname.guardianpacifier>Guardian Pacifier</entityname.guardianpacifier>
+<entityname.guardianhookcannon>Guardian Hook Cannon</entityname.guardianhookcannon>
+<entityname.guardianspear>Guardian Spear</entityname.guardianspear>
+<entityname.guardianinjector>Guardian Injector</entityname.guardianinjector>
+<character.swarmfeeder>Swarm Feeder</character.swarmfeeder>
+<entityname.ruincolumn>Ruin Column</entityname.ruincolumn>
+<entitydescription.ruincolumn>Ruin decoration.</entitydescription.ruincolumn>
+<entityname.ruincolumntop>Ruin Column Top</entityname.ruincolumntop>
+<entityname.ruincolumnbottom>Ruin Column Bottom</entityname.ruincolumnbottom>
+<entityname.ruinlight>Ruin Light</entityname.ruinlight>
+<entityname.alienmachine>Alien Machine</entityname.alienmachine>
+<entityname.incendium>Incendium Crystal</entityname.incendium>
+<entitydescription.incendium>A rare alien crystal capable of emitting extreme amounts of heat. Used in incendiary weapons.</entitydescription.incendium>
+<entityname.fulgurium>Fulgurium Chunk</entityname.fulgurium>
+<entitydescription.fulgurium>A rare metallic alien material, capable of storing massive amounts of energy. Used in high capacity batteries.</entitydescription.fulgurium>
+<entityname.physicorium>Physicorium Bar</entityname.physicorium>
+<entitydescription.physicorium>An incredibly hard and durable alien material. Used in highly advanced weaponry and ammunition.</entitydescription.physicorium>
+<entityname.dementonite>Dementonite Cluster</entityname.dementonite>
+<entitydescription.dementonite>A strange living metal. Holding it evokes a strange sense of unease.</entitydescription.dementonite>
+
+<!-- Gardening -->
+<entityname.smallplanter>Small Planter Box</entityname.smallplanter>
+<entitydescription.smallplanter>Suitable for most Europan plantlife while small enough to be transported around by hand.</entitydescription.smallplanter>
+<entityname.fertilizer>Fertilizer</entityname.fertilizer>
+<entitydescription.fertilizer>Carefully tended Europan soil guaranteed to give your plant the best living conditions.</entitydescription.fertilizer>
+<entityname.seedbag>Seed Bag</entityname.seedbag>
+<entitydescription.seedbag>Can store a wide variety of seeds.</entitydescription.seedbag>
+<entityname.wateringcan>Watering Can</entityname.wateringcan>
+<entitydescription.wateringcan>Keeps your plants happy and alive.</entitydescription.wateringcan>
+<entityname.creepingorange>Pomegrenade</entityname.creepingorange>
+<entitydescription.creepingorange>A tasty fruit. Its processed juice has minor healing properties.</entitydescription.creepingorange>
+<entityname.tobaccobud>Tobacco Bud</entityname.tobaccobud>
+<entitydescription.tobaccobud>Damp and strongly fragrant. Can be refined into serviceable pipe tobacco.</entitydescription.tobaccobud>
+<entityname.badraptorbane>Mutated Raptor Bane</entityname.badraptorbane>
+<entityname.saltbulb>Salt Bulb</entityname.saltbulb>
+<entitydescription.saltbulb>Salty. Avoid moisture.</entitydescription.saltbulb>
+<entityname.raptorbane>Raptor Bane</entityname.raptorbane>
+<entitydescription.raptorbane>It looks delicious, but should not be ingested under any circumstances. Not good for mudraptors.</entitydescription.raptorbane>
+<entityname.badcreepingorange>Mutated Pomegrenade</entityname.badcreepingorange>
+<entityname.creepingorangevineseed>Pomegrenade Seed</entityname.creepingorangevineseed>
+<entityname.tobaccovineseed>Tobacco Vine Seed</entityname.tobaccovineseed>
+<entityname.saltvineseed>Salt Vine Seed</entityname.saltvineseed>
+<entityname.raptorbaneseed>Raptor Bane Seed</entityname.raptorbaneseed>
+<entityname.raptorbaneextract>Raptor Bane Extract</entityname.raptorbaneextract>
+<entitydescription.raptorbaneextract>Concentrated raptorbane juice. Mildly toxic for humans, catastrophically toxic for mudraptors.</entitydescription.raptorbaneextract>
+<entityname.pomegrenadeextract>Pomegrenade Extract</entityname.pomegrenadeextract>
+<entitydescription.pomegrenadeextract>Concentrated pomegrenade juice. It offers minor healing properties.</entitydescription.pomegrenadeextract>
+<entityname.pipetobacco>Pipe Tobacco</entityname.pipetobacco>
+<entitydescription.pipetobacco>Put it in your pipe and smoke it.</entitydescription.pipetobacco>
+
+<!-- Room names -->
+<roomname.reactorroom>Reactor room</roomname.reactorroom>
+<roomname.engineroom>Engine room</roomname.engineroom>
+<roomname.commandroom>Command room</roomname.commandroom>
+<roomname.airlock>Airlock</roomname.airlock>
+<roomname.ballast>Ballast</roomname.ballast>
+<roomname.subtopleft>Upper aft side</roomname.subtopleft>
+<roomname.subtopcenter>Upper mid</roomname.subtopcenter>
+<roomname.subtopright>Upper fore side</roomname.subtopright>
+<roomname.subcenterleft>Mid aft side</roomname.subcenterleft>
+<roomname.subcenter>Amidships</roomname.subcenter>
+<roomname.subcenterright>Mid fore side</roomname.subcenterright>
+<roomname.subbottomleft>Lower aft side</roomname.subbottomleft>
+<roomname.subbottomcenter>Lower mid</roomname.subbottomcenter>
+<roomname.subbottomright>Lower fore side</roomname.subbottomright>
+<roomname.subdiroclock>[dir] o'clock</roomname.subdiroclock>
+<roomname.ballasttank1>Ballast tank A</roomname.ballasttank1>
+<roomname.ballasttank2>Ballast tank B</roomname.ballasttank2>
+<roomname.ballasttank3>Ballast tank C</roomname.ballasttank3>
+<roomname.ballasttank4>Ballast tank D</roomname.ballasttank4>
+<roomname.ballasttank5>Ballast tank E</roomname.ballasttank5>
+<roomname.stowage>Stowage compartment</roomname.stowage>
+<roomname.berthing>Berthing compartment</roomname.berthing>
+<roomname.utility>Utility compartment</roomname.utility>
+<roomname.rearballast>Rear ballast</roomname.rearballast>
+<roomname.frontballast>Front ballast</roomname.frontballast>
+<roomname.medbay>Medbay</roomname.medbay>
+<roomname.engineering>Engineering</roomname.engineering>
+<roomname.electrical>Electrical</roomname.electrical>
+<roomname.armory>Armory</roomname.armory>
+<roomname.dockingport>Docking port</roomname.dockingport>
+<roomname.upperdockingport>Upper docking port</roomname.upperdockingport>
+<roomname.lowerdockingport>Lower docking port</roomname.lowerdockingport>
+<roomname.cargo>Cargo</roomname.cargo>
+<roomname.brig>Brig</roomname.brig>
+<roomname.crewquarters>Crew quarters</roomname.crewquarters>
+<roomname.junctioncompartment>Junction compartment</roomname.junctioncompartment>
+<roomname.centralaccesspassage>Central access passage</roomname.centralaccesspassage>
+<roomname.centralaccessshaft>Central access shaft</roomname.centralaccessshaft>
+<roomname.forwardaccessshaft>Forward access shaft</roomname.forwardaccessshaft>
+<roomname.aftaccessshaft>Aft access shaft</roomname.aftaccessshaft>
+<roomname.airlockaccess>Airlock Access</roomname.airlockaccess>
+<roomname.gunnerycompartment>Gunnery Compartment</roomname.gunnerycompartment>
+<roomname.dronecontrol>Drone Control</roomname.dronecontrol>
+<roomname.drone>Drone</roomname.drone>
+<roomname.droneballast>Drone Ballast</roomname.droneballast>
+<roomname.bilge>Bilge</roomname.bilge>
+<roomname.oxygengenerator>Oxygen generator compartment</roomname.oxygengenerator>
+<roomname.research>Research lab</roomname.research>
+<roomname.reception>Reception</roomname.reception>
+<roomname.lounge>Lounge</roomname.lounge>
+
+<!-- Submarine & outpost labels -->
+<label.ventralcoilguncontrol>Ventral Coilgun Control</label.ventralcoilguncontrol>
+<label.dorsalcoilguncontrol>Dorsal Coilgun Control</label.dorsalcoilguncontrol>
+<label.rearcoilguncontrol>Rear Coilgun Control</label.rearcoilguncontrol>
+<label.frontcoilguncontrol>Front Coilgun Control</label.frontcoilguncontrol>
+<label.ventralrailguncontrol>Ventral Railgun Control</label.ventralrailguncontrol>
+<label.dorsalrailguncontrol>Dorsal Railgun Control</label.dorsalrailguncontrol>
+<label.rearrailguncontrol>Rear Railgun Control</label.rearrailguncontrol>
+<label.frontrailguncontrol>Front Railgun Control</label.frontrailguncontrol>
+<label.toggledocking>Toggle Docking</label.toggledocking>
+<label.reactorshutdown>Reactor Shutdown</label.reactorshutdown>
+<label.engine1>Engine #1</label.engine1>
+<label.engine2>Engine #2</label.engine2>
+<label.auxiliaryengine>Aux. engine</label.auxiliaryengine>
+<label.launchdecoy>Launch Decoy</label.launchdecoy>
+<label.launchdepthcharge>Launch Depth Charge</label.launchdepthcharge>
+<label.activatedischargecoil>Electrical Discharge Coil</label.activatedischargecoil>
+<label.activateupperdischargecoil>Upper Discharge Coil</label.activateupperdischargecoil>
+<label.activatelowerdischargecoil>Lower Discharge Coil</label.activatelowerdischargecoil>
+<label.exteriorcamera>Ext. camera view</label.exteriorcamera>
+<label.ventralcamera>Ventral camera view</label.ventralcamera>
+<label.dorsalcamera>Dorsal camera view</label.dorsalcamera>
+<label.reactortemp>Reactor temp.</label.reactortemp>
+<label.alphadeck>Alpha Deck</label.alphadeck>
+<label.gammadeck>Gamma Deck</label.gammadeck>
+<label.deltadeck>Delta Deck</label.deltadeck>
+<label.readytodock>Ready to dock</label.readytodock>
+<label.docked>Docked</label.docked>
+<label.emergencydooroverride>Emergency door override</label.emergencydooroverride>
+<label.emergencyhatchoverride>Emergency hatch override</label.emergencyhatchoverride>
+<label.supplies>Supplies</label.supplies>
+<label.togglebatteries>Toggle Batteries</label.togglebatteries>
+<label.togglesiren>Toggle Siren</label.togglesiren>
+<label.emergency>Emergency</label.emergency>
+<label.backuppowerarray>Backup power array</label.backuppowerarray>
+<label.dronecontrol>Drone control</label.dronecontrol>
+<label.statuslabel>Status</label.statuslabel>
+<label.onlinelabel>Online</label.onlinelabel>
+<label.offlinelabel>Offline</label.offlinelabel>
+<label.openlabel>Open</label.openlabel>
+<label.closelabel>Close</label.closelabel>
+<label.ballasthatch>Ballast hatch</label.ballasthatch>
+<label.betadeck>Beta Deck</label.betadeck>
+<label.airlock>Airlock</label.airlock>
+<label.dockingport>Docking Port</label.dockingport>
+<label.weapons>Weapons</label.weapons>
+<label.cargo>Cargo Bay</label.cargo>
+<label.crewquarters>Crew Quarters</label.crewquarters>
+<label.electrical1>Electrical #1</label.electrical1>
+<label.electrical2>Electrical #2</label.electrical2>
+<label.medical>Medical</label.medical>
+<label.engineering>Engineering</label.engineering>
+<label.ballast>Ballast</label.ballast>
+<label.reactor>Reactor</label.reactor>
+<label.armory>Armory</label.armory>
+<label.batteryoutput>Battery Output</label.batteryoutput>
+<label.onoff>On/Off</label.onoff>
+<label.bilge>Bilge</label.bilge>
+<label.powermainline>Power Mainline</label.powermainline>
+<label.command>Command</label.command>
+<label.engine>Engine</label.engine>
+<label.outpostinfodisplay1>Welcome. Oxygen Levels: Nominal. Power Levels: Nominal. Radiation Levels: Suboptimal. Weather Forecast for Today: Cold and Damp.</label.outpostinfodisplay1>
+<label.navterminaldock>Dock</label.navterminaldock>
+<label.navterminalundock>Undock</label.navterminalundock>
+<label.highpressurewarning>WARNING: High pressure</label.highpressurewarning>
+<label.reactortempwarning>Reactor temp. caution</label.reactortempwarning>
+<label.activatedischargecoils>Discharge Coils</label.activatedischargecoils>
+<label.lights1>Lights 1</label.lights1>
+<label.lights2>Lights 2</label.lights2>
+<label.lights3>Lights 3</label.lights3>
+<label.lights4>Lights 4</label.lights4>
+<label.lights5>Lights 5</label.lights5>
+<label.pumps1>Pumps 1</label.pumps1>
+<label.pumps2>Pumps 2</label.pumps2>
+<label.dronecharge>Drone Charge</label.dronecharge>
+<label.meltdown>Meltdown</label.meltdown>
+<label.batterycharge>Battery charge%</label.batterycharge>
+<label.hatchoverride>Hatch Override</label.hatchoverride>
+<label.batteryin>Battery IN</label.batteryin>
+<label.batteryout>Battery OUT</label.batteryout>
+<label.batteryarray>Battery Array</label.batteryarray>
+<label.fire>Fire</label.fire>
+<label.flood>Flood</label.flood>
+<label.dockingports>Docking Ports</label.dockingports>
+<label.oxygenlevels>Oxygen Levels</label.oxygenlevels>
+<label.dronedoor>Please ensure the drone door is closed before attempting to undock</label.dronedoor>
+<label.deliveryservice>Submarine Switch Terminal</label.deliveryservice>
+<label.storage>Storage</label.storage>
+<label.repellant>Intruder repellant</label.repellant>
+<label.emergencylights>Emergency lights</label.emergencylights>
+<label.letwaterdrain>Allow all water to drain before exiting!</label.letwaterdrain>
+<label.ventralturretcontrol>Ventral Turret Control</label.ventralturretcontrol>
+<label.dorsalturretcontrol>Dorsal Turret Control</label.dorsalturretcontrol>
+<label.rearturretcontrol>Rear Turret Control</label.rearturretcontrol>
+<label.frontturretcontrol>Front Turret Control</label.frontturretcontrol>
+<label.researchfacility>Research facility</label.researchfacility>
+<label.admin>Administrative office</label.admin>
+<label.hr>Human resources</label.hr>
+<label.store>General store</label.store>
+<label.waterintakevalve>Water Intake Valve</label.waterintakevalve>
+<label.daysafterlawsuit>Days since last malpractice lawsuit</label.daysafterlawsuit>
+<label.silentrunning>Silent Running</label.silentrunning>
+
+<!-- Submarine description -->
+<dimensions>Dimensions</dimensions>
+<dimensionsformat>[width]x[height] m</dimensionsformat>
+<crushdepth>Crush depth</crushdepth>
+<meterformat>[meters] m</meterformat>
+<subpreviewimagenotfound>Preview image not found</subpreviewimagenotfound>
+<subpreviewimage>Preview image</subpreviewimage>
+<subpreviewimagebrowse>Browse...</subpreviewimagebrowse>
+<subpreviewimagecreate>Create</subpreviewimagecreate>
+<recommendedcrewsize>Recommended crew size</recommendedcrewsize>
+<recommendedcrewexperience>Recommended crew experience</recommendedcrewexperience>
+<requiredcontentpackages>Required content packages</requiredcontentpackages>
+<crewexperiencelow>Beginner</crewexperiencelow>
+<crewexperiencemid>Intermediate</crewexperiencemid>
+<crewexperiencehigh>Experienced</crewexperiencehigh>
+<autoloadout_description>Modify the quantity of items to be spawned on the sub initially</autoloadout_description>
+<autoloadout_title>Auto Loadout</autoloadout_title>
+<cargocapacity>Cargo capacity</cargocapacity>
+<cargocapacityformat>[cratecount] crates</cargocapacityformat>
+<generatingsubmarinepreview>Generating preview...</generatingsubmarinepreview>
+<submarine.classandtier>[class] ([tier])</submarine.classandtier>
+<subeditor.tier>Tier</subeditor.tier>
+<submarinetier.1>Tier I</submarinetier.1>
+<submarinetier.2>Tier II</submarinetier.2>
+<submarinetier.3>Tier III</submarinetier.3>
+<submarinetier.description>Higher tier submarines are more advanced, costlier and better equipped than lower-tier submarines. They can also be upgraded further than lower tier submarines.</submarinetier.description>
+<submarineclass.description>A submarine's class describes what kinds of tasks it was primarily designed for. The class also affects how far certain features of the submarine can be upgraded.</submarineclass.description>
+<submarinetierandclass.description>Submarine tier and class affect the number of available upgrades, as well as the maximum upgrade level per category. Higher tier submarines can be upgraded further than lower tier submarines. Class can raise the maximum upgrade level of matching categories even higher.</submarinetierandclass.description>
+<submarineclass.scout.description>Scout class submarines are fast and agile. Their engines and turret visibility ranges can be upgraded further than other classes, and they support mineral scanner installations.</submarineclass.scout.description>
+<submarineclass.attack.description>Designed for combat, attack submarines are tough and heavily armed. Their turrets can be upgraded further than other classes.</submarineclass.attack.description>
+<submarineclass.transport.description>Transport submarines have plenty of space for cargo and are well equipped for collecting and processing resources. Their fabricators, deconstructors and fuel efficiency can be upgraded further than other classes, and they support mineral scanner installations.</submarineclass.transport.description>
+
+<!-- Submarine names & descriptions -->
+<submarine.name.humpback>Humpback</submarine.name.humpback>
+<submarine.description.humpback>A former military vessel, WH4-L3 "Humpback" has been outfitted to withstand most of the dangers in deep Europa. Her relatively high velocity is offset by low maneuverability. As she's still boasting an older model reactor, power needs to be supplemented by a backup battery array or the crew will find themselves unable to run all of the new equipment.</submarine.description.humpback>
+<submarine.name.bunyip>Bunyip</submarine.name.bunyip>
+<submarine.description.bunyip>Latest in the line of personnel transports, Bunyip is capable of ferrying crew between submarines and installations. Its operating radius is considerably lower than its more advanced cousins and no weapons on board makes it vulnerable to attacks.</submarine.description.bunyip>
+<submarine.name.muikku>Muikku</submarine.name.muikku>
+<submarine.description.muikku>The workhorse of the colonies, these little shuttles have good speed and dive/ascent characteristics, but they are fragile and their low-capacity batteries limit their range somewhat.</submarine.description.muikku>
+<submarine.name.orca>Orca</submarine.name.orca>
+<submarine.description.orca>With a relatively high top speed and fantastic ascent and descent characteristics due to her 3 large ballast tanks, Orca class subs are agile vessels, let down only by their small compliment of weapons, unreliable engine and reactors with a greater than average hunger for fuel.</submarine.description.orca>
+<submarine.name.remora>Remora</submarine.name.remora>
+<submarine.description.remora>A range of customization options are available for Remora. In this model, some of the main hull space has been replaced by a detachable ballast and a remote-controlled drone. A large crew is needed to operate this submarine.</submarine.description.remora>
+<submarine.name.typhon>Typhon</submarine.name.typhon>
+<submarine.description.typhon>Typhon class subs are known for their brutish appearance, reasonable array of light and heavy firepower, and their general dependability. Any captain should be aware of their poor rate of descent and unimpressive top speed.</submarine.description.typhon>
+<submarine.name.dugong>Dugong</submarine.name.dugong>
+<submarine.name.dugong_tutorial>Dugong</submarine.name.dugong_tutorial>
+<submarine.description.dugong>Compared to larger vessels, the Dugong series is overshadowed in all aspects except one: Their reliability for their price is world class. They're lacking in firepower and speed, so smart maneuvering is key.</submarine.description.dugong>
+<submarine.name.selkie>Selkie</submarine.name.selkie>
+<submarine.description.selkie>The workhorse of the colonies, these little shuttles have good speed and dive/ascent characteristics, but they are fragile and their low-capacity batteries limit their range somewhat.</submarine.description.selkie>
+<submarine.name.venture>Venture</submarine.name.venture>
+<submarine.description.venture>Originally intended as research vessels, Venture shuttles have been co-opted as a more robust alternative for travel between outposts and submarines.</submarine.description.venture>
+<submarine.name.berilia>Berilia</submarine.name.berilia>
+<submarine.description.berilia>Berilia is one of the biggest cargo ships on Europa. Its two engines and three ballasts require a copious amount of power to operate, and keeping the machinery in good working condition is a handful for even a moderately large crew.</submarine.description.berilia>
+<submarine.name.kastrull>Kastrull</submarine.name.kastrull>
+<submarine.description.kastrull>The Kastrull is a dependable attack sub class bringing plenty of firepower to any fight, and although it's not very nimble, it does sport a drone gunship as standard. Keep in mind that with its experimental open ballast tanks, low tolerance to flooding and numerous crew stations, a large, experienced crew will get the most out of this sub.</submarine.description.kastrull>
+<submarine.name.hemulen>Hemulen</submarine.name.hemulen>
+<submarine.description.hemulen>For when you need extra room to stretch your legs or want some space between you and the poor, choose Hemulen shuttles.</submarine.description.hemulen>
+<submarine.name.typhon2>Typhon 2</submarine.name.typhon2>
+<submarine.description.typhon2>Typhon 2 is an overhauled version of the venerable Typhon class of sub. Serving as a heavy gunship, the Typhon 2 class subs remain slow and ugly, but with the benefit of better survivability for their crews.</submarine.description.typhon2>
+<submarine.name.azimuth>Azimuth</submarine.name.azimuth>
+<submarine.description.azimuth>Superior speed, sleek design and quality-of-life systems make this submarine a favorite among wealthy Coalition captains who manage to make it to retirement.</submarine.description.azimuth>
+<submarine.name.r-29>R-29 "Big Rig"</submarine.name.r-29>
+<submarine.description.r-29>R-29 is a heavyweight transport ship. While not terribly well armed against Europa's underwater denizens, it has been retrofitted with two powerful electric discharge coils. Original design by rav2n.</submarine.description.r-29>
+<submarine.name.barsuk>Barsuk</submarine.name.barsuk>
+<submarine.description.barsuk>Barsuk is a favorite among beginner captains. Using materials out of recycled hulls of destroyed submarines (many of which were Barsuks anyway) keeps the price of the line down. Over the years, a subculture of Barsuk-enthusiasts has formed around customizing and tuning their vessels.</submarine.description.barsuk>
+<submarine.name.winterhalter>Winterhalter</submarine.name.winterhalter>
+<submarine.description.winterhalter>Originally manufactured by Archsteel Yards in New Iapetus, Winterhalter submarines were only in production for a year until they were acquired by the Coalition for research purposes. Many surviving models come equipped with an onboard research laboratory, and they are heavily armed.</submarine.description.winterhalter>
+<submarine.name.herja>Herja</submarine.name.herja>
+<submarine.description.herja>With its varied weaponry, Herja submarines are equipped for encounters against most expected and unexpected run-ins with the denizens of Europa. A reliable workhorse in the Coalition fleet. If a monster nest has been cleared nearby, chances are high that it was a Herja that did the deed.</submarine.description.herja>
+<submarine.name.orca2>Orca 2</submarine.name.orca2>
+<submarine.description.orca2>Successor for the classic Orca series, this submarine boasts the same three-ballast setup which allows it to ascend and descend with only a moment's notice. Well armed and equipped for a scout vessel, Orca2 is capable of taking on all but the most dangerous denizens of Europa.</submarine.description.orca2>
+<submarine.name.camel>Camel</submarine.name.camel>
+
+
+<!-- Terminal welcome messages -->
+<terminalwelcomemsg.humpback>Type "on" or "off" to either connect batteries to power grid or disconnect them. Enter a number from 0 to 100 to set recharge rate for each battery at once.</terminalwelcomemsg.humpback>
+<terminalwelcomemsg.typhon2>Enter a value between 0 and 100 to set battery array recharge rate.</terminalwelcomemsg.typhon2>
+<terminalwelcomemsg.kastrulldiary1>\nDay 1 of the expedition out of Meltwater. We're navigating through a newly discovered gap in the ice, trying to find a shorter route to Novaya Moskva.\n\nIt's not the safest of missions, but hopefully it'll be my last. Should be able to retire after this one.\n\nDay 3. Cap says the whole voyage shouldn't take more than six days. By my reckoning that should place us somewhere around halfway there.\n\nCourse there's always a chance this cave doesn't actually have an exit and we'll have to turn back.\n\nDay 4. Now if I were a superstitious man, I'd wager that saying the worst outcome in any given situation out loud makes it come true. Turns out this route is a dead end.\n\nCaptain is bummed out. I share his disappointment. It'll take a few days longer to get to an outpost now that we have to go back.\n\nDay 8. There was a hole in the ice here. It's gone now. Icebergs must've moved and closed it. We've started broadcasting our position in hopes that someone picks it up. They're joking now, asking me why I chose my last expedition to get lost at sea.\n\nDay 9. We're rationing food and water. Crew is getting ornery.\n\nDay 11? 12? No response. Food's running out. More concerned about water, myself. Don't feel like writing any more.\n\nDay 30-ish, who cares anymore? I'm surrounded by dead men. Pale husks of men slumped on the floor. Some of their eyes still move, but they're dead nonetheless.\n</terminalwelcomemsg.kastrulldiary1>
+<terminalwelcomemsg.dugongtransmission>Replaying last outgoing transmissions.\n[2451-3-4 11:33] DG-35 calling for Tara colony. Do you read?\n[2451-3-4 11:35] Tara colony, do you read? We're taking heavy hits to our topside!\n[2451-3-4 11:35] Look at the size of that thing!\n[2451-3-4 12:02] We managed to take down the attacker, but the hull is heavily damaged. Requesting rescue from anyone who receives this call.\n[2451-3-4 12:06] Hello?\n</terminalwelcomemsg.dugongtransmission>
+<terminalwelcomemsg.traitorletter>This message will be both my farewell and confession. I was tasked to smuggle this sonar beacon on board and turn it on when we were a safe distance away. It turns out it was set to a frequency that attracts monsters. I was promised a shuttle was picking me up when the task was done but they never showed.\n\nThis is the last time I accept a "research assignment" from a big-shoe. Or anyone, for that matter. May they honk in hell.</terminalwelcomemsg.traitorletter>
+
+
+<waypoint>Waypoint</waypoint>
+<linkwaypoint>Hold space to link to another waypoint</linkwaypoint>
+<spawnpoint>Spawnpoint</spawnpoint>
+<spawntype>Spawn type</spawntype>
+<idcarddescription>ID Card description</idcarddescription>
+<idcarddescriptiontooltip>Characters spawning at this spawnpoint will have the specified description added to their ID card. This can be used to describe additional access levels their card has on the sub.</idcarddescriptiontooltip>
+<idcardtags>ID Card tags</idcardtags>
+<idcardtagstooltip>Characters spawning at this spawnpoint will have the specified tags added to their ID card. You can, for example, use these tags to limit access to some parts of the sub.</idcardtagstooltip>
+<spawnpointjobs>Assigned jobs</spawnpointjobs>
+<spawnpointjobstooltip>Only characters with the specified job will spawn at this spawnpoint.</spawnpointjobstooltip>
+<spawnpointtags>Tags</spawnpointtags>
+<spawnpointtagstooltip>Can be used to refer to the spawnpoint in events and human prefabs.</spawnpointtagstooltip>
+
+<!-- Linked submarines -->
+<linkedsub>Linked submarine</linkedsub>
+<reloadlinkedsub>Refresh</reloadlinkedsub>
+<reloadlinkedsubtooltip>Reload the linked submarine from the specified file</reloadlinkedsubtooltip>
+<linklinkedsub>Hold space to link to a docking port</linklinkedsub>
+<reloadlinkedsuberror>Submarine file [file] not found!</reloadlinkedsuberror>
+
+<!-- Chat -->
+<spamfilterkicked>You have been kicked by the spam filter.</spamfilterkicked>
+<spamfilterblocked>You have been blocked by the spam filter. Try again after 10 seconds.</spamfilterblocked>
+<chat.shownewmessages>Show new messages</chat.shownewmessages>
+<chat>Chat</chat>
+<chatmode.local>Local</chatmode.local>
+<chatmode.radio>Radio</chatmode.radio>
+
+<!-- Item HUDs -->
+<iteminuse>In use by [character]</iteminuse>
+<item.lockuiposition>Lock position</item.lockuiposition>
+<item.unlockuiposition>Unlock position</item.unlockuiposition>
+<item.resetuiposition>Reset position</item.resetuiposition>
+<engineforce>Thrust</engineforce>
+<enginebackwards>Backwards</enginebackwards>
+<engineforwards>Forwards</engineforwards>
+<enginepowered>Powered</enginepowered>
+<fabricatornopower>Insufficient power</fabricatornopower>
+<fabricatorrequireditems>Required items</fabricatorrequireditems>
+<fabricatorrequiredtime>Required time</fabricatorrequiredtime>
+<fabricatorrequiredcondition>Condition</fabricatorrequiredcondition>
+<fabricatorrequiredskills>Recommended skills</fabricatorrequiredskills>
+<fabricatorrequiredskills.tooltip>Fabricating the item takes longer if your skills are insufficient.</fabricatorrequiredskills.tooltip>
+<fabricatorcreate>Create</fabricatorcreate>
+<fabricatorcancel>Cancel</fabricatorcancel>
+<fabricatorinsufficientskills>Difficult to fabricate</fabricatorinsufficientskills>
+<fabricatorsufficientskills>Easy to fabricate</fabricatorsufficientskills>
+<fabricator.input>Input</fabricator.input>
+<fabricatorrequiresrecipe>Requires recipe to fabricate</fabricatorrequiresrecipe>
+<vendingmachine.outofstock>Out of stock</vendingmachine.outofstock>
+<uilabel.input>Input</uilabel.input>
+<uilabel.output>Output</uilabel.output>
+<deconstructornopower>Insufficient power</deconstructornopower>
+<deconstructordeconstruct>Deconstruct</deconstructordeconstruct>
+<deconstructorcancel>Cancel</deconstructorcancel>
+<deconstructor.input>Input</deconstructor.input>
+<deconstructor.output>Deconstructs into</deconstructor.output>
+<deconstructor.unknownitemsoutput>Unknown output</deconstructor.unknownitemsoutput>
+<deconstructor.inputqueue>Queue</deconstructor.inputqueue>
+<lvl>Lvl</lvl>
+<minimaphullbreach>Hull breach</minimaphullbreach>
+<minimapwaterlevel>Water level</minimapwaterlevel>
+<minimapwaterlevelunavailable>Water level data not available</minimapwaterlevelunavailable>
+<minimapairquality>Air quality</minimapairquality>
+<minimapairqualityunavailable>Air quality data not available</minimapairqualityunavailable>
+<pumppowered>Powered</pumppowered>
+<pumpin>IN</pumpin>
+<pumpout>OUT</pumpout>
+<pumpspeed>Pumping speed</pumpspeed>
+<pumpautocontrol>Automatic control</pumpautocontrol>
+<reactorautotemp>Automatic\ncontrol</reactorautotemp>
+<reactoroutput>Output: [kw]</reactoroutput>
+<reactorload>Load: [kw]</reactorload>
+<reactorfissionrate>Fission rate</reactorfissionrate>
+<reactorturbineoutput>Turbine output</reactorturbineoutput>
+<reactorwarningcriticaltemp>Critical\nHeat</reactorwarningcriticaltemp>
+<reactorwarningcriticallowtemp>Critically Low\n Temperature</reactorwarningcriticallowtemp>
+<reactorwarningcriticaloutput>Critical\nOutput</reactorwarningcriticaloutput>
+<reactorwarninglowtemp>Temp Low</reactorwarninglowtemp>
+<reactorwarningoverheating>Overheat</reactorwarningoverheating>
+<reactorwarninglowoutput>Output Low</reactorwarninglowoutput>
+<reactorwarninghighoutput>Output High</reactorwarninghighoutput>
+<reactorwarninglowfuel>Fuel Low</reactorwarninglowfuel>
+<reactorwarningfuelout>Fuel Out</reactorwarningfuelout>
+<reactorwarningmeltdown>Meltdown</reactorwarningmeltdown>
+<reactorwarningscram>SCRAM</reactorwarningscram>
+<reactortipfissionrate>Increasing the fission rate makes the reactor consume more fuel and generate more heat. The heat is used to spin the turbine, which generates electricity.</reactortipfissionrate>
+<reactortipturbineoutput>The higher the turbine output, the more the reactor attempts to generate electricity. If the output is too high relative to the fission rate, the reactor will cool down, and if too low, it will overheat.</reactortipturbineoutput>
+<reactortiptemperature>The temperature of the reactor core. The temperature is optimal when the bar is between the red indicators.</reactortiptemperature>
+<reactortipload>How much power is currently being consumed by the devices connected to the reactor.</reactortipload>
+<reactortippower>How much power is currently being generated by the reactor.</reactortippower>
+<reactortipautotemp>When automatic control is on, the reactor will automatically adjust itself according to the power consumption. However, the system is not fast enough to react to large fluctuations in power consumption, so manual adjustments may still be needed.</reactortipautotemp>
+<reactor.temperatureboostup>Increase pressure to temporarily increase the temperature of the reactor.</reactor.temperatureboostup>
+<reactor.temperatureboostdown>Release pressure to temporarily reduce the temperature of the reactor.</reactor.temperatureboostdown>
+<closeinfographic>Close info</closeinfographic>
+<infographic.reactor.fuelslots>The reactor needs fuel to generate power. Place one in these slots.</infographic.reactor.fuelslots>
+<infographic.reactor.power>Turns the reactor on or off.</infographic.reactor.power>
+<infographic.reactor.load>Load is the amount of power the submarine is currently consuming, and output is the amount the reactor is currently generating. The output should be kept as close to the load as possible.</infographic.reactor.load>
+<infographic.reactor.fissionrate>Fission rate controls the amount of heat generated, and turbine output controls the amount of power generated from the heat. Try to keep both needles on the green.</infographic.reactor.fissionrate>
+<infographic.reactor.automaticcontrol>When automatic control is on, the reactor will operate itself automatically. However, it reacts to power fluctuations slower than a human operator would be able to.</infographic.reactor.automaticcontrol>
+<infographic.reactor.temperature>The temperature of the reactor core. The temperature is optimal when the bar is between the red indicators.</infographic.reactor.temperature>
+<uilabel.fuelrods>Fuel Rods</uilabel.fuelrods>
+<steeringmanual>Manual steering</steeringmanual>
+<steeringautopilot>Autopilot</steeringautopilot>
+<steeringmaintainpos>Maintain position</steeringmaintainpos>
+<steeringvelocityx>Velocity: [kph] km/h</steeringvelocityx>
+<steeringvelocityy>Descent velocity: [kph] km/h</steeringvelocityy>
+<steeringdepth>Depth: [m] m</steeringdepth>
+<steeringdepthwarning>DANGEROUS PRESSURE</steeringdepthwarning>
+<steeringnopowertip>WARNING: Insufficient power</steeringnopowertip>
+<steeringautopilotmaintainpostip>AUTOPILOT ON\nMaintaining position. Choose the position to maintain by clicking on the display.</steeringautopilotmaintainpostip>
+<steeringautopilotlocationtip>AUTOPILOT ON\nAutopilot is set to navigate toward [locationname].</steeringautopilotlocationtip>
+<sonaractive>Active Sonar</sonaractive>
+<sonarpassive>Passive Sonar</sonarpassive>
+<sonarzoom>Zoom</sonarzoom>
+<sonardirectionalping>Directional ping</sonardirectionalping>
+<sonarsignalweak>Signal weak</sonarsignalweak>
+<sonarnosignal>No signal</sonarnosignal>
+<sonartipactive>When active sonar is on, the transponders send out pings that reflect from nearby obstacles. The pings may also be heard by hostile creatures or enemy submarines.</sonartipactive>
+<sonartippassive>In passive mode, the sonar only listens to sources of sound and sounds reflected from nearby obstacles without actively sending out pings.</sonartippassive>
+<powercontainercharge>Charge: [charge] kWmin ([percentage] %)</powercontainercharge>
+<powercontainerrechargerate>Recharge rate [rate] %</powercontainerrechargerate>
+<uilabel.chargingdock>Charging Dock</uilabel.chargingdock>
+<powertransferpowered>Powered</powertransferpowered>
+<powertransferhighvoltage>Overvoltage</powertransferhighvoltage>
+<powertransferlowvoltage>Low voltage</powertransferlowvoltage>
+<powertransferpowerlabel>Power</powertransferpowerlabel>
+<powertransferpower>[power] kW</powertransferpower>
+<powertransferloadlabel>Load</powertransferloadlabel>
+<powertransferload>[load] kW</powertransferload>
+<powertransfertipovervoltage>When the electrical grid is supplied more power than what is being consumed, the voltage rises, which may cause damage to electrical devices.</powertransfertipovervoltage>
+<powertransfertiplowvoltage>When there's not enough power available, the voltage drops, which may cause some devices to shut down.</powertransfertiplowvoltage>
+<powertransfertipload>How much power is currently being consumed by the devices connected to the electrical grid.</powertransfertipload>
+<powertransfertippower>How much power is currently being supplied to the electrical grid.</powertransfertippower>
+<connectionlocked>(Locked)</connectionlocked>
+<requiredrepairskills>Required skills:</requiredrepairskills>
+<requiredskill.helm>Required helm skill:</requiredskill.helm>
+<requiredskill.weapons>Required weapons skill:</requiredskill.weapons>
+<requiredskill.mechanical>Required mechanical skill:</requiredskill.mechanical>
+<requiredskill.electrical>Required electrical skill:</requiredskill.electrical>
+<requiredskill.medical>Required medical skill:</requiredskill.medical>
+<repairbutton>Repair</repairbutton>
+<repairing>Repairing</repairing>
+<tinkerbutton>Tinker</tinkerbutton>
+<tinkering>Tinkering</tinkering>
+<electricalrepairsheader>Electrical Repairs</electricalrepairsheader>
+<mechanicalrepairsheader>Mechanical Repairs</mechanicalrepairsheader>
+<powerlabel>Power</powerlabel>
+<fabricationrecipenamewithamount>[name] (x[amount])</fabricationrecipenamewithamount>
+<statusmonitor.battery.tooltip>Charge: [amount]%</statusmonitor.battery.tooltip>
+<statusmonitor.durability.tooltip>Durability: [amount]%</statusmonitor.durability.tooltip>
+<statusmonitor.junctioncurrent.tooltip>Current: [amount] kW</statusmonitor.junctioncurrent.tooltip>
+<statusmonitor.junctionload.tooltip>Load: [amount] kW</statusmonitor.junctionload.tooltip>
+<statusmonitor.junctionpower.tooltip>Power: [amount] kW</statusmonitor.junctionpower.tooltip>
+<statusmonitorbutton.hullstatus.tooltip>General status</statusmonitorbutton.hullstatus.tooltip>
+<statusmonitorbutton.electricalview.tooltip>Electrical view</statusmonitorbutton.electricalview.tooltip>
+<statusmonitorbutton.hullcondition.tooltip>Hull condition</statusmonitorbutton.hullcondition.tooltip>
+<statusmonitorbutton.itemfinder.tooltip>Item finder</statusmonitorbutton.itemfinder.tooltip>
+<draganddropreports>Drag and drop on a room</draganddropreports>
+<researchstation.invalidinput>Invalid input</researchstation.invalidinput>
+<researchstation.empty.infotext>No material inserted. Insert genetic material.</researchstation.empty.infotext>
+<researchstation.research>Research</researchstation.research>
+<researchstation.research.infotext>Alien material inserted. Use caution.</researchstation.research.infotext>
+<researchstation.refine>Refine</researchstation.refine>
+<researchstation.refine.infotext>Genetic material detected. Ready to refine. Caution: [taintedprobability]% risk of contamination.</researchstation.refine.infotext>
+<researchstation.refine.missingitem>Insufficient material. Insert more genetic material to refine.</researchstation.refine.missingitem>
+<researchstation.combine>Combine</researchstation.combine>
+<researchstation.combine.infotext>Unstable combination of materials detected. Proceed with caution.</researchstation.combine.infotext>
+<researchstation.combine.missingitem>Alien material inserted. Accelerant required ([itemname]).</researchstation.combine.missingitem>
+
+<!-- Health interface -->
+<vitality>Vitality</vitality>
+<suitabletreatments>Suitable treatments:</suitabletreatments>
+<healthitemusetip>Drop items here to use them on the selected limb. You can also use items with the inventory hotkeys or by double-clicking.</healthitemusetip>
+<afflictionstrengthlow>Light</afflictionstrengthlow>
+<afflictionstrengthmedium>Medium</afflictionstrengthmedium>
+<afflictionstrengthhigh>Heavy</afflictionstrengthhigh>
+<lowmedicalskillwarning>Low medical skill! The suitable treatments list may be inaccurate.</lowmedicalskillwarning>
+<healthlimbname.head>Head</healthlimbname.head>
+<healthlimbname.torso>Torso</healthlimbname.torso>
+<healthlimbname.leftarm>Left arm</healthlimbname.leftarm>
+<healthlimbname.rightarm>Right arm</healthlimbname.rightarm>
+<healthlimbname.leftleg>Left leg</healthlimbname.leftleg>
+<healthlimbname.rightleg>Right leg</healthlimbname.rightleg>
+
+<!-- Repairing -->
+<fixheader>Attempting to fix [itemname]</fixheader>
+<fixbutton>Fix</fixbutton>
+<repair>Repair</repair>
+<repairallwalls>Repair all walls</repairallwalls>
+<repairallitems>Repair all items</repairallitems>
+
+
+<!-- Causes of death -->
+<causeofdeath>Cause of death</causeofdeath>
+<causeofdeath.damage>Damage</causeofdeath.damage>
+<causeofdeath.bloodloss>Blood loss</causeofdeath.bloodloss>
+<causeofdeath.drowning>Drowning</causeofdeath.drowning>
+<causeofdeath.suffocation>Suffocation</causeofdeath.suffocation>
+<causeofdeath.pressure>Pressure</causeofdeath.pressure>
+<causeofdeath.burn>Burn</causeofdeath.burn>
+<causeofdeath.husk>Husk infection</causeofdeath.husk>
+<causeofdeath.disconnected>Brain dead</causeofdeath.disconnected>
+<causeofdeath.unknown>Unknown</causeofdeath.unknown>
+<causeofdeathdescription.damage>Succumbed to their injuries</causeofdeathdescription.damage>
+<causeofdeathdescription.bloodloss>Bled out</causeofdeathdescription.bloodloss>
+<causeofdeathdescription.drowning>Drowned</causeofdeathdescription.drowning>
+<causeofdeathdescription.suffocation>Suffocated</causeofdeathdescription.suffocation>
+<causeofdeathdescription.pressure>Crushed by water pressure</causeofdeathdescription.pressure>
+<causeofdeathdescription.burn>Burned to death</causeofdeathdescription.burn>
+<causeofdeathdescription.husk>Taken over by a parasite</causeofdeathdescription.husk>
+<causeofdeathdescription.disconnected>Disconnected</causeofdeathdescription.disconnected>
+<causeofdeathdescription.unknown>Unknown</causeofdeathdescription.unknown>
+<self_causeofdeathdescription.damage>You have succumbed to your injuries.</self_causeofdeathdescription.damage>
+<self_causeofdeathdescription.bloodloss>You have bled out.</self_causeofdeathdescription.bloodloss>
+<self_causeofdeathdescription.drowning>You have drowned.</self_causeofdeathdescription.drowning>
+<self_causeofdeathdescription.suffocation>You have suffocated.</self_causeofdeathdescription.suffocation>
+<self_causeofdeathdescription.pressure>You have been crushed by water pressure.</self_causeofdeathdescription.pressure>
+<self_causeofdeathdescription.burn>You have burned to death.</self_causeofdeathdescription.burn>
+<self_causeofdeathdescription.husk>The parasite has taken over your body.</self_causeofdeathdescription.husk>
+<self_causeofdeathdescription.disconnected>You were disconnected from the server.</self_causeofdeathdescription.disconnected>
+<self_causeofdeathdescription.unknown>You have died.</self_causeofdeathdescription.unknown>
+<giveinbutton>Give in</giveinbutton>
+<giveinhelpmultiplayer>Let go of your character and enter spectator mode (other players will no longer be able to revive you)</giveinhelpmultiplayer>
+<giveinhelpsingleplayer>The character can no longer be revived if you give in.</giveinhelpsingleplayer>
+<deathchatnotification>Your chat messages will only be visible to other dead players.</deathchatnotification>
+
+<!-- Character dialogue -->
+<dialogaffirmative>Aye aye!</dialogaffirmative>
+<dialogaffirmative>Yes, sir!</dialogaffirmative>
+<dialogaffirmative>Aye!</dialogaffirmative>
+<dialogaffirmative>Got it!</dialogaffirmative>
+<dialogaffirmative>Sure thing!</dialogaffirmative>
+<dialogaffirmative>Copy that.</dialogaffirmative>
+<dialognegative>Negative.</dialognegative>
+<dialognegative>No way!</dialognegative>
+<dialogcannotreach>Can't reach the target.</dialogcannotreach>
+<dialogreactorfuel>Loading more fuel to the reactor!</dialogreactorfuel>
+<dialogreactortaken>Hey, I'm operating the reactor!</dialogreactortaken>
+<dialogreactortaken>Hands off please! I've got this!</dialogreactortaken>
+<dialogreactortaken>Hey, we don't need two people at the reactor!</dialogreactortaken>
+<dialogcantfindcontroller>I can't find a way to operate the [item]!</dialogcantfindcontroller>
+<dialogcantfindcontroller>I don't know how to control the [item]!</dialogcantfindcontroller>
+<dialogloadturret>Loading ammunition to the [itemname]!</dialogloadturret>
+<dialogfireturret>Firing!</dialogfireturret>
+<dialogfireturret>Fire in the hole!</dialogfireturret>
+<dialogturrettargetdead>Enemy down!</dialogturrettargetdead>
+<dialogturrettargetdead>Target down!</dialogturrettargetdead>
+<dialogturrettargetdead>I think I got it!</dialogturrettargetdead>
+<dialogturrettargetdead>Aand it's dead!</dialogturrettargetdead>
+<dialogchargebatteries>Charging [itemname] at [rate] %!</dialogchargebatteries>
+<dialogchargebatteries>[itemname] now charging at [rate] %!</dialogchargebatteries>
+<dialognobatteries>What batteries?</dialognobatteries>
+<dialognobatteries>There aren't any batteries on this boat!</dialognobatteries>
+<dialognobatteries>Can't find any batteries!</dialognobatteries>
+<dialogstopchargingbatteries>Stopped charging [itemname]!</dialogstopchargingbatteries>
+<dialogleakfixed>One leak fixed in [roomname]!</dialogleakfixed>
+<dialogleakfixed>Repairing [roomname]. A few more holes to go!</dialogleakfixed>
+<dialogleaksfixed>All leaks repaired in [roomname]!</dialogleaksfixed>
+<dialogleaksfixed>No more leaks in [roomname]!</dialogleaksfixed>
+<dialogitemrepaired>[itemname] repaired!</dialogitemrepaired>
+<dialogitemrepaired>[itemname] back in order!</dialogitemrepaired>
+<dialogitemrepaired>[itemname] fixed!</dialogitemrepaired>
+<dialoggetdivinggear>Need to find a diving suit!</dialoggetdivinggear>
+<dialoggetdivinggear>I need diving gear!</dialoggetdivinggear>
+<dialoggetoxygentank>Need to find an oxygen tank!</dialoggetoxygentank>
+<dialoggetoxygentank>I need an oxygen tank!</dialoggetoxygentank>
+<dialoggetoxygentank>Where are the oxygen tanks?</dialoggetoxygentank>
+<dialoggetoxygentank>I need oxygen!</dialoggetoxygentank>
+<dialoglowoxygen>I'm passing out!</dialoglowoxygen>
+<dialoglowoxygen>Can't breathe!</dialoglowoxygen>
+<dialoglowoxygen>gasping</dialoglowoxygen>
+<dialogbleeding>Help, I'm bleeding!</dialogbleeding>
+<dialogbleeding>I'm bleeding out!</dialogbleeding>
+<dialogbleeding>I'm losing blood!</dialogbleeding>
+<dialogpressure>Pressure rising in [roomname]!</dialogpressure>
+<dialogpressure>Dangerous pressure in [roomname]!</dialogpressure>
+<dialogpressure>Pressure level dangerously high in [roomname]!</dialogpressure>
+<dialogfindextinguisher>I need a fire extinguisher!</dialogfindextinguisher>
+<dialogfindextinguisher>Trying to find an extinguisher!</dialogfindextinguisher>
+<dialogfindextinguisher>Got to find an extinguisher!</dialogfindextinguisher>
+<dialogputoutfire>Put out a fire in [roomname]!</dialogputoutfire>
+<dialogputoutfire>Extinguished a fire in [roomname]!</dialogputoutfire>
+<dialognofire>What fire?</dialognofire>
+<dialognofire>Can't see any fires!</dialognofire>
+<dialognofire>I don't think there's any fire to put out!</dialognofire>
+<dialogsteeringtaken>Hey, I'm at the helm now!</dialogsteeringtaken>
+<dialogsteeringtaken>Hands off please! I'm steering now!</dialogsteeringtaken>
+<dialogsteeringtaken>Hey, we don't need two people to steer!</dialogsteeringtaken>
+<dialogsonartarget>A target on the sonar at [direction]!</dialogsonartarget>
+<dialogsonartarget>A blip on the sonar at [direction]!</dialogsonartarget>
+<dialogsonartarget>Something on the sonar at [direction]!</dialogsonartarget>
+<dialogsonartarget>Got a target at [direction]!</dialogsonartarget>
+<dialogsonartargetlarge>A large target on the sonar at [direction]!</dialogsonartargetlarge>
+<dialogsonartargetlarge>Got a large ping at [direction]!</dialogsonartargetlarge>
+<dialogsonartargetlarge>Something big on the sonar at [direction]!</dialogsonartargetlarge>
+<dialogsonartargetmultiple>[count] targets on the sonar at [direction]!</dialogsonartargetmultiple>
+<dialogsonartargetmultiple>We've got [count] targets at [direction]!</dialogsonartargetmultiple>
+<dialogfoundunconscioustarget>Found [targetname] unconscious in [roomname]!</dialogfoundunconscioustarget>
+<dialogfoundunconscioustarget>Giving first aid to [targetname] in [roomname]!</dialogfoundunconscioustarget>
+<dialoglistrequiredtreatments>I need to find [treatmentlist]!</dialoglistrequiredtreatments>
+<dialoglistrequiredtreatments>I need [treatmentlist] to treat [targetname]!</dialoglistrequiredtreatments>
+<dialogrequiredtreatmentoptionsfirst>[treatment1], [treatment2]</dialogrequiredtreatmentoptionsfirst>
+<dialogrequiredtreatmentoptionslast>[treatment1] or [treatment2]</dialogrequiredtreatmentoptionslast>
+<dialogtargethealed>[targetname] is back in shape!</dialogtargethealed>
+<dialogtargethealed>[targetname] is all right!</dialogtargethealed>
+<dialogtargetresuscitated>[targetname] has been resuscitated!</dialogtargetresuscitated>
+<dialogtargetresuscitated>[targetname] is back on their feet again!</dialogtargetresuscitated>
+<dialogignoreminorinjuries>[targetname]'s injuries are so minor I don't think I should waste any meds on them.</dialogignoreminorinjuries>
+<dialogignoreminorinjuries>[targetname] is mildly injured, but I think they'll manage without my help.</dialogignoreminorinjuries>
+<dialogcannotrepair>Cannot repair [itemname]!</dialogcannotrepair>
+<dialogenemydown>Enemy down!</dialogenemydown>
+<dialogenemydown>Another one eliminated.</dialogenemydown>
+<dialognorepairtargets>There's nothing to repair.</dialognorepairtargets>
+<dialognorepairtargets>What do you mean? Everything is working all right.</dialognorepairtargets>
+<dialognopumps>The pumps are okay, aren't they?</dialognopumps>
+<dialognopumps>None of the pumps require attention at the moment.</dialognopumps>
+<dialognoenemies>Can't see any intruders onboard.</dialognoenemies>
+<dialognoenemies>Enemies? Where?</dialognoenemies>
+<dialognoleaks>Cannot find any leaks.</dialognoleaks>
+<dialognoleaks>What leaks?</dialognoleaks>
+<dialogfoundwoundedtarget>Giving first aid to [targetname] in [roomname]!</dialogfoundwoundedtarget>
+<dialogfoundwoundedtarget>Treating [targetname] in [roomname]!</dialogfoundwoundedtarget>
+<dialognorescuetargets>No one seems to be in need of medical attention at the moment!</dialognorescuetargets>
+<dialognorescuetargets>I don't think anyone needs medical attention at the moment.</dialognorescuetargets>
+<dialogcannotreachtarget>Can't reach [name]!</dialogcannotreachtarget>
+<dialogcannotreachplace>Can't get there!</dialogcannotreachplace>
+<dialogcannotreachfire>Can't get to the fire at [name]!</dialogcannotreachfire>
+<dialogcannotreachleak>Can't get to the leak near [name]!</dialogcannotreachleak>
+<dialogcannotreachpatient>Can't get to [name]!</dialogcannotreachpatient>
+<dialogcannotloadturret>Failed to load ammunition to [itemname]!</dialogcannotloadturret>
+<dialog.cantupgrade>I'm not able to work on your new submarine until it has been delivered.</dialog.cantupgrade>
+<dialog.upgradepurchased>Thank you for your purchase! I will start working on your submarine shortly before you depart.</dialog.upgradepurchased>
+<dialogattackedbyfriendly>What the hell are you doing?!</dialogattackedbyfriendly>
+<dialogattackedbyfriendly>Ow, what was that for?</dialogattackedbyfriendly>
+<dialogattackedbyfriendly>Hey! What do you think you're doing?</dialogattackedbyfriendly>
+<dialogattackedbyfriendly>Why are you doing this?</dialogattackedbyfriendly>
+<dialogattackedbyfriendly>Please, no!</dialogattackedbyfriendly>
+<dialogattackedbyfriendly>Stop it!</dialogattackedbyfriendly>
+<dialogattackedbyfriendly>Security! Security!</dialogattackedbyfriendly>
+<dialogenteroutpostwarning>Okay, that's far enough. Get back to your sub and leave right now or we'll open fire.</dialogenteroutpostwarning>
+<dialogenteroutpostwarning>You people are not welcome here. Get the hell out or you'll be leaving in a duffel bag.</dialogenteroutpostwarning>
+<dialogstealwarning>Hey! Put that back!</dialogstealwarning>
+<dialogstealwarning>What do you think you're doing? Put that back!</dialogstealwarning>
+<dialogstealwarning>Thief! Put it back right now and I'll pretend I didn't see anything.</dialogstealwarning>
+<dialogtargetdown>Enemy down!</dialogtargetdown>
+<dialogtargetdown>Target down!</dialogtargetdown>
+<dialogtargetdown>Target eliminated!</dialogtargetdown>
+<dialogtargetarrested>Target arrested!</dialogtargetarrested>
+<dialogattackedbyfriendlysecurityresponse>Stop it, right now!</dialogattackedbyfriendlysecurityresponse>
+<dialogattackedbyfriendlysecurityresponse>Stop messing around!</dialogattackedbyfriendlysecurityresponse>
+<dialogattackedbyfriendlysecurityresponse>Do you really want to take that path?</dialogattackedbyfriendlysecurityresponse>
+<dialogattackedbyfriendlysecurityresponse>Don't push your luck!</dialogattackedbyfriendlysecurityresponse>
+<dialogattackedbyfriendlysecurityresponse>Hey! This is the last warning!</dialogattackedbyfriendlysecurityresponse>
+<dialogattackedbyfriendlysecurityarrest>Okay, that's too much!</dialogattackedbyfriendlysecurityarrest>
+<dialogattackedbyfriendlysecurityarrest>Now you're in deep shit!</dialogattackedbyfriendlysecurityarrest>
+<dialogattackedbyfriendlysecurityarrest>Freeze, bastard!</dialogattackedbyfriendlysecurityarrest>
+<dialogattackedbyfriendlysecurityarrest>I'm gonna get you!</dialogattackedbyfriendlysecurityarrest>
+<dialogattackedbyfriendlysecurityarrest>Don't you run away!</dialogattackedbyfriendlysecurityarrest>
+<dialogattackedbyfriendlysecurityarrest>Stop right there!</dialogattackedbyfriendlysecurityarrest>
+<dialogcannotfindrequireditemtorepair>Can't find the tools to do the repairs!</dialogcannotfindrequireditemtorepair>
+<dialogcannotfindrequireditemtorepair>I don't have the tools for the repairs!</dialogcannotfindrequireditemtorepair>
+<dialogcannotfindfireextinguisher>I need something to help with the fire! Where are all the fire extinguishers?</dialogcannotfindfireextinguisher>
+<dialogcannotfindfireextinguisher>Can't find any fire extinguishers on board!</dialogcannotfindfireextinguisher>
+<dialogcannotfindweldingequipment>Where's all the welding equipment? I can't find any!</dialogcannotfindweldingequipment>
+<dialogcannotfindweldingequipment>A torch, a welding torch... Where are you when I need you the most?</dialogcannotfindweldingequipment>
+<dialogdamagewallswarning>Hey, what the hell do you think you're doing?!</dialogdamagewallswarning>
+<dialogdamagewallswarning>Stop that or you'll drown us all!</dialogdamagewallswarning>
+<dialogdamagewallswarning>Are you out of your mind? Stop it or you'll flood the whole place!</dialogdamagewallswarning>
+<dialogidentifiedtargetspotted>Target spotted: [speciesname]!</dialogidentifiedtargetspotted>
+<dialogidentifiedtargetspotted>New target: [speciesname]!</dialogidentifiedtargetspotted>
+<dialogidentifiedtargetspotted>Target locked: [speciesname]!</dialogidentifiedtargetspotted>
+<dialogidentifiedtargetspotted>Target identified: [speciesname]!</dialogidentifiedtargetspotted>
+<dialogunidentifiedtargetspotted>I've got a new target! I'm not sure what it is...</dialogunidentifiedtargetspotted>
+<dialogunidentifiedtargetspotted>An unknown target spotted!</dialogunidentifiedtargetspotted>
+<dialognewtargetspotted>New target spotted!</dialognewtargetspotted>
+<dialognewtargetspotted>I've got a new target!</dialognewtargetspotted>
+<dialogicespirespotted>New target: ice spire!</dialogicespirespotted>
+<dialogicespirespotted>Target locked: ice spire!</dialogicespirespotted>
+<dialogicespirespotted>Targeting an ice spire!</dialogicespirespotted>
+<dialogicespirespottedsonar>Ice spire spotted!</dialogicespirespottedsonar>
+<dialogicespirespottedsonar>Got some ice spires on the sonar!</dialogicespirespottedsonar>
+<dialogcannottreatpatient>I don't have the means to treat [name]!</dialogcannottreatpatient>
+<dialogcannottreatpatient>I'm sorry, there's nothing I can do for [name]!</dialogcannottreatpatient>
+<dialogcantfindtoxygen>I can't find any oxygen tanks!</dialogcantfindtoxygen>
+<dialogswappingoxygentank>Swapping oxygen tanks!</dialogswappingoxygentank>
+<dialoglowonweldingfuel>There's not many welding fuel tanks left aboard the sub!</dialoglowonweldingfuel>
+<dialoglowonoxygentanks>Almost all the oxygen tanks on the sub are empty! Can we get some of the empty tanks to the oxygen generator for refilling?</dialoglowonoxygentanks>
+<dialoglowoncoilgunammo>We're running low on coilgun ammunition! Fire short controlled bursts!</dialoglowoncoilgunammo>
+<dialoglowonrailgunammo>There's not many railgun shells left onboard.</dialoglowonrailgunammo>
+<dialoglowonturretammo>We're running low on ammunition. We should get some more at the next stop.</dialoglowonturretammo>
+<dialoglowonfuelrods>We're very low on fuel rods. We should buy more ASAP, or make some.</dialoglowonfuelrods>
+<dialogoutofweldingfuel>We're out of welding fuel!</dialogoutofweldingfuel>
+<dialogoutofoxygentanks>All our oxygen tanks are empty!</dialogoutofoxygentanks>
+<dialogoutofcoilgunammo>We're out of coilgun ammunition.</dialogoutofcoilgunammo>
+<dialogoutofrailgunammo>There are no more shells for the railgun!</dialogoutofrailgunammo>
+<dialogoutofturretammo>We're out of ammunition!</dialogoutofturretammo>
+<dialogoutoffuelrods>We're completely out of fuel rods!</dialogoutoffuelrods>
+<dialogcannotfindloadable>I can't find the items I'm looking for!</dialogcannotfindloadable>
+<dialogcannotfindloadable>I can't find anything to load into these containers!</dialogcannotfindloadable>
+<dialogcannotfindloadable.batterycells>I can't find battery cells to recharge!</dialogcannotfindloadable.batterycells>
+<dialogcannotfindloadable.batterycells>I can't find anything to recharge!</dialogcannotfindloadable.batterycells>
+<dialogcannotfindloadable.oxygentanks>I can't find oxygen tanks to refill!</dialogcannotfindloadable.oxygentanks>
+<dialogcannotfindloadable.oxygentanks>I can't find any tanks to refill!</dialogcannotfindloadable.oxygentanks>
+<dialogcannotfindloadable.turretammo>I can't find ammo for the submarine weapons!</dialogcannotfindloadable.turretammo>
+<dialogcannotfindloadable.turretammo>I can't find any ammo to put into the loaders!</dialogcannotfindloadable.turretammo>
+<dialoglastoxygentank>I'm using my last oxygen tank now.</dialoglastoxygentank>
+<dialoglastoxygentank>I've got no more oxygen tanks after this one.</dialoglastoxygentank>
+<dialoglastoxygentank>This is my last oxygen tank then.</dialoglastoxygentank>
+<dialogcannotfinditem>I can't find the item.</dialogcannotfinditem>
+<dialogcombatnoweapons>I don't have a weapon to defend myself!</dialogcombatnoweapons>
+<dialogcombatnoweapons>I need a weapon!</dialogcombatnoweapons>
+<dialogcombatretreating>Trying to get somewhere safe!</dialogcombatretreating>
+<dialogcombatretreating>Get away from me!</dialogcombatretreating>
+<dialogcombatretreating>AAAAAAAAAA!</dialogcombatretreating>
+<dialogcombatretreating>Fucking creatures everywhere!</dialogcombatretreating>
+<dialogcombatretreating>Help!</dialogcombatretreating>
+<dialogcombatretreating>Help me!</dialogcombatretreating>
+<dialogcannotreturn>Can't get back to the submarine!</dialogcannotreturn>
+<dialogcannotreturn>I can't find my way back to the submarine!</dialogcannotreturn>
+<rearrangedorders>[name], check your order priorities!</rearrangedorders>
+<rearrangedorders>[name], your priorities have changed!</rearrangedorders>
+<dialogturrethasnopower>There's no power in the supercapacitor!</dialogturrethasnopower>
+<dialogturrethasnopower>The supercapacitor is dead!</dialogturrethasnopower>
+<dialogturrethasnopower>I can't shoot! The turret is not working.</dialogturrethasnopower>
+<dialogsupercapacitorisbroken>The supercapacitor is broken!</dialogsupercapacitorisbroken>
+<dialogsupercapacitorisbroken>The supercapacitor is not working!</dialogsupercapacitorisbroken>
+<dialogsupercapacitorisbroken>The supercapacitor is malfunctioning!</dialogsupercapacitorisbroken>
+<dialogsupercapacitorisbroken>I need someone to fix the supercapacitor!</dialogsupercapacitorisbroken>
+<dialogreactorisbroken>The reactor is broken!</dialogreactorisbroken>
+<dialogreactorisbroken>The reactor is not working!</dialogreactorisbroken>
+<dialogreactorisbroken>The reactor is malfunctioning!</dialogreactorisbroken>
+<dialogreactorisbroken>I need someone to fix the reactor!</dialogreactorisbroken>
+<dialognavterminalisbroken>The navigation terminal is broken!</dialognavterminalisbroken>
+<dialognavterminalisbroken>The navigation terminal is not working!</dialognavterminalisbroken>
+<dialognavterminalisbroken>The navigation terminal is malfunctioning!</dialognavterminalisbroken>
+<dialognavterminalisbroken>I need someone to fix the navigation terminal!</dialognavterminalisbroken>
+<dialogmentalstateconfused>Uhh... What was that?</dialogmentalstateconfused>
+<dialogmentalstateconfused>Huh... I must be seeing things.</dialogmentalstateconfused>
+<dialogmentalstateconfused>That can't be right...</dialogmentalstateconfused>
+<dialogmentalstateconfused>Huh? Did you hear that?</dialogmentalstateconfused>
+<dialogmentalstateafraid>I don't feel safe here.</dialogmentalstateafraid>
+<dialogmentalstateafraid>Is someone out there?</dialogmentalstateafraid>
+<dialogmentalstateafraid>Who's there?</dialogmentalstateafraid>
+<dialogmentalstateafraid>I want to go home.</dialogmentalstateafraid>
+<dialogmentalstatedesperate>Shut up. Shut up. Shut up.</dialogmentalstatedesperate>
+<dialogmentalstatedesperate>I don't... I can't...</dialogmentalstatedesperate>
+<dialogmentalstatedesperate>Please leave me alone.</dialogmentalstatedesperate>
+<dialogmentalstatedesperate>They're coming for me.</dialogmentalstatedesperate>
+<dialogmentalstateberserk>It will all be over soon.</dialogmentalstateberserk>
+<dialogmentalstateberserk>I understand my purpose.</dialogmentalstateberserk>
+<dialogmentalstateberserk>They won't trouble us for long.</dialogmentalstateberserk>
+<dialogmentalstateberserk>I will set things right.</dialogmentalstateberserk>
+<dialogmentalstatereactionretreat>I want to go home!</dialogmentalstatereactionretreat>
+<dialogmentalstatereactionretreat>Stay away from me!</dialogmentalstatereactionretreat>
+<dialogmentalstatereactionretreat>Make it stop!</dialogmentalstatereactionretreat>
+<dialogmentalstatereactionretreat>Oh god, oh god!</dialogmentalstatereactionretreat>
+<dialogmentalstatereactiondefensive>I won't let you take me!</dialogmentalstatereactiondefensive>
+<dialogmentalstatereactiondefensive>Get away from me, damnit!</dialogmentalstatereactiondefensive>
+<dialogmentalstatereactiondefensive>I can't take it anymore!</dialogmentalstatereactiondefensive>
+<dialogmentalstatereactiondefensive>Just let me go home!</dialogmentalstatereactiondefensive>
+<dialogmentalstatereactionarrest>These people cannot be trusted!</dialogmentalstatereactionarrest>
+<dialogmentalstatereactionarrest>I won't let you hurt me!</dialogmentalstatereactionarrest>
+<dialogmentalstatereactionarrest>Get down on the ground!</dialogmentalstatereactionarrest>
+<dialogmentalstatereactionarrest>I have to put you down!</dialogmentalstatereactionarrest>
+<dialogmentalstatereactionoffensive>AHAHAHAHA!</dialogmentalstatereactionoffensive>
+<dialogmentalstatereactionoffensive>I'll end you!</dialogmentalstatereactionoffensive>
+<dialogmentalstatereactionoffensive>Die, scum!</dialogmentalstatereactionoffensive>
+<dialogmentalstatereactionoffensive>Kill! Kill! Kill!</dialogmentalstatereactionoffensive>
+<dialogterroristannounce>This ship belongs to the Jovian Separatists!</dialogterroristannounce>
+<dialogterroristannounce>Death to the Coalition!</dialogterroristannounce>
+<dialogterroristannounce>Long live the revolution!</dialogterroristannounce>
+<dialogterroristannounce>This ship will serve the Separatists well!</dialogterroristannounce>
+<dialogterroristannounce>You must all die for the revolution!</dialogterroristannounce>
+<dialogterroristannounce>The Jovian Separatists shall be victorious!</dialogterroristannounce>
+<dialogterroristannounce>The Jovian Separatists shall rule Europa!</dialogterroristannounce>
+<dialogoutofchaingunammo>We're out of chaingun ammunition.</dialogoutofchaingunammo>
+<dialogoutofpulselaserammo>We're out of pulse laser fuel.</dialogoutofpulselaserammo>
+<dialoglowonchaingunammo>We're running low on chaingun ammunition! Fire short controlled bursts!</dialoglowonchaingunammo>
+<dialoglowonpulselaserammo>There's not much pulse laser fuel left onboard.</dialoglowonpulselaserammo>
+<dialoghuskdormant>My throat feels a bit sore.</dialoghuskdormant>
+<dialoghuskdormant>I think I might have a fever.</dialoghuskdormant>
+<dialoghuskdormant>I feel really weak. Every muscle hurts.</dialoghuskdormant>
+<dialoghuskcantspeak>There's something in my mouth...</dialoghuskcantspeak>
+<dialoginsufficientpressureprotection>I'm not protected enough from the pressure!</dialoginsufficientpressureprotection>
+<dialoginsufficientpressureprotection>The pressure is breaking up my suit!</dialoginsufficientpressureprotection>
+<dialoginsufficientpressureprotection>I'm getting crushed by the pressure!</dialoginsufficientpressureprotection>
+<dialogcannottreatself>I don't have the means to treat myself!</dialogcannottreatself>
+<dialoglowrepcampaigninteraction>Honestly, I'd rather not do business with you people, but I don't have the luxury of picking my customers.</dialoglowrepcampaigninteraction>
+<dialoglowrepcampaigninteraction>They say I shouldn't be serving you, but I say I shouldn't be turning down a paying customer.</dialoglowrepcampaigninteraction>
+<dialoglowrepcampaigninteraction>If I wasn't broke, I'd tell you to piss off. But if you've got the money…</dialoglowrepcampaigninteraction>
+<dialoglowrepcampaigninteraction>Oh, you're one of those people. Although…if there's marks in your wallet, let's pretend you're just a kind stranger in need of my services.</dialoglowrepcampaigninteraction>
+<dialogrefusedragging>Let go of me!</dialogrefusedragging>
+<dialogrefusedragging>Get your hands off me!</dialogrefusedragging>
+<dialogrefusedragging>Stop that!</dialogrefusedragging>
+
+<!-- Character orders -->
+<orderdialog.follow>[name], follow me!</orderdialog.follow>
+<orderdialogself.follow>Lead the way!</orderdialogself.follow>
+<orderdialog.wait>[name], wait there!</orderdialog.wait>
+<orderdialog.wait>[name], stay where you are!</orderdialog.wait>
+<orderdialogself.wait>I'll wait here!</orderdialogself.wait>
+<orderdialog.dismissed>[name], you are dismissed!</orderdialog.dismissed>
+<orderdialogself.dismissed></orderdialogself.dismissed>
+<orderdialog.operatereactor>[name], operate the reactor!</orderdialog.operatereactor>
+<orderdialog.operatereactor>[name], man the reactor!</orderdialog.operatereactor>
+<orderdialogself.operatereactor>I'll operate the reactor!</orderdialogself.operatereactor>
+<orderdialogself.operatereactor>I'll take care of the reactor!</orderdialogself.operatereactor>
+<orderdialog.operatereactor.powerup>[name], power up the reactor!</orderdialog.operatereactor.powerup>
+<orderdialogself.operatereactor.powerup>I'll power up the reactor!</orderdialogself.operatereactor.powerup>
+<orderdialog.operatereactor.shutdown>[name], shut down the reactor!</orderdialog.operatereactor.shutdown>
+<orderdialogself.operatereactor.shutdown>I'll shut down the reactor!</orderdialogself.operatereactor.shutdown>
+<orderdialog.operateweapons>[name], operate the weapons!</orderdialog.operateweapons>
+<orderdialog.operateweapons>[name], man the weapons!</orderdialog.operateweapons>
+<orderdialog.operateweapons>[name], man the guns!</orderdialog.operateweapons>
+<orderdialogself.operateweapons>I'll man the guns!</orderdialogself.operateweapons>
+<orderdialog.operateweapons.fireatwill>[name], fire at will!</orderdialog.operateweapons.fireatwill>
+<orderdialogself.operateweapons.fireatwill>I'm ready to fire!</orderdialogself.operateweapons.fireatwill>
+<orderdialog.operateweapons.holdfire>[name], hold fire!</orderdialog.operateweapons.holdfire>
+<orderdialogself.operateweapons.holdfire>Holding fire!</orderdialogself.operateweapons.holdfire>
+<orderdialog.steer>[name], man the helm!</orderdialog.steer>
+<orderdialog.steer>[name], steer the submarine!</orderdialog.steer>
+<orderdialogself.steer>I'll steer the submarine!</orderdialogself.steer>
+<orderdialogself.steer>I'll man the helm!</orderdialogself.steer>
+<orderdialog.steer.maintainposition>[name], maintain position!</orderdialog.steer.maintainposition>
+<orderdialog.steer.maintainposition>[name], hold our position!</orderdialog.steer.maintainposition>
+<orderdialogself.steer.maintainposition>I'll maintain our position!</orderdialogself.steer.maintainposition>
+<orderdialog.steer.navigateback>[name], set the course back!</orderdialog.steer.navigateback>
+<orderdialogself.steer.navigateback>I'll set the course back!</orderdialogself.steer.navigateback>
+<orderdialog.steer.navigatetodestination>[name], navigate onwards!</orderdialog.steer.navigatetodestination>
+<orderdialog.steer.navigatetodestination>[name], set the course onwards!</orderdialog.steer.navigatetodestination>
+<orderdialog.steer.navigatetodestination>[name], set the course to our destination!</orderdialog.steer.navigatetodestination>
+<orderdialogself.steer.navigatetodestination>I'll set the course onwards!</orderdialogself.steer.navigatetodestination>
+<orderdialog.fixleaks>[name], start fixing leaks!</orderdialog.fixleaks>
+<orderdialog.fixleaks>[name], take care of any leaks!</orderdialog.fixleaks>
+<orderdialogself.fixleaks>I'll take care of leaks!</orderdialogself.fixleaks>
+<orderdialog.extinguishfires>[name], extinguish the fire!</orderdialog.extinguishfires>
+<orderdialogself.extinguishfires>I'll extinguish the fires!</orderdialogself.extinguishfires>
+<orderdialog.chargebatteries>[name], operate the batteries!</orderdialog.chargebatteries>
+<orderdialogself.chargebatteries>I'll operate the batteries!</orderdialogself.chargebatteries>
+<orderdialog.chargebatteries.charge>[name], charge the batteries!</orderdialog.chargebatteries.charge>
+<orderdialog.chargebatteries.charge>[name], make sure all batteries are charged!</orderdialog.chargebatteries.charge>
+<orderdialogself.chargebatteries.charge>I'll charge the batteries!</orderdialogself.chargebatteries.charge>
+<orderdialog.chargebatteries.stopcharging>[name], stop charging the batteries!</orderdialog.chargebatteries.stopcharging>
+<orderdialogself.chargebatteries.stopcharging>I'll stop charging the batteries!</orderdialogself.chargebatteries.stopcharging>
+<orderdialog.pumpwater>[name], start pumping out water!</orderdialog.pumpwater>
+<orderdialogself.pumpwater>I'll start pumping out water!</orderdialogself.pumpwater>
+<orderdialog.pumpwater.pumpout>[name], start pumping out water!</orderdialog.pumpwater.pumpout>
+<orderdialogself.pumpwater.pumpout>I'll start pumping out water!</orderdialogself.pumpwater.pumpout>
+<orderdialog.pumpwater.stoppumping>[name], shut down the pumps!</orderdialog.pumpwater.stoppumping>
+<orderdialog.pumpwater.stoppumping>[name], stop the pumps!</orderdialog.pumpwater.stoppumping>
+<orderdialogself.pumpwater.stoppumping>I'll stop the pumps!</orderdialogself.pumpwater.stoppumping>
+<orderdialog.rescue>[name], rescue anyone in distress!</orderdialog.rescue>
+<orderdialog.rescue>[name], give medical aid to anyone in need!</orderdialog.rescue>
+<orderdialogself.rescue>I'll give medical aid to anyone in need!</orderdialogself.rescue>
+<orderdialog.repairsystems>[name], repair damaged systems!</orderdialog.repairsystems>
+<orderdialog.repairsystems>[name], take care of broken devices!</orderdialog.repairsystems>
+<orderdialogself.repairsystems>I'll take care of broken devices!</orderdialogself.repairsystems>
+<orderdialog.repairsystems.jobspecific>[name], repair damaged systems!</orderdialog.repairsystems.jobspecific>
+<orderdialog.repairsystems.jobspecific>[name], take care of broken devices!</orderdialog.repairsystems.jobspecific>
+<orderdialogself.repairsystems.jobspecific>I'll take care of broken devices!</orderdialogself.repairsystems.jobspecific>
+<orderdialog.repairsystems.all>[name], repair any damaged systems! I don't care if you don't have the skills—do your best!</orderdialog.repairsystems.all>
+<orderdialog.repairsystems.all>[name], try to fix any broken devices, even if it's something you're not trained for!</orderdialog.repairsystems.all>
+<orderdialog.repairsystems.all>[name], repair any damaged devices! Anything you can—I don't care about your training now!</orderdialog.repairsystems.all>
+<orderdialogself.repairsystems.all>I'll take care of broken devices!</orderdialogself.repairsystems.all>
+<orderdialog.reportfire>Fire in [roomname]!</orderdialog.reportfire>
+<orderdialog.reportfire>[roomname] is on fire!</orderdialog.reportfire>
+<orderdialog.reportbreach>Hull breach in [roomname]!</orderdialog.reportbreach>
+<orderdialog.reportbreach>Leak in [roomname]!</orderdialog.reportbreach>
+<orderdialog.reportintruders>Intruders in [roomname]!</orderdialog.reportintruders>
+<orderdialog.reportintruders>Hostiles in [roomname]!</orderdialog.reportintruders>
+<orderdialog.reportbrokendevices>Broken devices in [roomname]!</orderdialog.reportbrokendevices>
+<orderdialog.reportbrokendevices>Need someone to repair devices in [roomname]!</orderdialog.reportbrokendevices>
+<orderdialog.requestfirstaid>Need a medic in [roomname]!</orderdialog.requestfirstaid>
+<orderdialog.requestfirstaid>Need medical assistance in [roomname]!</orderdialog.requestfirstaid>
+<orderdialog.fightintruders>[name], eliminate all intruders!</orderdialog.fightintruders>
+<orderdialog.fightintruders>[name], defend the crew!</orderdialog.fightintruders>
+<orderdialogself.fightintruders>Taking care of the intruders!</orderdialogself.fightintruders>
+<orderdialogself.fightintruders>Fighting the enemy!</orderdialogself.fightintruders>
+<orderdialog.repairelectrical>[name], repair electrical systems!</orderdialog.repairelectrical>
+<orderdialog.repairelectrical>[name], take care of electrical devices!</orderdialog.repairelectrical>
+<orderdialogself.repairelectrical>I'll take care of electrical devices!</orderdialogself.repairelectrical>
+<orderdialog.repairmechanical>[name], repair mechanical systems!</orderdialog.repairmechanical>
+<orderdialog.repairmechanical>[name], take care of mechanical devices!</orderdialog.repairmechanical>
+<orderdialogself.repairmechanical>I'll take care of mechanical devices!</orderdialogself.repairmechanical>
+<orderdialog.cleanupitems>[name], clean up all the items lying around!</orderdialog.cleanupitems>
+<orderdialog.cleanupitems>[name], put things back where they belong!</orderdialog.cleanupitems>
+<orderdialogself.cleanupitems>Cleaning up items!</orderdialogself.cleanupitems>
+<orderdialogself.cleanupitems>Putting things where they belong!</orderdialogself.cleanupitems>
+<orderoptions.operatereactor>Power up, Shut down</orderoptions.operatereactor>
+<orderoptions.operateweapons>Fire at will, Hold fire</orderoptions.operateweapons>
+<orderoptions.steer>Maintain position, Navigate back, Navigate to destination</orderoptions.steer>
+<orderoptions.chargebatteries>Charge, Stop charging</orderoptions.chargebatteries>
+<orderoptions.repairsystems>Repair job specific, Repair everything</orderoptions.repairsystems>
+<ordername.dismissed>Dismiss</ordername.dismissed>
+<ordername.follow>Follow</ordername.follow>
+<ordername.wait>Wait</ordername.wait>
+<ordername.operatereactor>Operate Reactor</ordername.operatereactor>
+<ordername.operateweapons>Operate Weapons</ordername.operateweapons>
+<ordername.steer>Steer</ordername.steer>
+<ordername.fixleaks>Fix Leaks</ordername.fixleaks>
+<ordername.extinguishfires>Extinguish Fires</ordername.extinguishfires>
+<ordername.fightintruders>Fight Intruders</ordername.fightintruders>
+<ordername.chargebatteries>Charge Batteries</ordername.chargebatteries>
+<ordername.pumpwater>Operate Pumps</ordername.pumpwater>
+<orderoptions.pumpwater>Pump out, Pump in, Stop pumping</orderoptions.pumpwater>
+<ordername.rescue>Heal and Rescue</ordername.rescue>
+<ordername.repairsystems>Repair Damaged Systems</ordername.repairsystems>
+<ordername.reportfire>Report Fire</ordername.reportfire>
+<ordername.reportbreach>Report Hull Breach</ordername.reportbreach>
+<ordername.reportintruders>Report Intruders</ordername.reportintruders>
+<ordername.reportbrokendevices>Report Broken Devices</ordername.reportbrokendevices>
+<ordername.requestfirstaid>Request First Aid</ordername.requestfirstaid>
+<ordername.repairmechanical>Repair Mechanical Systems</ordername.repairmechanical>
+<ordername.repairelectrical>Repair Electrical Systems</ordername.repairelectrical>
+<ordername.use>Use</ordername.use>
+<ordername.detach>Detach</ordername.detach>
+<ordername.weldshut>Weld Shut</ordername.weldshut>
+<ordername.forceopen>Force Open</ordername.forceopen>
+<ordername.setchargepct>Set Charge %</ordername.setchargepct>
+<orderoptions.setchargepct>100%, 50%, 0%</orderoptions.setchargepct>
+<ordername.reload>Reload</ordername.reload>
+<ordername.dock>Dock</ordername.dock>
+<ordername.refuel>Refuel</ordername.refuel>
+<ordername.make>Make...</ordername.make>
+<orderoptions.make>Ammunition, Fuel rods</orderoptions.make>
+<ordername.refilloxygentanks>Refill Oxygen Tanks</ordername.refilloxygentanks>
+<ordername.rechargebatteries>Recharge Batteries</ordername.rechargebatteries>
+<ordername.unpack>Unpack</ordername.unpack>
+<ordername.usedelayed>Use in...</ordername.usedelayed>
+<orderoptions.usedelayed>1 sec, 3 sec, 10 sec</orderoptions.usedelayed>
+<ordername.loot>Loot</ordername.loot>
+<ordername.equipfor>Equip for...</ordername.equipfor>
+<orderoptions.equipfor>Away mission, Invaders, Hull breach</orderoptions.equipfor>
+<ordername.getitem>Get Item</ordername.getitem>
+<ordername.cleanupitems>Cleanup Items</ordername.cleanupitems>
+<ordername.ignorethis>Ignore This</ordername.ignorethis>
+<orderdialog.ignorethis>Ignore the target in [roomname]!</orderdialog.ignorethis>
+<orderdialog.ignorethis>Don't touch the target in [roomname]!</orderdialog.ignorethis>
+<ordername.unignorethis>Unignore This</ordername.unignorethis>
+<orderdialog.unignorethis>Stop ignoring the target in [roomname]!</orderdialog.unignorethis>
+<orderdialog.unignorethis>You should consider the target in [roomname] again!</orderdialog.unignorethis>
+<orderdialog.reportballastflora>There's something alien growing in [roomname].</orderdialog.reportballastflora>
+<orderdialog.reportballastflora>I found weird, fleshy, plants in [roomname].</orderdialog.reportballastflora>
+<orderdialog.reportballastflora>We need to do something to these things growing in [roomname]!</orderdialog.reportballastflora>
+<ordernamecontextual.wait>Wait Here</ordernamecontextual.wait>
+<ordername.assaultenemy>Assault Enemy</ordername.assaultenemy>
+<orderdialog.assaultenemy>[name], find and eliminate all enemies!</orderdialog.assaultenemy>
+<orderdialog.assaultenemy>[name], take care of any enemy you can find!</orderdialog.assaultenemy>
+<orderdialogself.assaultenemy>I'll eliminate the enemies!</orderdialogself.assaultenemy>
+<orderdialogself.assaultenemy>I'll take care of the enemies!</orderdialogself.assaultenemy>
+<orderdialog.dismissed.assaultenemy>[name], leave the enemies for now!</orderdialog.dismissed.assaultenemy>
+<orderdialog.dismissed.assaultenemy>[name], time to retreat!</orderdialog.dismissed.assaultenemy>
+<ordername.loaditems>Load Items</ordername.loaditems>
+<orderoptions.loaditems>Recharge battery cells, Refill oxygen tanks, Reload ammo</orderoptions.loaditems>
+<orderdialog.loaditems.batterycells>[name], make sure all the battery cells are charged!</orderdialog.loaditems.batterycells>
+<orderdialog.loaditems.batterycells>[name], get those battery cells charged!</orderdialog.loaditems.batterycells>
+<orderdialogself.loaditems.batterycell>I'll charge the battery cells.</orderdialogself.loaditems.batterycell>
+<orderdialog.loaditems.oxygentanks>[name], make sure all the oxygen tanks are filled!</orderdialog.loaditems.oxygentanks>
+<orderdialog.loaditems.oxygentanks>[name], fill the oxygen tanks!</orderdialog.loaditems.oxygentanks>
+<orderdialogself.loaditems.oxygentanks>I'll fill the oxygen tanks.</orderdialogself.loaditems.oxygentanks>
+<orderdialogself.loaditems.oxygentanks>I'll load ammo for the submarine weapons.</orderdialogself.loaditems.oxygentanks>
+<orderdialog.loaditems.turretammo>[name], make sure the submarine weapons don't run out of ammo!</orderdialog.loaditems.turretammo>
+<orderdialog.loaditems.turretammo>[name], load ammo for the submarine weapons!</orderdialog.loaditems.turretammo>
+<orderdialog.dismissed.loaditems>[name], never mind the weapon!</orderdialog.dismissed.loaditems>
+<orderdialogself.loaditems.turretammo>I'll load ammo for the submarine weapons.</orderdialogself.loaditems.turretammo>
+<orderdialog.pumpwater.pumpin>[name], start pumping in water!</orderdialog.pumpwater.pumpin>
+<orderdialogself.pumpwater.pumpin>I'll start pumping in water!</orderdialogself.pumpwater.pumpin>
+<ordername.findweapon>Find Weapon</ordername.findweapon>
+<ordername.prepareforexpedition>Prepare for Expedition</ordername.prepareforexpedition>
+<orderdialog.findweapon>[name], grab a gun!</orderdialog.findweapon>
+<orderdialog.findweapon>[name], arm yourself!</orderdialog.findweapon>
+<orderdialog.findweapon>[name], pick a weapon!</orderdialog.findweapon>
+<orderdialog.prepareforexpedition>[name], prepare to leave the sub!</orderdialog.prepareforexpedition>
+<orderdialog.prepareforexpedition>[name], let's go outside!</orderdialog.prepareforexpedition>
+<orderdialog.prepareforexpedition>[name], let's have a dive!</orderdialog.prepareforexpedition>
+<orderdialog.dismissed.findweapon>[name], never mind the weapon!</orderdialog.dismissed.findweapon>
+<orderdialog.dismissed.prepareforexpedition>[name], forget it!</orderdialog.dismissed.prepareforexpedition>
+<ordername.return>Return</ordername.return>
+<orderdialog.return>[name], return to the submarine!</orderdialog.return>
+<orderdialogself.return>I'll return to the submarine!</orderdialogself.return>
+<orderdialog.dismissed.return>[name], you don't have to return to the submarine!</orderdialog.dismissed.return>
+<orderdialog.dismissed.follow>[name], thanks for following me!</orderdialog.dismissed.follow>
+<orderdialog.dismissed.wait>[name], thanks for waiting!</orderdialog.dismissed.wait>
+<orderdialog.dismissed.operatereactor>[name], thanks for operating the reactor!</orderdialog.dismissed.operatereactor>
+<orderdialog.dismissed.operatereactor>[name], thanks for manning the reactor!</orderdialog.dismissed.operatereactor>
+<orderdialog.dismissed.operateweapons>[name], thanks for operating the weapons!</orderdialog.dismissed.operateweapons>
+<orderdialog.dismissed.operateweapons>[name], thanks for manning the weapons!</orderdialog.dismissed.operateweapons>
+<orderdialog.dismissed.operateweapons>[name], thanks for manning the guns!</orderdialog.dismissed.operateweapons>
+<orderdialog.dismissed.steer>[name], thanks for manning the helm!</orderdialog.dismissed.steer>
+<orderdialog.dismissed.steer>[name], thanks for steering the submarine!</orderdialog.dismissed.steer>
+<orderdialog.dismissed.fixleaks>[name], thanks for fixing the leaks!</orderdialog.dismissed.fixleaks>
+<orderdialog.dismissed.fixleaks>[name], thanks for taking care of the leaks!</orderdialog.dismissed.fixleaks>
+<orderdialog.dismissed.extinguishfires>[name], thanks for extinguishing the fire!</orderdialog.dismissed.extinguishfires>
+<orderdialog.dismissed.chargebatteries>[name], thanks for operating the batteries!</orderdialog.dismissed.chargebatteries>
+<orderdialog.dismissed.pumpwater>[name], thanks for pumping out water!</orderdialog.dismissed.pumpwater>
+<orderdialog.dismissed.rescue>[name], thanks for giving medical aid!</orderdialog.dismissed.rescue>
+<orderdialog.dismissed.repairsystems>[name], thanks for repairing damaged systems!</orderdialog.dismissed.repairsystems>
+<orderdialog.dismissed.repairsystems>[name], thanks for taking care of broken devices!</orderdialog.dismissed.repairsystems>
+<orderdialog.dismissed.fightintruders>[name], thanks for eliminating all intruders!</orderdialog.dismissed.fightintruders>
+<orderdialog.dismissed.fightintruders>[name], thanks for defending the crew!</orderdialog.dismissed.fightintruders>
+<orderdialog.dismissed.repairelectrical>[name], thanks for repairing electrical systems!</orderdialog.dismissed.repairelectrical>
+<orderdialog.dismissed.repairelectrical>[name], thanks for taking care of electrical devices!</orderdialog.dismissed.repairelectrical>
+<orderdialog.dismissed.repairmechanical>[name], thanks for repairing mechanical systems!</orderdialog.dismissed.repairmechanical>
+<orderdialog.dismissed.repairmechanical>[name], thanks for taking care of mechanical devices!</orderdialog.dismissed.repairmechanical>
+<orderdialog.dismissed.cleanupitems>[name], thanks for cleaning up all the items lying around!</orderdialog.dismissed.cleanupitems>
+<orderdialog.dismissed.cleanupitems>[name], thanks for putting things back where they belong!</orderdialog.dismissed.cleanupitems>
+<orderdialog.prisonerescaped>Prisoner on the run in [roomname]!</orderdialog.prisonerescaped>
+<orderdialog.prisonerescaped>Prisoner breaking out in [roomname]!</orderdialog.prisonerescaped>
+<orderdialog.mentalcase>Mental breakdown in [roomname]!</orderdialog.mentalcase>
+<orderdialog.mentalcase>We have a nutcase in [roomname]!</orderdialog.mentalcase>
+
+<!-- Command UI -->
+<commandui.return>Return</commandui.return>
+<commandui.expand>Expand</commandui.expand>
+<commandui.quickassigntooltip>Quick assignment</commandui.quickassigntooltip>
+<commandui.manualassigntooltip>Manual assignment</commandui.manualassigntooltip>
+<ordercategorytitle.emergency>Emergency</ordercategorytitle.emergency>
+<ordercategorydescription.emergency></ordercategorydescription.emergency>
+<ordercategorytitle.movement>Movement</ordercategorytitle.movement>
+<ordercategorydescription.movement></ordercategorydescription.movement>
+<ordercategorytitle.power>Power</ordercategorytitle.power>
+<ordercategorydescription.power></ordercategorydescription.power>
+<ordercategorytitle.maintenance>Maintenance</ordercategorytitle.maintenance>
+<ordercategorydescription.maintenance></ordercategorydescription.maintenance>
+<ordercategorytitle.operate>Operate</ordercategorytitle.operate>
+<ordercategorydescription.operate></ordercategorydescription.operate>
+<crewlistordericontooltip>[ordername] ([orderoption])</crewlistordericontooltip>
+<crewlistelementtooltip>[name] ([job])\nDrag to rearrange crewmembers</crewlistelementtooltip>
+<thischaractercanthear>This character can't hear the order</thischaractercanthear>
+<nocharactercanhear>There's no character that can hear the order</nocharactercanhear>
+<objective.idle>Idle</objective.idle>
+<objective.findsafety>Find Safety</objective.findsafety>
+<objective.combat>Combat</objective.combat>
+<crewlistobjectivetooltip>Current task: [objective]</crewlistobjectivetooltip>
+
+<!-- Status -->
+<deceased>Deceased</deceased>
+<unconscious>Unconscious</unconscious>
+<stunned>Stunned</stunned>
+<huskinfectiontransition>Velonaceps calyx infection</huskinfectiontransition>
+<huskinfectionactive>Advanced Velonaceps calyx infection</huskinfectionactive>
+<statusok>OK</statusok>
+<minorbleeding>Minor bleeding</minorbleeding>
+<bleeding>Bleeding</bleeding>
+<heavybleeding>Heavy bleeding</heavybleeding>
+<catastrophicbleeding>Catastrophic bleeding</catastrophicbleeding>
+<noinjuries>No visible injuries</noinjuries>
+<minorinjuries>Minor injuries</minorinjuries>
+<injuries>Injured</injuries>
+<injured>Injured</injured>
+<majorinjuries>Major injuries</majorinjuries>
+<criticalinjuries>Critically injured</criticalinjuries>
+<oxygennormal>Oxygen level normal</oxygennormal>
+<oxygenreduced>Gasping for air</oxygenreduced>
+<oxygenlow>Signs of oxygen deprivation</oxygenlow>
+<notbreathing>Not breathing</notbreathing>
+<noavailablemedicalitems>No medical items available</noavailablemedicalitems>
+
+<!-- Huskification -->
+<huskdormant>Your throat feels sore</huskdormant>
+<huskdormant>You feel feverish</huskdormant>
+<huskdormant>It feels as if something was stuck in your throat</huskdormant>
+<huskdormant>Your muscles are aching</huskdormant>
+<huskcantspeak>You feel something moving in your throat. You try to scream but no sound comes out.</huskcantspeak>
+<huskactivate>A strange chitinous appendage bursts out from your mouth. Use it to inject eggs into a living body by pressing [Attack]!</huskactivate>
+
+<!-- Skills -->
+<skillname.helm>Helm</skillname.helm>
+<skillname.weapons>Weapons</skillname.weapons>
+<skillname.mechanical>Mechanical Engineering</skillname.mechanical>
+<skillname.electrical>Electrical Engineering</skillname.electrical>
+<skillname.medical>Medical</skillname.medical>
+<skillname.initiative>Initiative</skillname.initiative>
+<skillname.courage>Courage</skillname.courage>
+
+<!-- Item messages -->
+<itemmsginteractselect>[[select]] Interact</itemmsginteractselect>
+<itemmsgequipselect>[[select]] Equip</itemmsgequipselect>
+<itemmsgpickupselect>[[select]] Pick up</itemmsgpickupselect>
+<itemmsgclimbselect>[[select]] Climb</itemmsgclimbselect>
+<itemmsgpressselect>[[select]] Press</itemmsgpressselect>
+<itemmsggoinside>[[use]] Go inside</itemmsggoinside>
+<itemmsgunauthorizedaccess>UNAUTHORIZED ACCESS</itemmsgunauthorizedaccess>
+<accessdenied>UNAUTHORIZED ACCESS</accessdenied>
+<itemmsgrewirescrewdriver>[[use]] Rewire (Screwdriver)</itemmsgrewirescrewdriver>
+<itemmsgdetachwrench>[[use]] Detach (Wrench)</itemmsgdetachwrench>
+<itemmsgforceopencrowbar>[[use]] Force open (Crowbar)</itemmsgforceopencrowbar>
+<itemmsgrepairscrewdriver>[[use]] Repair (Screwdriver)</itemmsgrepairscrewdriver>
+<itemmsgrepairweldingtool>[[shoot]] Repair (Welding Tool)</itemmsgrepairweldingtool>
+<itemmsgrepairwrench>[[use]] Repair (Wrench)</itemmsgrepairwrench>
+<itemmsguseplasmacutter>[[shoot]] Cut (Plasma Cutter)</itemmsguseplasmacutter>
+<itemmsgbatterycellrequired>Battery cell required</itemmsgbatterycellrequired>
+<itemmsgweldingfuelrequired>Welding fuel required</itemmsgweldingfuelrequired>
+<itemmsgoxygentankrequired>Oxygen tank required</itemmsgoxygentankrequired>
+<itemmsgspearrequired>Out of spears</itemmsgspearrequired>
+<itemmsgammorequired>Out of ammo</itemmsgammorequired>
+<itemmsgsyringerequired>Out of syringes</itemmsgsyringerequired>
+<itemmsgopen>[[select]] Open</itemmsgopen>
+<doormsgcannotopen>This door is controlled by buttons or remote controllers wired to it.</doormsgcannotopen>
+<idcardname>This belongs to [name].</idcardname>
+<idcardnamejob>This belongs to [name], the [job].</idcardnamejob>
+<dropitem>Drop</dropitem>
+<putitemin>Put in [itemname]</putitemin>
+<itemmsgoxygenrefill>Insert oxygen tank to refill it</itemmsgoxygenrefill>
+<itemmsgcontextualorders>[[command]] Contextual Orders</itemmsgcontextualorders>
+<itemmsgdetach>[[use]] Detach</itemmsgdetach>
+<itemmsgplantseed>[[select]] Plant seed</itemmsgplantseed>
+<itemmsgaddfertilizer>[[select]] Add fertilizer</itemmsgaddfertilizer>
+<itemmsgharvest>[[select]] Uproot</itemmsgharvest>
+<itemmsgpaintorcleaningagentrequired>Paint or cleaning agent required</itemmsgpaintorcleaningagentrequired>
+<itemmsgpickupuse>[[use]] Pick up</itemmsgpickupuse>
+<itemmsgrequiretraining>Special training required to place this item.</itemmsgrequiretraining>
+<itemmsgtotalnumberlimited>Too many of this item type placed on this submarine</itemmsgtotalnumberlimited>
+
+<!-- Afflictions -->
+<afflictionname.internaldamage>Internal damage</afflictionname.internaldamage>
+<afflictiondescription.internaldamage>There are signs of burst blood vessels and of organ damage.</afflictiondescription.internaldamage>
+<afflictioncauseofdeath.internaldamage>Died of internal injuries.</afflictioncauseofdeath.internaldamage>
+<afflictioncauseofdeathself.internaldamage>You have succumbed to your internal injuries.</afflictioncauseofdeathself.internaldamage>
+<afflictionname.bleeding>Bleeding</afflictionname.bleeding>
+<afflictiondescription.bleeding>Blood pours freely from this ragged and particularly nasty open wound.</afflictiondescription.bleeding>
+<afflictioncauseofdeath.bleeding>Bled to death.</afflictioncauseofdeath.bleeding>
+<afflictioncauseofdeathself.bleeding>You have bled to death.</afflictioncauseofdeathself.bleeding>
+<afflictionname.burn>Burn</afflictionname.burn>
+<afflictiondescription.burn>The area is blistered and red, and skin is already beginning to peel away in sheets.</afflictiondescription.burn>
+<afflictioncauseofdeath.burn>Burned to death.</afflictioncauseofdeath.burn>
+<afflictioncauseofdeathself.burn>You have burned to death.</afflictioncauseofdeathself.burn>
+<afflictionname.oxygenlow>Oxygen low</afflictionname.oxygenlow>
+<afflictiondescription.oxygenlow>The skin is pale and clammy, and the lips turning blue.</afflictiondescription.oxygenlow>
+<afflictioncauseofdeath.oxygenlow>Suffocated.</afflictioncauseofdeath.oxygenlow>
+<afflictioncauseofdeathself.oxygenlow>You have suffocated.</afflictioncauseofdeathself.oxygenlow>
+<afflictionname.bloodloss>Blood loss</afflictionname.bloodloss>
+<afflictiondescription.bloodloss>The patient is pale and cold. Their heart beats in an alarmingly rapid fashion.</afflictiondescription.bloodloss>
+<afflictioncauseofdeath.bloodloss>Bled to death.</afflictioncauseofdeath.bloodloss>
+<afflictioncauseofdeathself.bloodloss>You have bled to death.</afflictioncauseofdeathself.bloodloss>
+<afflictionname.stun>Stun</afflictionname.stun>
+<afflictiondescription.stun>The patient is dazed and unresponsive.</afflictiondescription.stun>
+<afflictionname.pressure>Barotrauma</afflictionname.pressure>
+<afflictiondescription.pressure>There is obvious massive organ damage and the blood vessels of the eye have burst, creating an unnerving red gaze.</afflictiondescription.pressure>
+<afflictioncauseofdeath.pressure>Crushed by water pressure.</afflictioncauseofdeath.pressure>
+<afflictioncauseofdeathself.pressure>You have been crushed by water pressure.</afflictioncauseofdeathself.pressure>
+<afflictionname.huskinfection>Husk infection</afflictionname.huskinfection>
+<afflictiondescription.huskinfection>Something dark and unpleasant moves in the mouth. They are rendered completely mute, save for occasional clicking sounds apparently emanating from deep within the throat.</afflictiondescription.huskinfection>
+<afflictioncauseofdeath.huskinfection>Taken over by a husk parasite.</afflictioncauseofdeath.huskinfection>
+<afflictioncauseofdeathself.huskinfection>You have been taken over by the husk parasite.</afflictioncauseofdeathself.huskinfection>
+<afflictionname.psychosis>Psychosis</afflictionname.psychosis>
+<afflictiondescription.psychosis>The patient rants and mutters in an agitated fashion, a steady commentary of unseen events.</afflictiondescription.psychosis>
+<afflictionname.drunk>Drunk</afflictionname.drunk>
+<afflictiondescription.drunk>The smell of alcohol rises from them like a vapor, their speech slurs a little, and their eyes fail to focus.</afflictiondescription.drunk>
+<afflictioncauseofdeath.drunk>Died of alcohol poisoning.</afflictioncauseofdeath.drunk>
+<afflictioncauseofdeathself.drunk>You have died of alcohol poisoning.</afflictioncauseofdeathself.drunk>
+<afflictionname.opiatewithdrawal>Opiate withdrawal</afflictionname.opiatewithdrawal>
+<afflictiondescription.opiatewithdrawal>Agitation and a tremor are obvious, as are the signs of nausea.</afflictiondescription.opiatewithdrawal>
+<afflictioncauseofdeath.opiatewithdrawal>Died of opiate withdrawal.</afflictioncauseofdeath.opiatewithdrawal>
+<afflictioncauseofdeathself.opiatewithdrawal>You have died of opiate withdrawal.</afflictioncauseofdeathself.opiatewithdrawal>
+<afflictionname.opiateoverdose>Opiate overdose</afflictionname.opiateoverdose>
+<afflictiondescription.opiateoverdose>The patient has pinpoint pupils and icy cold skin. They struggle to breathe and swallow.</afflictiondescription.opiateoverdose>
+<afflictioncauseofdeath.opiateoverdose>Died of opiate overdose.</afflictioncauseofdeath.opiateoverdose>
+<afflictioncauseofdeathself.opiateoverdose>You have died of opiate overdose.</afflictioncauseofdeathself.opiateoverdose>
+<afflictionname.opiateaddiction>Opiate addiction</afflictionname.opiateaddiction>
+<afflictiondescription.opiateaddiction>The patient is happy enough...so long as they get what they need.</afflictiondescription.opiateaddiction>
+<afflictionname.gunshotwound>Gunshot wound</afflictionname.gunshotwound>
+<afflictiondescription.gunshotwound>The entry site is a small, dark, bruised hole oozing a little blood. The exit wound, however, is a large ragged mess of exposed tissue, and it's pouring blood.</afflictiondescription.gunshotwound>
+<afflictioncauseofdeath.gunshotwound>Shot to death.</afflictioncauseofdeath.gunshotwound>
+<afflictioncauseofdeathself.gunshotwound>You have died of gunshot wounds.</afflictioncauseofdeathself.gunshotwound>
+<afflictionname.morbusinepoisoning>Morbusine poisoning</afflictionname.morbusinepoisoning>
+<afflictiondescription.morbusinepoisoning>The patient can't breathe at all, and their heart rate is slowing rapidly.</afflictiondescription.morbusinepoisoning>
+<afflictioncauseofdeath.morbusinepoisoning>Died of morbusine poisoning.</afflictioncauseofdeath.morbusinepoisoning>
+<afflictioncauseofdeathself.morbusinepoisoning>You have died of morbusine poisoning.</afflictioncauseofdeathself.morbusinepoisoning>
+<afflictionname.sufforinpoisoning>Sufforin poisoning</afflictionname.sufforinpoisoning>
+
+<afflictioncauseofdeath.sufforinpoisoning>Died of sufforin poisoning.</afflictioncauseofdeath.sufforinpoisoning>
+<afflictioncauseofdeathself.sufforinpoisoning>You have died of sufforin poisoning.</afflictioncauseofdeathself.sufforinpoisoning>
+<afflictionname.cyanidepoisoning>Cyanide poisoning</afflictionname.cyanidepoisoning>
+
+<afflictioncauseofdeath.cyanidepoisoning>Died of cyanide poisoning.</afflictioncauseofdeath.cyanidepoisoning>
+<afflictioncauseofdeathself.cyanidepoisoning>You have died of cyanide poisoning.</afflictioncauseofdeathself.cyanidepoisoning>
+<afflictionname.blunttrauma>Blunt force trauma</afflictionname.blunttrauma>
+<afflictiondescription.blunttrauma>The area is an ugly shade of purple, and apparently very painful to touch. You suspect a bone might be broken.</afflictiondescription.blunttrauma>
+<afflictioncauseofdeath.blunttrauma>Died of blunt force trauma.</afflictioncauseofdeath.blunttrauma>
+<afflictioncauseofdeathself.blunttrauma>You have succumbed to injuries from blunt force trauma.</afflictioncauseofdeathself.blunttrauma>
+<afflictionname.lacerations>Lacerations</afflictionname.lacerations>
+<afflictiondescription.lacerations>The skin is pierced and there are deep, bleeding wounds.</afflictiondescription.lacerations>
+<afflictioncauseofdeath.lacerations>Died of lacerations.</afflictioncauseofdeath.lacerations>
+<afflictioncauseofdeathself.lacerations>You have succumbed to your wounds.</afflictioncauseofdeathself.lacerations>
+<afflictionname.bitewounds>Bite wounds</afflictionname.bitewounds>
+<afflictiondescription.bitewounds>There is extensive damage to soft tissue in the area and there are asymmetrical, bleeding wounds.</afflictiondescription.bitewounds>
+<afflictioncauseofdeath.bitewounds>Mauled to death.</afflictioncauseofdeath.bitewounds>
+<afflictioncauseofdeathself.bitewounds>You have been mauled to death.</afflictioncauseofdeathself.bitewounds>
+<afflictionname.radiationsickness>Radiation sickness</afflictionname.radiationsickness>
+<afflictiondescription.radiationsickness>The patient's skin is red and blistering.</afflictiondescription.radiationsickness>
+<afflictionname.deliriuminepoisoning>Deliriumine poisoning</afflictionname.deliriuminepoisoning>
+<afflictiondescription.deliriuminepoisoning>The patient seems agitated, with small but noticeable nervous twitches in their face and hands.</afflictiondescription.deliriuminepoisoning>
+<afflictionname.paralysis>Paralysis</afflictionname.paralysis>
+<afflictiondescription.paralysis>The patient has trouble moving.</afflictiondescription.paralysis>
+<afflictionname.organdamage>Organ damage</afflictionname.organdamage>
+<afflictiondescription.organdamage>The patient is suffering from sharp pain in their internal organs. There is no visible damage to the epidermis.</afflictiondescription.organdamage>
+<afflictioncauseofdeath.organdamage>Perished as a result of internal organ failure.</afflictioncauseofdeath.organdamage>
+<afflictioncauseofdeathself.organdamage>You have perished as a result of internal organ failure.</afflictioncauseofdeathself.organdamage>
+<afflictionname.explosiondamage>Deep tissue injury</afflictionname.explosiondamage>
+<afflictiondescription.explosiondamage>The area is colored purple. The tissue underneath feels different than the surrounding skin.</afflictiondescription.explosiondamage>
+<afflictioncauseofdeath.explosiondamage>Succumbed to deep tissue injuries.</afflictioncauseofdeath.explosiondamage>
+<afflictioncauseofdeathself.explosiondamage>You have succumbed to your deep tissue injuries.</afflictioncauseofdeathself.explosiondamage>
+<afflictionname.captainbuff>Cool and collected</afflictionname.captainbuff>
+<afflictionname.nausea>Nausea</afflictionname.nausea>
+<afflictiondescription.nausea>The skin is clammy and the patient is vomiting periodically.</afflictiondescription.nausea>
+<afflictioncauseofdeath.nausea>Choked on vomit.</afflictioncauseofdeath.nausea>
+<afflictioncauseofdeathself.nausea>You have choked on your own vomit.</afflictioncauseofdeathself.nausea>
+<afflictionname.watchersgaze>Watcher's Gaze</afflictionname.watchersgaze>
+<afflictiondescription.watchersgaze>Seeming confused and slightly terrified, the patient doesn't look good. Could it be a mental breakdown? A stress reaction? There's not much you can do about it.</afflictiondescription.watchersgaze>
+<afflictioncauseofdeath.watchersgaze>Stared to death by a Watcher.</afflictioncauseofdeath.watchersgaze>
+<afflictioncauseofdeathself.watchersgaze>Stared to death by a Watcher.</afflictioncauseofdeathself.watchersgaze>
+<afflictionname.hallucinating>Hallucinating</afflictionname.hallucinating>
+<afflictionname.reaperstax>Reaper's Tax</afflictionname.reaperstax>
+<afflictiondescription.reaperstax>The patient is tormented by painful visions of death and rebirth. Memories of past lives or just a stress reaction...? Consulting a medical doctor at an outpost is advised.</afflictiondescription.reaperstax>
+<afflictioncauseofdeath.reaperstax>The Reaper took his toll.</afflictioncauseofdeath.reaperstax>
+<afflictioncauseofdeathself.reaperstax>The Reaper took his toll.</afflictioncauseofdeathself.reaperstax>
+<afflictionname.concussion>Concussion</afflictionname.concussion>
+<afflictiondescription.concussion>The patient seems disoriented and has trouble focusing their eyes.</afflictiondescription.concussion>
+<afflictionname.disguised>Disguised</afflictionname.disguised>
+<afflictiondescription.disguised>As long as you keep covering your face, others might not be able to tell who you are...</afflictiondescription.disguised>
+<afflictiondescription.hallucinating>The things you hear and see appear so real! But are they?</afflictiondescription.hallucinating>
+<afflictiontype.damage>Damage</afflictiontype.damage>
+<afflictionname.acidreaction>Acid Vulnerability</afflictionname.acidreaction>
+<afflictiondescription.acidreaction>Reagent that drastically increases acid burn damage.</afflictiondescription.acidreaction>
+<afflictiondescription.internaldamage.low>No injuries are visible externally, but the sweating and aches suggest something is amiss.</afflictiondescription.internaldamage.low>
+<afflictiondescription.blunttrauma.low>A light bruise shows where something hit, but it doesn’t look like anything is broken.</afflictiondescription.blunttrauma.low>
+<afflictiondescription.lacerations.low>The cuts look worse than they really are.</afflictiondescription.lacerations.low>
+<afflictiondescription.bitewounds.low>Something tried to take a big chomp but luckily only caught a nibble. It will leave a scar though.</afflictiondescription.bitewounds.low>
+<afflictiondescription.gunshotwound.low>The bullet missed all the important bits and went straight through, but the pain is real and so is the risk of infection.</afflictiondescription.gunshotwound.low>
+<afflictiondescription.organdamage.self>You feel a sharp pain in your abdomen. There are no wounds to be seen.</afflictiondescription.organdamage.self>
+<afflictiondescription.explosiondamage.low>The area of skin appears slightly bruised.</afflictiondescription.explosiondamage.low>
+<afflictiondescription.bleeding.low>Blood is slowly dripping out from the wound.</afflictiondescription.bleeding.low>
+<afflictiondescription.bleeding.high>Blood is gushing out at an alarming rate.</afflictiondescription.bleeding.high>
+<afflictiondescription.burn.low>The area is red and dry.</afflictiondescription.burn.low>
+<afflictiondescription.burn.high>The skin is white and partially charred; this looks severe.</afflictiondescription.burn.high>
+<afflictionname.acidburn>Acid Burn</afflictionname.acidburn>
+<afflictiondescription.acidburn.low>The skin is irritated and raw.</afflictiondescription.acidburn.low>
+<afflictiondescription.acidburn>Parts of the flesh are stripped away by acid; a mixture of red and white mark the edges.</afflictiondescription.acidburn>
+<afflictiondescription.acidburn.high>The flesh has deformed and essentially melted away due to high amounts of acid.</afflictiondescription.acidburn.high>
+<afflictiondescription.oxygenlow.low>Restless anxiety and headaches hint at low blood oxygen levels.</afflictiondescription.oxygenlow.low>
+<afflictiondescription.bloodloss.low.self>You feel cold and fatigued.</afflictiondescription.bloodloss.low.self>
+<afflictiondescription.bloodloss.high.self>You feel cold and dizzy, probably not far from passing out.</afflictiondescription.bloodloss.high.self>
+<afflictiondescription.bloodloss.low>The patient's skin feels cold and moist.</afflictiondescription.bloodloss.low>
+<afflictiondescription.stun.self>You are temporarily rendered unable to move.</afflictiondescription.stun.self>
+<afflictiondescription.concussion.low>The patient seems slightly disoriented.</afflictiondescription.concussion.low>
+<afflictiondescription.concussion.low.self>Something hit you so hard your eyes are still shaking.</afflictiondescription.concussion.low.self>
+<afflictiondescription.concussion.high.self>A massive headache, your ears are ringing and your eyes refuse to focus. It takes a lot of effort to stand upright.</afflictiondescription.concussion.high.self>
+<afflictiondescription.huskinfection.dormant.self>There’s an itch in your throat; the source seems to move around.</afflictiondescription.huskinfection.dormant.self>
+<afflictiondescription.huskinfection.transition.self>Something growing in your throat prevents you from talking; it’s freaking you out.</afflictiondescription.huskinfection.transition.self>
+<afflictiondescription.huskinfection.active.self>Deep down you know you should be worried about the thing chittering and moving about in your mouth. Yet, you feel oddly at peace.</afflictiondescription.huskinfection.active.self>
+<afflictiondescription.huskinfection.dormant.other>A faint clicking noise can be heard occasionally from within the patient.</afflictiondescription.huskinfection.dormant.other>
+<afflictiondescription.huskinfection.transition.other>The patient is eerily silent, save for occasional clicking sounds apparently emanating from deep within the throat.</afflictiondescription.huskinfection.transition.other>
+<afflictiondescription.huskinfection.active.other>Something dark and unpleasant moves in the mouth. They are rendered completely mute.</afflictiondescription.huskinfection.active.other>
+<afflictiondescription.huskinfection.final>Violent seizures signal the emergence of the husk.</afflictiondescription.huskinfection.final>
+<afflictiondescription.spaceherpes.self>You feel as ugly on the outside as they said you were on the inside. Karma strikes back?</afflictiondescription.spaceherpes.self>
+<afflictiondescription.invertcontrols.self>You seem to have two left feet, and your brain disagrees with both. It’s like trying to walk mirrored.</afflictiondescription.invertcontrols.self>
+<afflictiondescription.psychosis.low>The patient insists they saw a spider the other day, but seem otherwise healthy.</afflictiondescription.psychosis.low>
+<afflictiondescription.drunk.self>After all… why not? Why shouldn’t you have another drink?</afflictiondescription.drunk.self>
+<afflictiondescription.drunk.lethal.self>Is it time to lie down? Oh the infinite bliss of drowning out your sorrow…</afflictiondescription.drunk.lethal.self>
+<afflictiondescription.drunk.low>This crewmate is in high spirits, perhaps a bit too high to operate complex machinery.</afflictiondescription.drunk.low>
+<afflictiondescription.drunk.lethal>This crewmate has departed this world mentally, with a grin on their face. You fear the crewmate's life functions will soon depart as well.</afflictiondescription.drunk.lethal>
+<afflictiondescription.opiatewithdrawal.low>Teary-eyed, sweaty and fidgety, the craving is growing.</afflictiondescription.opiatewithdrawal.low>
+<afflictiondescription.opiateoverdose.self>You feel disoriented and struggle to breathe. The world is very cold, even colder than usual.</afflictiondescription.opiateoverdose.self>
+<afflictiondescription.opiateaddiction.self>You’re feeling good… so long as the next fix isn’t too far.</afflictiondescription.opiateaddiction.self>
+<afflictiondescription.radiationsickness.low.self>You feel feverish. Even your skin feels as though it’s on fire.</afflictiondescription.radiationsickness.low.self>
+<afflictiondescription.radiationsickness.high.self>You’ve never felt nausea like this, and your body aches all over.</afflictiondescription.radiationsickness.high.self>
+<afflictiondescription.radiationsickness.high>The patient can’t stop vomiting, and they’re showing ulcers and various soft tissue symptoms.</afflictiondescription.radiationsickness.high>
+<afflictiondescription.morbusinepoisoning.low.self>You have some trouble breathing.</afflictiondescription.morbusinepoisoning.low.self>
+<afflictiondescription.morbusinepoisoning.high.self>You’re gasping for air, but to no avail.</afflictiondescription.morbusinepoisoning.high.self>
+<afflictiondescription.morbusinepoisoning.low>The patient’s breathing seems irregular.</afflictiondescription.morbusinepoisoning.low>
+<afflictiondescription.sufforinpoisoning>The patient is seemingly sick, and without a prompt treatment they will only get worse.</afflictiondescription.sufforinpoisoning>
+<afflictiondescription.sufforinpoisoning.high>The patient has been poisoned and is unable to move. Unless an antidote is found, the patient will eventually die in agony.</afflictiondescription.sufforinpoisoning.high>
+<afflictiondescription.sufforinpoisoning.medium.self>Your vision seems to be getting blurry and you feel the urgent need to regurgitate.</afflictiondescription.sufforinpoisoning.medium.self>
+<afflictiondescription.sufforinpoisoning.low>The patient’s symptoms are barely detectable, but may indicate poisoning.</afflictiondescription.sufforinpoisoning.low>
+<afflictiondescription.deliriuminepoisoning.high.self>You see and hear things that aren't there. They're the effects of Deliriumine poisoning.</afflictiondescription.deliriuminepoisoning.high.self>
+<afflictiondescription.deliriuminepoisoning.high>The patient is manic, their eyes darting around wildly. They're wondering how you can be so calm, when everything around you is on fire…</afflictiondescription.deliriuminepoisoning.high>
+<afflictiondescription.cyanidepoisoning.medium.self>You feel very very wrong. Have you been poisoned?</afflictiondescription.cyanidepoisoning.medium.self>
+<afflictiondescription.cyanidepoisoning.high.self>You regret not having invested in antidotes for Cyanide poisoning. Now you die.</afflictiondescription.cyanidepoisoning.high.self>
+<afflictiondescription.cyanidepoisoning.low>Scanning the patient reveals Cyanide poisoning. Unless administered an antidote, this will be fatal.</afflictiondescription.cyanidepoisoning.low>
+<afflictiondescription.cyanidepoisoning.high>The patient's mouth is foaming and they are rendered unable to move. You could probably steal their valuables and get away with it…</afflictiondescription.cyanidepoisoning.high>
+<afflictiondescription.cyanidepoisoning>The patient is gasping, the skin is blue, and there are occasional muscle spasms all over the body. Their condition is decreasing rapidly.</afflictiondescription.cyanidepoisoning>
+<afflictiondescription.paralysis.low.self>You’re having trouble moving your limbs.</afflictiondescription.paralysis.low.self>
+<afflictiondescription.paralysis.high.self>You can’t move a muscle.</afflictiondescription.paralysis.high.self>
+<afflictiondescription.paralysis.high>The patient is completely paralyzed and unable to move.</afflictiondescription.paralysis.high>
+<afflictiondescription.nausea.low>Feeling queasy, but nothing a rest wouldn't fix.</afflictiondescription.nausea.low>
+<afflictiondescription.nausea.high>You are really sick. Should you worry about it or just rest?</afflictiondescription.nausea.high>
+<afflictiondescription.watchersgaze.self>You can’t shake it. It will always be there, staring. Would tearing out your own eyes make it go away?</afflictiondescription.watchersgaze.self>
+<afflictiondescription.hallucinating.low>There's something strange going on with your senses.</afflictiondescription.hallucinating.low>
+<afflictiondescription.reaperstax.self>You’re plagued by a sense of déjà vu, and it’s too real. Maybe you should be glad you can only remember your death, and not your birth.</afflictiondescription.reaperstax.self>
+
+<!-- Buffs -->
+<afflictionname.durationincrease>Slow metabolism</afflictionname.durationincrease>
+<afflictiondescription.durationincrease>Causes chemicals to last longer.</afflictiondescription.durationincrease>
+<afflictionname.haste>Hyperactivity</afflictionname.haste>
+<afflictiondescription.haste>Movement speed and reflexes are heightened.</afflictiondescription.haste>
+<afflictionname.huskinfectionresistance>Husk infection resistance</afflictionname.huskinfectionresistance>
+<afflictiondescription.huskinfectionresistance>Patient's immune system is more attuned to alien parasites.</afflictiondescription.huskinfectionresistance>
+<afflictionname.psychosisresistance>Psychosis resistance</afflictionname.psychosisresistance>
+<afflictiondescription.psychosisresistance>Patient exhibits high mental fortitude.</afflictiondescription.psychosisresistance>
+<afflictionname.pressureresistance>Pressure resistance</afflictionname.pressureresistance>
+<afflictiondescription.pressureresistance>Internal organs are more accustomed to high pressures.</afflictiondescription.pressureresistance>
+<afflictionname.strengthen>Vigor</afflictionname.strengthen>
+<afflictiondescription.strengthen>Patient's pain receptors are numbed.</afflictiondescription.strengthen>
+<afflictionname.paralysisresistance>Paralysis Resistance</afflictionname.paralysisresistance>
+<afflictiondescription.paralysisresistance>The patient's body is less affected by paralysis. It also seems to recover from any existing effects.</afflictiondescription.paralysisresistance>
+
+<!-- Genetic afflictions -->
+<afflictionname.increasedswimmingspeed>Crawler Genes</afflictionname.increasedswimmingspeed>
+<afflictiondescription.increasedswimmingspeed>Oxygen flows more freely into the subject's limbs, resulting in greater swimming speed.</afflictiondescription.increasedswimmingspeed>
+<afflictionname.naturalmeleeweapon>Mudraptor Genes</afflictionname.naturalmeleeweapon>
+<afflictiondescription.naturalmeleeweapon>A sharp beak is protruding from the subject's forehead.</afflictiondescription.naturalmeleeweapon>
+<afflictionname.naturalrangedweapon>Spineling Genes</afflictionname.naturalrangedweapon>
+<afflictiondescription.naturalrangedweapon>Sharp spikes are growing from the subject's back.</afflictiondescription.naturalrangedweapon>
+<afflictionname.damageresistance>Moloch Genes</afflictionname.damageresistance>
+<afflictiondescription.damageresistance>Subject's skin is hardened and more resistant to damage.</afflictiondescription.damageresistance>
+<afflictionname.decreasedoxygenconsumption>Tiger Thresher Genes</afflictionname.decreasedoxygenconsumption>
+<afflictiondescription.decreasedoxygenconsumption>Subject's lung capacity is grown, resulting in more efficient oxygen consumption.</afflictiondescription.decreasedoxygenconsumption>
+<afflictionname.increasedwalkingspeed>Mantis Genes</afflictionname.increasedwalkingspeed>
+<afflictiondescription.increasedwalkingspeed>Subject's bone structure is lighter, resulting in greater walking and running speed.</afflictiondescription.increasedwalkingspeed>
+<afflictionname.increasedmeleedamage>Hammerhead Genes</afflictionname.increasedmeleedamage>
+<afflictiondescription.increasedmeleedamage>Subject has gained muscle mass, resulting in greater strength.</afflictiondescription.increasedmeleedamage>
+<afflictionname.healdamage>Hammerhead Matriarch Genes</afflictionname.healdamage>
+<afflictiondescription.healdamage>Subject's wounds are healed at an accelerated rate.</afflictiondescription.healdamage>
+<afflictionname.vigorondamage>Mollusc Genes</afflictionname.vigorondamage>
+<afflictiondescription.vigorondamage>Subject's pain receptors are numbed in response to physical trauma.</afflictiondescription.vigorondamage>
+<afflictionname.hyperactivityondamage>Skitter Genes</afflictionname.hyperactivityondamage>
+<afflictiondescription.hyperactivityondamage>Subject's reflexes are heightened in response to physical trauma.</afflictiondescription.hyperactivityondamage>
+<afflictionname.increasedmeleedamageondamage>Hunter Genes</afflictionname.increasedmeleedamageondamage>
+<afflictiondescription.increasedmeleedamageondamage>Subject's adrenaline level is heightened in response to physical trauma.</afflictiondescription.increasedmeleedamageondamage>
+<afflictionname.increasedmeleedamage_temporary>Increased Melee Damage (Temporary)</afflictionname.increasedmeleedamage_temporary>
+<afflictionname.husktransformimmunity>Husk Genes</afflictionname.husktransformimmunity>
+<afflictiondescription.husktransformimmunity>Subject has gained a heightened tolerance for the husk parasite.</afflictiondescription.husktransformimmunity>
+<afflictionname.tunnelvision>Tunnel Vision</afflictionname.tunnelvision>
+<afflictiondescription.tunnelvision>Subject's eyes are sensitive to light.</afflictiondescription.tunnelvision>
+<afflictionname.rigidjoints>Rigid Joints</afflictionname.rigidjoints>
+<afflictiondescription.rigidjoints>Subject's joints are stiff and moving is more difficult.</afflictiondescription.rigidjoints>
+<afflictionname.hypersensitivity>Hypersensitivity</afflictionname.hypersensitivity>
+<afflictiondescription.hypersensitivity>Subject's skin is sore and more sensitive to touch.</afflictiondescription.hypersensitivity>
+<afflictionname.xenobiology>Xenobiology</afflictionname.xenobiology>
+<afflictiondescription.xenobiology>Subject's organs are resistant to traditional medicine.</afflictiondescription.xenobiology>
+<afflictionname.outsideinfluence>Outside Influence</afflictionname.outsideinfluence>
+<afflictiondescription.outsideinfluence>Subject hears unintelligible voices inside their head.</afflictiondescription.outsideinfluence>
+<afflictionname.glassjaw>Glass Jaw</afflictionname.glassjaw>
+<afflictiondescription.glassjaw>Subject suffers from longer periods of unconsciousness when knocked out.</afflictiondescription.glassjaw>
+<afflictionname.decrepify>Decrepify</afflictionname.decrepify>
+<afflictiondescription.decrepify>Subject's endurance is decreased.</afflictiondescription.decrepify>
+<afflictionname.musculardystrophy>Muscular Dystrophy</afflictionname.musculardystrophy>
+<afflictiondescription.musculardystrophy>Subject suffers from decreased muscle mass.</afflictiondescription.musculardystrophy>
+<afflictionname.inflamedlung>Inflamed Lung</afflictionname.inflamedlung>
+<afflictiondescription.inflamedlung>Subject has an adverse reaction to oxygen.</afflictiondescription.inflamedlung>
+
+<!-- Talent afflictions -->
+<afflictionname.regeneration>Regenerating</afflictionname.regeneration>
+<afflictiondescription.regeneration>The subject is slowly regaining their vitality.</afflictiondescription.regeneration>
+<afflictionname.repairflow>In the Flow</afflictionname.repairflow>
+<afflictiondescription.repairflow>The subject is in the flow, and able to repair devices effortlessly.</afflictiondescription.repairflow>
+<afflictionname.evasivemaneuvers>Emergency Maneuvers</afflictionname.evasivemaneuvers>
+<afflictiondescription.evasivemaneuvers>The subject has momentarily become a much better captain.</afflictiondescription.evasivemaneuvers>
+<afflictionname.skedaddle>Skedaddle</afflictionname.skedaddle>
+<afflictiondescription.skedaddle>The subject is skedaddling away!</afflictiondescription.skedaddle>
+<afflictionname.stonewall>Stonewall</afflictionname.stonewall>
+<afflictiondescription.stonewall>The subject has become sturdier and resistant to stuns.</afflictiondescription.stonewall>
+<afflictionname.clownpower>Clown Power</afflictionname.clownpower>
+<afflictiondescription.clownpower>Only by wearing the mask is the true self revealed.</afflictiondescription.clownpower>
+<afflictionname.soothingsounds>Soothing Sounds</afflictionname.soothingsounds>
+<afflictiondescription.soothingsounds>The sounds of clownery have a healing effect on the subject.</afflictiondescription.soothingsounds>
+<afflictionname.inspiringtunes>Inspiring Tunes</afflictionname.inspiringtunes>
+<afflictiondescription.inspiringtunes>The subject's skills are momentarily increased.</afflictiondescription.inspiringtunes>
+<afflictionname.tandemfire>Tandem Fire</afflictionname.tandemfire>
+<afflictiondescription.tandemfire>The subject is gaining combat effectiveness from being near an inspiring ally.</afflictiondescription.tandemfire>
+<afflictionname.tumbling>Tumbling</afflictionname.tumbling>
+<afflictiondescription.tumbling>The subject's effectiveness with pistols is increased.</afflictiondescription.tumbling>
+<afflictionname.quickdrawing>Ready to Draw</afflictionname.quickdrawing>
+<afflictiondescription.quickdrawing>The subject is prepared to draw.</afflictiondescription.quickdrawing>
+<afflictionname.dashing>Dashing</afflictionname.dashing>
+<afflictiondescription.dashing>The subject is moving forward, quickly.</afflictiondescription.dashing>
+<afflictionname.inspiredtoact>Inspired to Act</afflictionname.inspiredtoact>
+<afflictiondescription.inspiredtoact>The subject, ordered by their captain, has become stalwart and able!</afflictiondescription.inspiredtoact>
+<afflictionname.welldrilled>Well-drilled</afflictionname.welldrilled>
+<afflictiondescription.welldrilled>The subject, ordered by their captain, has become better at ship repairs and maintenance.</afflictiondescription.welldrilled>
+<afflictionname.battleready>Battle-ready</afflictionname.battleready>
+<afflictiondescription.battleready>The subject, ordered by their captain, is now a much better warrior.</afflictiondescription.battleready>
+<afflictionname.downwiththeship>Down with the Ship</afflictionname.downwiththeship>
+<afflictiondescription.downwiththeship>The subject refuses to abandon ship, and will do anything to restore it to its former glory.</afflictiondescription.downwiththeship>
+<afflictionname.powerattack>Powerattacking</afflictionname.powerattack>
+<afflictiondescription.powerattack>The subject is about to unleash a powerful attack.</afflictiondescription.powerattack>
+<afflictionname.pickinguptheslack>Picking Up the Slack</afflictionname.pickinguptheslack>
+<afflictiondescription.pickinguptheslack>The subject feels they must work a bit harder to make up for someone else.</afflictiondescription.pickinguptheslack>
+<afflictionname.pyromania>Pyromania</afflictionname.pyromania>
+<afflictiondescription.pyromania>The subject is enjoying the smell of searing flesh a bit too much.</afflictiondescription.pyromania>
+<afflictionname.tinkerexhaustion>Tinker Exhaustion</afflictionname.tinkerexhaustion>
+<afflictiondescription.tinkerexhaustion>The subject can't tinker with any more devices for the time being.</afflictiondescription.tinkerexhaustion>
+<afflictionname.bedsidemanner>Vitamin Supplements</afflictionname.bedsidemanner>
+<afflictiondescription.bedsidemanner>The subject is feeling very healthy.</afflictiondescription.bedsidemanner>
+<afflictionname.guarded>Guarded</afflictionname.guarded>
+<afflictiondescription.guarded>The subject is prepared for the next attack on them.</afflictiondescription.guarded>
+<afflictionname.skillfulmelodies>Skillful Melodies</afflictionname.skillfulmelodies>
+<afflictiondescription.skillfulmelodies>The subject has become better at learning.</afflictiondescription.skillfulmelodies>
+<afflictionname.combatstimulant>Combat Stimulant</afflictionname.combatstimulant>
+<afflictiondescription.combatstimulant>Gaining combat-based performance-boosting abilities.</afflictiondescription.combatstimulant>
+<afflictionname.chemaddiction>Chem addiction</afflictionname.chemaddiction>
+<afflictiondescription.chemaddiction>The patient has grown dependent on performance-boosting drugs.</afflictiondescription.chemaddiction>
+<afflictionname.chemwithdrawal>Chem withdrawal</afflictionname.chemwithdrawal>
+<afflictiondescription.chemwithdrawal>The patient sweats and twitches a lot, likely craving their next fix.</afflictiondescription.chemwithdrawal>
+<afflictionname.pressurestabilized>Pressure Stabilized</afflictionname.pressurestabilized>
+<afflictiondescription.pressurestabilized>The subject is immune to pressure and has no need for oxygen at this time.</afflictiondescription.pressurestabilized>
+<afflictionname.endocrineboost>Endocrine Boost</afflictionname.endocrineboost>
+<afflictiondescription.endocrineboost>The subject has gained heightened capabilities, permanently.</afflictiondescription.endocrineboost>
+<afflictionname.physicaldamage>Physical damage</afflictionname.physicaldamage>
+<afflictionname.implacable>Implacable</afflictionname.implacable>
+<afflictiondescription.implacable>The subject is unable to fall unconscious.</afflictiondescription.implacable>
+<afflictionname.lonewolf>Lone Wolf</afflictionname.lonewolf>
+<afflictiondescription.lonewolf>You thrive in isolation. Without interference of others, your capabilities are enhanced.</afflictiondescription.lonewolf>
+<afflictionname.deputy>Deputy</afflictionname.deputy>
+<afflictiondescription.deputy>Your captain trusts you to take care of the sub in case of their absence. You wouldn't let them down.</afflictiondescription.deputy>
+<afflictionname.highmorale>High Morale</afflictionname.highmorale>
+<afflictiondescription.highmorale>Your captain is leading by example. You feel confident and energetic.</afflictiondescription.highmorale>
+<afflictionname.excellentmorale>Excellent Morale</afflictionname.excellentmorale>
+<afflictiondescription.excellentmorale>This crew is like a family to you. Nobody messes with your little submarine family.</afflictiondescription.excellentmorale>
+<afflictionname.inspirationalleader>Inspirational Leader</afflictionname.inspirationalleader>
+<afflictiondescription.inspirationalleader>Your captain inspires and encourages you to learn.</afflictiondescription.inspirationalleader>
+<afflictionname.inspiringpresence>Notice me</afflictionname.inspiringpresence>
+<afflictiondescription.inspiringpresence>The presence of your captain makes you eager to impress.</afflictiondescription.inspiringpresence>
+<afflictionname.genetampering>Gene Tampering</afflictionname.genetampering>
+<afflictiondescription.genetampering>Your medical doctor has tampered with your genes, eliminating minor health issues.</afflictiondescription.genetampering>
+<afflictionname.emergencyresponse>Emergency Response</afflictionname.emergencyresponse>
+<afflictiondescription.emergencyresponse>It's fortunate food is scarce. It makes crewmmates that much easier to carry to safety.</afflictiondescription.emergencyresponse>
+<afflictionname.medicalassistance>Medical Assistant</afflictionname.medicalassistance>
+<afflictiondescription.medicalassistance>As long as you follow the Doctor's instructions, the patient will be fine.</afflictiondescription.medicalassistance>
+<afflictionname.miracleworker>Miracle In Progress</afflictionname.miracleworker>
+<afflictiondescription.miracleworker>Your lifeforces are fading, yet one Doctor shines bright like a beacon. While they're nearby, you won't give in.</afflictiondescription.miracleworker>
+<afflictionname.quickfixer>Quickfixer</afflictionname.quickfixer>
+<afflictiondescription.quickfixer>Gotta go speedily.</afflictiondescription.quickfixer>
+<afflictionname.berserker>Berserker</afflictionname.berserker>
+<afflictiondescription.berserker>They've bruised your body and, more importantly, your ego. You'll make them pay. Deal more damage.</afflictiondescription.berserker>
+<afflictionname.foolhardy>Foolhardy</afflictionname.foolhardy>
+<afflictiondescription.foolhardy>Dang, they sure gave you a beating. But what doesn't kill you makes you stronger. Resist some physical damage.</afflictiondescription.foolhardy>
+<afflictionname.revengesquad>Revenge Squad</afflictionname.revengesquad>
+<afflictiondescription.revengesquad>They killed our assistant. You don't remember their name, but you will avenge them. Temporarily take reduced damage.</afflictiondescription.revengesquad>
+<afflictionname.journeyman>Journeyman</afflictionname.journeyman>
+<afflictiondescription.journeyman>Once an apprentice proves their skill, they can efficiently help the professionals. Gain your primary skill faster.</afflictiondescription.journeyman>
+<afflictionname.loyalassistant>Loyal Assistant</afflictionname.loyalassistant>
+<afflictiondescription.loyalassistant>A friend is someone who walks into a room when everyone else is walking out. A loyal assistant keeps working even when you walk out. Increases your crafting quality.</afflictiondescription.loyalassistant>
+<afflictionname.disloyalscum>Treacherous Assistant</afflictionname.disloyalscum>
+<afflictiondescription.disloyalscum>The assistant's dedication to their apprenticeship and their master leaves a lot to be desired, but hanging out with the other crew boosts their efficiency. Repairing and skill gains are increased.</afflictiondescription.disloyalscum>
+
+<!-- Jobs -->
+<jobname.captain>Captain</jobname.captain>
+<jobdescription.captain>The commanding officer is responsible for commanding the entirety of the crew and ensuring that everything is running smoothly.</jobdescription.captain>
+<jobname.engineer>Engineer</jobname.engineer>
+<jobdescription.engineer>Engineers are the backbone of a submarine's crew, complementing a mechanic's mechanical engineering skill with their knowledge of electrical engineering. They are capable of performing maintenance on the various electrical pieces of the submarine.</jobdescription.engineer>
+<jobname.mechanic>Mechanic</jobname.mechanic>
+<jobdescription.mechanic>Mechanics are capable of fixing various mechanical devices with their high mechanical engineering skill. Together with engineers they ensure a submarine is working to its fullest.</jobdescription.mechanic>
+<jobname.securityofficer>Security Officer</jobname.securityofficer>
+<jobdescription.securityofficer>Security Officers are responsible for keeping the submarine safe from threats, both external and internal. The creatures inhabiting the ocean aren't the only threat they need to worry about, as several of the renegade groups opposing the Europa Coalition are known to have sent infiltrators on board the vessels.</jobdescription.securityofficer>
+<jobname.medicaldoctor>Medical Doctor</jobname.medicaldoctor>
+<jobdescription.medicaldoctor>Although usually taken for granted, doctors play an important role on the submarine, possessing the required skill to treat injured or unconscious crewmembers. Their skills can also be useful for creating various non-medicinal chemicals.</jobdescription.medicaldoctor>
+<jobname.assistant>Assistant</jobname.assistant>
+<jobdescription.assistant>Assistants don't have any specific responsibilities or areas of expertise. This job is a good choice for newcomers who want to get a hang of working on board the submarine without taking up tasks that they aren't qualified for.</jobdescription.assistant>
+<jobname.watchman>Watchman</jobname.watchman>
+<jobdescription.watchman></jobdescription.watchman>
+<jobname.captain1>Veteran</jobname.captain1>
+<jobname.captain2>Renegade</jobname.captain2>
+<jobname.captain3>Admiral</jobname.captain3>
+<jobname.engineer1>Nuclear engineer</jobname.engineer1>
+<jobname.engineer2>Electrical engineer</jobname.engineer2>
+<jobname.mechanic1>Welder</jobname.mechanic1>
+<jobname.mechanic2>Fabricator</jobname.mechanic2>
+<jobname.securityofficer1>Commando</jobname.securityofficer1>
+<jobname.securityofficer2>Peacekeeper</jobname.securityofficer2>
+<jobname.securityofficer3>Gunner</jobname.securityofficer3>
+<jobname.medicaldoctor1>First responder</jobname.medicaldoctor1>
+<jobname.medicaldoctor2>Pharmacologist</jobname.medicaldoctor2>
+<jobname.prisoner>Prisoner</jobname.prisoner>
+<jobname.commoner>Commoner</jobname.commoner>
+<jobname.vip>VIP</jobname.vip>
+<jobname.vipsecurityofficer>Bodyguard</jobname.vipsecurityofficer>
+<jobdescription.captain1>A veteran of Europan seas, this captain either inspires loyalty in their crew or keeps them in line by force.</jobdescription.captain1>
+<jobdescription.captain2>Renegade captains are a thorn in the establishment's side. They use a combination of daring and aggressive maneuvers to keep the Coalition off balance.</jobdescription.captain2>
+<jobdescription.captain3>Captains of the Coalition adhere to a strict set of rules. That doesn't stop them from coming up with new innovations to hunt down their enemies.</jobdescription.captain3>
+<jobdescription.engineer1>Nuclear engineers are in charge of the sub's reactor. Occupational hazards require them to wear some protective gear against radiation.</jobdescription.engineer1>
+<jobdescription.engineer2>The submarine's fickle electrical systems need constant maintenance. The dubious honor of replacing fuses, hooking up devices with power and taking numerous electric shocks falls to electrical engineers.</jobdescription.engineer2>
+<jobdescription.mechanic1>A mechanic's primary job in Europa is to plug leaks wherever they appear. These guys are trained to keep the hull, devices and equipment in shape.</jobdescription.mechanic1>
+<jobdescription.mechanic2>A mechanic variant that specializes in making art (and supplies) out of crude materials.</jobdescription.mechanic2>
+<jobdescription.securityofficer1>Commandos are a special breed of security officer. They only have a single purpose: Destroy the enemy, whether it's at range or mano a mano.</jobdescription.securityofficer1>
+<jobdescription.securityofficer2>These peacekeepers are dedicated to keeping the peace at any cost. Preferably but not necessarily using non-lethal force.</jobdescription.securityofficer2>
+<jobdescription.securityofficer3>Submarine gunners are trained not only to shoot accurately with coil and railguns but also to keep them in working condition.</jobdescription.securityofficer3>
+<jobdescription.medicaldoctor1>Administering first aid often requires venturing into dangerous areas. These front-line medics have gear that offers them some protection against monsters and guns, while not compromising their mobility.</jobdescription.medicaldoctor1>
+<jobdescription.medicaldoctor2>These doctors are prepared to treat most, if not all, injuries that threaten the crew on lengthy trips underwater.</jobdescription.medicaldoctor2>
+<startingequipmentname>Loadout #[number]</startingequipmentname>
+<npctitle.piratecaptain>Pirate Captain</npctitle.piratecaptain>
+<npctitle.piratecaptainlord>Pirate Lord</npctitle.piratecaptainlord>
+<npctitle.piratesecurityrecruit>Pirate Recruit</npctitle.piratesecurityrecruit>
+<npctitle.piratesecuritygunner>Pirate Gunner</npctitle.piratesecuritygunner>
+<npctitle.piratesecuritybrute>Pirate Brute</npctitle.piratesecuritybrute>
+<npctitle.piratesecurityelite>Pirate Elite</npctitle.piratesecurityelite>
+<npctitle.piratemechanicveteran>Pirate Technician</npctitle.piratemechanicveteran>
+<npctitle.pirateengineerveteran>Pirate Physicist</npctitle.pirateengineerveteran>
+<npctitle.piratemechanicrecruit>Pirate Mechanic</npctitle.piratemechanicrecruit>
+<npctitle.pirateengineerrecruit>Pirate Engineer</npctitle.pirateengineerrecruit>
+<npctitle.huskextremist>Husk Extremist</npctitle.huskextremist>
+<npctitle.huskextremist_leader>Extremist Chief Scientist</npctitle.huskextremist_leader>
+
+<!-- Locations -->
+<locationname.none></locationname.none>
+<locationnameformat.none>[name]</locationnameformat.none>
+<locationchange.none.changeto.outpost>A group of settlers has ventured into [previousname] and established a new outpost.</locationchange.none.changeto.outpost>
+<locationchange.none.changeto.military>A new military outpost has been established at [previousname].</locationchange.none.changeto.military>
+<locationchange.none.changeto.research>A new research outpost has been established at [previousname].</locationchange.none.changeto.research>
+<locationname.city>Colony</locationname.city>
+<locationnameformat.city>[name]</locationnameformat.city>
+<locationnameformat.city>The city of [name]</locationnameformat.city>
+<locationnameformat.city>[name] City</locationnameformat.city>
+<locationnameformat.city>[name] Station</locationnameformat.city>
+<locationname.outpost>Habitation Outpost</locationname.outpost>
+<locationnameformat.outpost>[name] Habitation Outpost</locationnameformat.outpost>
+<locationnameformat.outpost>[name] Outpost</locationnameformat.outpost>
+<locationchange.outpost.changeto.city>[previousname] has become [name].</locationchange.outpost.changeto.city>
+<locationchange.outpost.changeto.city>[previousname] has become a city.</locationchange.outpost.changeto.city>
+<locationname.military>Military Outpost</locationname.military>
+<locationnameformat.military>[name]</locationnameformat.military>
+<locationnameformat.military>[name] Facility</locationnameformat.military>
+<locationnameformat.military>[name] Station</locationnameformat.military>
+<locationnameformat.military>[name] Fortification</locationnameformat.military>
+<locationname.research>Research Outpost</locationname.research>
+<locationnameformat.research>[name] Research Facility</locationnameformat.research>
+<locationnameformat.research>[name] Research Center</locationnameformat.research>
+<locationnameformat.research>[name] Institute of Astrobiology</locationnameformat.research>
+<locationnameformat.research>[name] Biomedical Research Center</locationnameformat.research>
+<locationname.mine>Mining Outpost</locationname.mine>
+<locationnameformat.mine>[name] Mining Facility</locationnameformat.mine>
+<locationnameformat.mine>[name] Mining Claim</locationnameformat.mine>
+<locationnameformat.mine>[name] Prospecting Outpost</locationnameformat.mine>
+<locationnameformat.mine>[name] Mine</locationnameformat.mine>
+<locationname.lair>Breeding Grounds</locationname.lair>
+<locationnameformat.lair>[name] Breeding Grounds</locationnameformat.lair>
+<locationnameformat.lair>The Hives of [name]</locationnameformat.lair>
+<locationchange.lair.changeto.none>[previousname] has been rid of its monster lair and is now safe for colonization.</locationchange.lair.changeto.none>
+<locationname.ruins>Alien Ruins</locationname.ruins>
+<locationnameformat.ruins>[name] Ruins</locationnameformat.ruins>
+<locationchange.ruins.changeto.outpost>An outpost has been established at [previousname].</locationchange.ruins.changeto.outpost>
+<locationchange.ruins.changeto.military>A military outpost has been established at [previousname].</locationchange.ruins.changeto.military>
+<locationchange.ruins.changeto.research>A research outpost has been established at [previousname].</locationchange.ruins.changeto.research>
+<locationchange.outpost.changeto.military>A coalition force has moved into [previousname], establishing a military presence in the area.</locationchange.outpost.changeto.military>
+<locationchange.outpost.changeto.research>A band of researchers have turned [previousname] into a research station to study the surrounding fauna.</locationchange.outpost.changeto.research>
+<locationchange.outpost.changeto.mine>Mining operations have begun at [previousname].</locationchange.outpost.changeto.mine>
+<locationchange.military.changeto.city>The commander at [previousname] has been appointed governor, making [name] officially a city.</locationchange.military.changeto.city>
+<locationchange.research.changeto.city>Research laboratories at [previousname] have driven more settlers to move in. It is now known as [name].</locationchange.research.changeto.city>
+<locationchange.mine.changeto.city>Families of miners at [previousname] have moved in and turned it into a proper city.</locationchange.mine.changeto.city>
+<locationname.explored>Explored Location</locationname.explored>
+<locationnameformat.explored>[name]</locationnameformat.explored>
+<cave>Cave</cave>
+<locationname.abandoned>Abandoned Outpost</locationname.abandoned>
+<locationnameformat.abandoned>[name] Outpost</locationnameformat.abandoned>
+<locationchange.outpost.changeto.abandoned>[previousname] has been abandoned.</locationchange.outpost.changeto.abandoned>
+<locationchange.outpost.changeto.abandoned>Contact has been lost to [previousname].</locationchange.outpost.changeto.abandoned>
+<locationdescription.none>Uninhabited, a potential location for an outpost.</locationdescription.none>
+<locationdescription.city>Bristling with activity and no shortage of supplies.</locationdescription.city>
+<locationdescription.outpost>Average-sized outpost, without any specialization.</locationdescription.outpost>
+<locationdescription.military>Offers an abundance of military hardware.</locationdescription.military>
+<locationdescription.research>Offers rare and exotic items.</locationdescription.research>
+<locationdescription.mine>Offers raw materials at discount prices.</locationdescription.mine>
+<locationdescription.abandoned>Contact was lost with this outpost.\nRe-establishing contact or eliminating a threat here could net you money.</locationdescription.abandoned>
+<advancedsub.all>Tier [tiernumber] submarines available.</advancedsub.all>
+<advancedsub.attack>Tier [tiernumber] Attack submarines available.</advancedsub.attack>
+<advancedsub.scout>Tier [tiernumber] Scout submarines available.</advancedsub.scout>
+<advancedsub.transport>Tier [tiernumber] Transport submarines available.</advancedsub.transport>
+<advancedsub.none>No submarines available.</advancedsub.none>
+<locationname.generic.0>Adonis Linea</locationname.generic.0>
+<locationname.generic.1>Agave Linea</locationname.generic.1>
+<locationname.generic.2>Agenor Linea</locationname.generic.2>
+<locationname.generic.3>Alkonost</locationname.generic.3>
+<locationname.generic.4>Alphesiboea Linea</locationname.generic.4>
+<locationname.generic.5>Ana</locationname.generic.5>
+<locationname.generic.6>Androgeos Linea</locationname.generic.6>
+<locationname.generic.7>Anid</locationname.generic.7>
+<locationname.generic.8>Annwn</locationname.generic.8>
+<locationname.generic.9>Apep</locationname.generic.9>
+<locationname.generic.10>Argadnel</locationname.generic.10>
+<locationname.generic.11>Argiope Linea</locationname.generic.11>
+<locationname.generic.12>Arid Troma</locationname.generic.12>
+<locationname.generic.13>Arnthor</locationname.generic.13>
+<locationname.generic.14>Asmundur</locationname.generic.14>
+<locationname.generic.15>Asterius Linea</locationname.generic.15>
+<locationname.generic.16>Astypalaea Linea</locationname.generic.16>
+<locationname.generic.17>Attis</locationname.generic.17>
+<locationname.generic.18>Autonoe Linea</locationname.generic.18>
+<locationname.generic.19>Balagtan</locationname.generic.19>
+<locationname.generic.20>Bast</locationname.generic.20>
+<locationname.generic.21>Beenalaght Fossa</locationname.generic.21>
+<locationname.generic.22>Belenos Mensa</locationname.generic.22>
+<locationname.generic.23>Belus Linea</locationname.generic.23>
+<locationname.generic.24>Berith</locationname.generic.24>
+<locationname.generic.25>Borvo Mensa</locationname.generic.25>
+<locationname.generic.26>Butterdon Linea</locationname.generic.26>
+<locationname.generic.27>Cadmus Linea</locationname.generic.27>
+<locationname.generic.28>Callanish</locationname.generic.28>
+<locationname.generic.29>Cilicia Flexus</locationname.generic.29>
+<locationname.generic.30>Corick Linea</locationname.generic.30>
+<locationname.generic.31>Cylymala</locationname.generic.31>
+<locationname.generic.32>Dagrun</locationname.generic.32>
+<locationname.generic.33>Delphi Flexus</locationname.generic.33>
+<locationname.generic.34>Drizzlecomb Linea</locationname.generic.34>
+<locationname.generic.35>Drumskinny Linea</locationname.generic.35>
+<locationname.generic.36>Dyfed</locationname.generic.36>
+<locationname.generic.37>Echion Linea</locationname.generic.37>
+<locationname.generic.38>Eightercua Fossa</locationname.generic.38>
+<locationname.generic.39>Embla</locationname.generic.39>
+<locationname.generic.40>Euphemus Linea</locationname.generic.40>
+<locationname.generic.41>Falga</locationname.generic.41>
+<locationname.generic.42>Glaukos Linea</locationname.generic.42>
+<locationname.generic.43>Gortyna Flexus</locationname.generic.43>
+<locationname.generic.44>Grannus Mensa</locationname.generic.44>
+<locationname.generic.45>Guthlaug</locationname.generic.45>
+<locationname.generic.46>Harmonia Linea</locationname.generic.46>
+<locationname.generic.47>Hyldemoer</locationname.generic.47>
+<locationname.generic.48>Hyperenor Linea</locationname.generic.48>
+<locationname.generic.49>Ino Linea</locationname.generic.49>
+<locationname.generic.50>Jaavuari</locationname.generic.50>
+<locationname.generic.51>Jokull</locationname.generic.51>
+<locationname.generic.52>Katreus Linea</locationname.generic.52>
+<locationname.generic.53>Kennet Linea</locationname.generic.53>
+<locationname.generic.54>Kerlescan Fossa</locationname.generic.54>
+<locationname.generic.55>Kermario Fossa</locationname.generic.55>
+<locationname.generic.56>Libya Linea</locationname.generic.56>
+<locationname.generic.57>Maughanasilly Fossa</locationname.generic.57>
+<locationname.generic.58>Mehen Linea</locationname.generic.58>
+<locationname.generic.59>Merrivale Linea</locationname.generic.59>
+<locationname.generic.60>Milda</locationname.generic.60>
+<locationname.generic.61>Minos Linea</locationname.generic.61>
+<locationname.generic.62>Moyle Cavus</locationname.generic.62>
+<locationname.generic.63>Moytura</locationname.generic.63>
+<locationname.generic.64>Menec Fossa</locationname.generic.64>
+<locationname.generic.65>New Iapetus</locationname.generic.65>
+<locationname.generic.66>Noctae</locationname.generic.66>
+<locationname.generic.67>Nome</locationname.generic.67>
+<locationname.generic.68>Nwoska</locationname.generic.68>
+<locationname.generic.69>Onga Linea</locationname.generic.69>
+<locationname.generic.70>Oshan</locationname.generic.70>
+<locationname.generic.71>Paaru</locationname.generic.71>
+<locationname.generic.72>Pelagon Linea</locationname.generic.72>
+<locationname.generic.73>Pelorus Linea</locationname.generic.73>
+<locationname.generic.74>Phineus Linea</locationname.generic.74>
+<locationname.generic.75>Phocis Flexus</locationname.generic.75>
+<locationname.generic.76>Phoenix Linea</locationname.generic.76>
+<locationname.generic.77>Powys</locationname.generic.77>
+<locationname.generic.78>Rhadamanthys Linea</locationname.generic.78>
+<locationname.generic.79>Sarpedon Linea</locationname.generic.79>
+<locationname.generic.80>Set</locationname.generic.80>
+<locationname.generic.81>Sharpitor Linea</locationname.generic.81>
+<locationname.generic.82>Sidon Flexus</locationname.generic.82>
+<locationname.generic.83>Skaani</locationname.generic.83>
+<locationname.generic.84>Sontu</locationname.generic.84>
+<locationname.generic.85>Sparti Linea</locationname.generic.85>
+<locationname.generic.86>Staldon Linea</locationname.generic.86>
+<locationname.generic.87>Tara</locationname.generic.87>
+<locationname.generic.88>Tectamus Linea</locationname.generic.88>
+<locationname.generic.89>Telephassa Linea</locationname.generic.89>
+<locationname.generic.90>Thasus Linea</locationname.generic.90>
+<locationname.generic.91>Thorarinn</locationname.generic.91>
+<locationname.generic.92>Thrudur</locationname.generic.92>
+<locationname.generic.93>Thynia Linea</locationname.generic.93>
+<locationname.generic.94>Topol</locationname.generic.94>
+<locationname.generic.95>Tormsdale Linea</locationname.generic.95>
+<locationname.generic.96>Tyre</locationname.generic.96>
+<locationname.generic.97>Udaeus Linea</locationname.generic.97>
+<locationname.generic.98>Vorta</locationname.generic.98>
+<locationname.generic.99>Yasa</locationname.generic.99>
+<locationname.generic.100>Yelland Linea</locationname.generic.100>
+<locationname.city.0>Alkonost</locationname.city.0>
+<locationname.city.1>Ana</locationname.city.1>
+<locationname.city.2>Anid</locationname.city.2>
+<locationname.city.3>Apep</locationname.city.3>
+<locationname.city.4>Arid Troma</locationname.city.4>
+<locationname.city.5>Attis</locationname.city.5>
+<locationname.city.6>Aylesbury</locationname.city.6>
+<locationname.city.7>Bast</locationname.city.7>
+<locationname.city.8>Berith</locationname.city.8>
+<locationname.city.9>Binnsmouth</locationname.city.9>
+<locationname.city.10>Bramerton</locationname.city.10>
+<locationname.city.11>Brunhes</locationname.city.11>
+<locationname.city.12>Chandelle Crevasse</locationname.city.12>
+<locationname.city.13>Couwola</locationname.city.13>
+<locationname.city.14>Dank</locationname.city.14>
+<locationname.city.15>Dolgovskoy</locationname.city.15>
+<locationname.city.16>Dunwice</locationname.city.16>
+<locationname.city.17>Erlangshen</locationname.city.17>
+<locationname.city.18>Gangpo</locationname.city.18>
+<locationname.city.19>Huronia</locationname.city.19>
+<locationname.city.20>Hyldemoer</locationname.city.20>
+<locationname.city.21>Kimju</locationname.city.21>
+<locationname.city.22>Kogavostok</locationname.city.22>
+<locationname.city.23>Krytogorsk</locationname.city.23>
+<locationname.city.24>Kury</locationname.city.24>
+<locationname.city.25>Meltwater</locationname.city.25>
+<locationname.city.26>Milda</locationname.city.26>
+<locationname.city.27>Molovsk</locationname.city.27>
+<locationname.city.28>Moulin</locationname.city.28>
+<locationname.city.29>New Nanhui</locationname.city.29>
+<locationname.city.30>New Siberia</locationname.city.30>
+<locationname.city.31>Newellstead</locationname.city.31>
+<locationname.city.32>Nome</locationname.city.32>
+<locationname.city.33>Novaya Moskva</locationname.city.33>
+<locationname.city.34>Oshan</locationname.city.34>
+<locationname.city.35>Pastonia</locationname.city.35>
+<locationname.city.36>Randkluft</locationname.city.36>
+<locationname.city.37>Riville</locationname.city.37>
+<locationname.city.38>Salthole</locationname.city.38>
+<locationname.city.39>Seosu</locationname.city.39>
+<locationname.city.40>Serac</locationname.city.40>
+<locationname.city.41>Sermilik</locationname.city.41>
+<locationname.city.42>Set</locationname.city.42>
+<locationname.city.43>Shinkonai</locationname.city.43>
+<locationname.city.44>Skaani</locationname.city.44>
+<locationname.city.45>Skadi's Cauldron</locationname.city.45>
+<locationname.city.46>Sontu</locationname.city.46>
+<locationname.city.47>St. May</locationname.city.47>
+<locationname.city.48>St. Musk</locationname.city.48>
+<locationname.city.49>Tara</locationname.city.49>
+<locationname.city.50>Thaw</locationname.city.50>
+<locationname.city.51>The Bucket</locationname.city.51>
+<locationname.city.52>Topol</locationname.city.52>
+<locationname.city.53>Undermoist</locationname.city.53>
+<locationname.city.54>Uusi-Turcu</locationname.city.54>
+<locationname.city.55>Vellamo's Crevasse</locationname.city.55>
+<locationname.city.56>Versas</locationname.city.56>
+<locationname.city.57>Vorta</locationname.city.57>
+<locationname.city.58>Wolstone</locationname.city.58>
+<locationname.city.59>Worm Cave</locationname.city.59>
+<locationname.city.60>Xinzou</locationname.city.60>
+<locationname.city.61>Zamoroska</locationname.city.61>
+<locationname.alien.0>Aegirsgrave</locationname.alien.0>
+<locationname.alien.1>Aitreles</locationname.alien.1>
+<locationname.alien.2>Amar</locationname.alien.2>
+<locationname.alien.3>Arran Chaos</locationname.alien.3>
+<locationname.alien.4>Ashvini II</locationname.alien.4>
+<locationname.alien.5>Baal's Vent</locationname.alien.5>
+<locationname.alien.6>Baluni</locationname.alien.6>
+<locationname.alien.7>Bathakon</locationname.alien.7>
+<locationname.alien.8>Begorot</locationname.alien.8>
+<locationname.alien.9>Boeotia Macula</locationname.alien.9>
+<locationname.alien.10>Brullu</locationname.alien.10>
+<locationname.alien.11>Calyx Cave</locationname.alien.11>
+<locationname.alien.12>Castalia Macula</locationname.alien.12>
+<locationname.alien.13>Chmi</locationname.alien.13>
+<locationname.alien.14>Chthonius Linea</locationname.alien.14>
+<locationname.alien.15>Conamara Chaos</locationname.alien.15>
+<locationname.alien.16>Cyclades Macula</locationname.alien.16>
+<locationname.alien.17>Dondar</locationname.alien.17>
+<locationname.alien.18>Drool</locationname.alien.18>
+<locationname.alien.19>Galpus</locationname.alien.19>
+<locationname.alien.20>Gegir</locationname.alien.20>
+<locationname.alien.21>Gerra</locationname.alien.21>
+<locationname.alien.22>Gleeu Kalach</locationname.alien.22>
+<locationname.alien.23>Gope</locationname.alien.23>
+<locationname.alien.24>Graoklost</locationname.alien.24>
+<locationname.alien.25>Hadal Crevasse</locationname.alien.25>
+<locationname.alien.26>Hecta</locationname.alien.26>
+<locationname.alien.27>Hullsbane</locationname.alien.27>
+<locationname.alien.28>Ihegga</locationname.alien.28>
+<locationname.alien.29>Kecnash</locationname.alien.29>
+<locationname.alien.30>Kyklis</locationname.alien.30>
+<locationname.alien.31>Malcam's Cauldron</locationname.alien.31>
+<locationname.alien.32>Mandel Wastes</locationname.alien.32>
+<locationname.alien.33>Mori</locationname.alien.33>
+<locationname.alien.34>Murias Chaos</locationname.alien.34>
+<locationname.alien.35>Narbeth Chaos</locationname.alien.35>
+<locationname.alien.36>Naur</locationname.alien.36>
+<locationname.alien.37>Nythra</locationname.alien.37>
+<locationname.alien.38>Orlonsgrave</locationname.alien.38>
+<locationname.alien.39>R'lyeh</locationname.alien.39>
+<locationname.alien.40>Rathmore Chaos</locationname.alien.40>
+<locationname.alien.41>Sabbati Macula</locationname.alien.41>
+<locationname.alien.42>Sierpinsk</locationname.alien.42>
+<locationname.alien.43>Soggoth Crevasse</locationname.alien.43>
+<locationname.alien.44>Thera Macula</locationname.alien.44>
+<locationname.alien.45>Thotep Chaos</locationname.alien.45>
+<locationname.alien.46>Thrace Macula</locationname.alien.46>
+<locationname.alien.47>Tnaboe</locationname.alien.47>
+<locationname.alien.48>Untarktika</locationname.alien.48>
+<locationname.alien.49>Vermo</locationname.alien.49>
+<locationname.alien.50>Vulbass</locationname.alien.50>
+
+<!-- Biomes -->
+<biome>Biome</biome>
+<biomename.coldcaverns>Cold Caverns</biomename.coldcaverns>
+<biomename.europanridge>Europan Ridge</biomename.europanridge>
+<biomename.theaphoticplateau>The Aphotic Plateau</biomename.theaphoticplateau>
+<biomename.hydrothermalwastes>Hydrothermal Wastes</biomename.hydrothermalwastes>
+<biomename.thegreatsea>The Great Sea</biomename.thegreatsea>
+
+<!-- Tutorials -->
+<!-- Generic -->
+<tutorial.tryagainheader>You have died</tutorial.tryagainheader>
+<tutorial.tryagain>Do you want to try again?</tutorial.tryagain>
+<tutorial.radio.speaker>Captain Huskinson</tutorial.radio.speaker>
+<tutorial.radio.watchman>Watchman</tutorial.radio.watchman>
+<tutorial.course>Training Course</tutorial.course>
+<tutorial.coursecomplete>Training Course complete!</tutorial.coursecomplete>
+<tutorial.startbutton>Let's go!</tutorial.startbutton>
+<tutorial.mechanictraining>Mechanic training</tutorial.mechanictraining>
+<tutorial.engineertraining>Engineer training</tutorial.engineertraining>
+<tutorial.securityofficertraining>Security officer training</tutorial.securityofficertraining>
+<tutorial.medicaldoctortraining>Medical doctor training</tutorial.medicaldoctortraining>
+<tutorial.captaintraining>Captain training</tutorial.captaintraining>
+<tutorial.newobjective>New Objective</tutorial.newobjective>
+<tutorial.objective>Objective (Click to review)</tutorial.objective>
+<tutorialskipwarning>It looks like this might be the first time you've played Barotrauma. We strongly recommend that you give the tutorials a try before starting your journey through the depths of Europa.</tutorialskipwarning>
+<tutorialwarningplaytutorials>Play tutorials</tutorialwarningplaytutorials>
+<tutorialwarningskiptutorials>Skip tutorials</tutorialwarningskiptutorials>
+<tutorial.objectives>Objectives</tutorial.objectives>
+<tutorial.roomcompleted>Room completed</tutorial.roomcompleted>
+<tutorial.taskinprogress>Task in progress...</tutorial.taskinprogress>
+<tutorialcompleted>[tutorialname] (Completed)</tutorialcompleted>
+<tutorial.continue>“Got it.”</tutorial.continue>
+<tutorial.continue>“Understood.”</tutorial.continue>
+<tutorial.skiptotutorial>Skip to tutorial.</tutorial.skiptotutorial>
+
+<!-- Job descriptions -->
+<tutorial.mechanictitle>Mechanic - Glue, duct tape and your nerve are the only things keeping the crew alive.</tutorial.mechanictitle>
+<tutorial.mechanicdescription>When the plan goes as planned and the gear works is as probable as the human race leaving this shithole. There are no breaks or rest for you, as everything that can break down, will break down. And if nothing’s broken, then it's maintenance, maintenance, maintenance. Getting to the next destination is all that matters, and you’re the one who delivers. There’s no thank-yous or respect, just snickering and contempt from your "fellow crewmembers"—but that’s okay. This is YOUR survival vessel, and if any of them make it too, well...whoop dee doo for them.</tutorial.mechanicdescription>
+<tutorial.mechanicresponsibilities>Responsibilities\n-Maintenance of machinery\n-Repairing leaks</tutorial.mechanicresponsibilities>
+<tutorial.engineertitle>Engineer - The one who harnesses the power of nature.</tutorial.engineertitle>
+<tutorial.engineerdescription>Power and oxygen, it's like that. Without, the ship don’t move and the lungs won’t breathe. Beyond the fancy talk and costume play, you are the guy who really runs the ship, get it? Trust in the laws of physics and think clear. Also, keep your eye on that damn toy-tinkering wannabe engineer mechanic, and whatever you do, don’t bite into the psycho-babble of the medic. He’s so deep in his softie inner world he’s practically a woman. Captain and security are harmless, and way below your intelligence. Obviously.</tutorial.engineerdescription>
+<tutorial.engineerresponsibilities>Responsibilities\n-Electrical item maintenance\n-Operating the reactor</tutorial.engineerresponsibilities>
+<tutorial.securityofficertitle>Security Officer - The backbone of violence.</tutorial.securityofficertitle>
+<tutorial.securityofficerdescription>It is said that pressure brings out the worst in people. Not everybody has your moral strength—hell, most of them are so crooked that it’s questionable if they even should be allowed to live. Channel the crew’s anger toward the creatures outside, but never fool yourself into trusting them. Keep the nukes ready, the handcuffs available, and every now and then put someone in the brig just so they know who’s in charge!</tutorial.securityofficerdescription>
+<tutorial.securityofficerresponsibilities>Responsibilities\n-Keeping the order\n-Repelling intruders</tutorial.securityofficerresponsibilities>
+<tutorial.medicaldoctortitle>Medical Doctor - Maintaining the key resource: the people</tutorial.medicaldoctortitle>
+<tutorial.medicaldoctordescription>Guns and engines and reactors don't keep the ship running—people do. It’s up to you to keep the gunner alive to man the guns and captain alive to steer the ship. And remember, your job goes well beyond the physical. We live crammed into tight spaces, under ice, in the sea. When the lights go out and your "buddies" go to sleep, all kinds of dark shit crawls into their minds. Keep them alive and sane, or put them down like dogs. It’s up to you.</tutorial.medicaldoctordescription>
+<tutorial.medicaldoctorresponsibilities>Responsibilities\n-First aid\n-Poisons and antidotes</tutorial.medicaldoctorresponsibilities>
+<tutorial.captaintitle>Captain - Naval visionary, seafarer, a genius. Possibly.</tutorial.captaintitle>
+<tutorial.captaindescription>Captain Ahab once said, "Hell is an idea first born on an undigested apple-dumpling." Do you know what that means? No. Does the crew think you are a mysterious genius? Hell yeah. This job is at least as much appearing to know what to do as actually knowing what to do. You are the map and the compass, the guy with the big picture. Navigate and make the tough calls. And remember, you’re just a few steps away from being the mayor of an outpost, and if a couple fellows need to die for that—so be it!</tutorial.captaindescription>
+<tutorial.captainresponsibilities>Responsibilities\n-Steering the ship\n-Delegating</tutorial.captainresponsibilities>
+
+<!-- Basics tutorial -->
+<tutorial.basic>Basics</tutorial.basic>
+<tutorial.basics.message.1>“Ah, I see you're standing. I'd like to keep this brief, since you're the sixth person I've had to guide today, and frankly I'm getting tired of it.”</tutorial.basics.message.1>
+<tutorial.basics.message.1_player>“...Where am I? Who am I?”</tutorial.basics.message.1_player>
+<tutorial.basics.message.2>“You're in an automated rehabilitation chamber. You've suffered a traumatic experience and were in a perpetual state of screaming and defecating your boiler suit. Dr. Happy has seen fit to treat you.”</tutorial.basics.message.2>
+<tutorial.basics.message.2_player>“I don't remember anything...”</tutorial.basics.message.2_player>
+<tutorial.basics.message.3>“That's great news! And significantly reduces the chance of intense nightmares and flashbacks, too. It's an intended but slightly inconvenient side effect of your medication. We just have to re-teach you all the basics, like using your arms and legs, and you're good to go and make some money to pay your medical bills!”</tutorial.basics.message.3>
+<tutorial.basics.message.3_player>“Medical bills?”</tutorial.basics.message.3_player>
+<tutorial.basics.message.4>“Anyways, let's get you going. Try to move those arms and legs, will you? The door will open once you press the button. It's slightly out of reach, though.”</tutorial.basics.message.4>
+<tutorial.basics.endmessage.1>“Ah shit, we didn't think you'd get this far so soon... This sector is unfortunately still quite unfinished, as you can see. There used to be a Mudraptor nest here, but we're 90% sure they're all gone.”</tutorial.basics.endmessage.1>
+<tutorial.basics.endmessage.1_player>“What's a Mudraptor?”</tutorial.basics.endmessage.1_player>
+<tutorial.basics.endmessage.2>“Hold on a second... I see some additional movement on a camera. Uh oh...”</tutorial.basics.endmessage.2>
+<tutorial.basics.endmessage.2_player>“What's that noise?!”</tutorial.basics.endmessage.2_player>
+<tutorial.basics.wasd>Use [InputType.Up], [InputType.Left], [InputType.Down], and [InputType.Right] to move your character.</tutorial.basics.wasd>
+<tutorial.basics.looking>Use the cursor to control the direction your character is facing.\nPress [InputType.Use] to close this instruction.</tutorial.basics.looking>
+<tutorial.basics.cursor>Use [InputType.Select] to interact with buttons, doors and objects.</tutorial.basics.cursor>
+<tutorial.basics.highlight>Interactable objects are highlighted when the cursor moves over them.</tutorial.basics.highlight>
+<tutorial.basics.obtain>To pick up an item, point at it with the cursor and use [InputType.Select].</tutorial.basics.obtain>
+<tutorial.basics.lockeddoor>Locked doors require an ID card to get through.</tutorial.basics.lockeddoor>
+<tutorial.basics.stairsusage>Press [InputType.Down] to drop down the platform, onto the stairs.</tutorial.basics.stairsusage>
+<tutorial.basics.sprint>Hold [InputType.Run] to run.</tutorial.basics.sprint>
+<tutorial.basics.repair>Devices sometimes break down. They can be repaired with the correct repair tool.\nPress [InputType.Use] to close this instruction.</tutorial.basics.repair>
+<tutorial.basics.containers>Items can be found in containers. Use the cursor and [InputType.Select] to open a container.</tutorial.basics.containers>
+<tutorial.basics.equip>Double-click an item to equip it.</tutorial.basics.equip>
+<tutorial.basics.equip2>Items in your hotbar can also be equipped by pressing the corresponding hotbar number (1-9).</tutorial.basics.equip2>
+<tutorial.basics.repair2>Press [InputType.Select] to repair damaged devices.</tutorial.basics.repair2>
+<tutorial.basics.waitdrain>Well done! Wait for the pump to drain the room.</tutorial.basics.waitdrain>
+<tutorial.basics.repairouchie>Ouch! Time your repairs by clicking the repair button when the line is in the colored section of the bar.</tutorial.basics.repairouchie>
+<tutorial.basics.weldingtool>Welding tools are vital equipment for sealing leaks. Obtain a welding tool.</tutorial.basics.weldingtool>
+<tutorial.basics.weldingfuel>Welding tools need welding fuel to work. Get a welding fuel tank from the container.</tutorial.basics.weldingfuel>
+<tutorial.basics.insertweldingfuel>Drag a Welding Fuel Tank onto the Welding Tool to insert it.\nAlternatively press the hotbar number of the Welding Fuel Tank to insert it, while you have the tool equipped.</tutorial.basics.insertweldingfuel>
+<tutorial.basics.insertweldingfuelalt>Alternatively, while you have a welding tool equipped, press the welding fuel tank's hotbar number to insert it.</tutorial.basics.insertweldingfuelalt>
+<tutorial.basics.aimandfire>To aim your tool or weapon, hold the [InputType.Aim] button, then press [InputType.Shoot] to use or fire it.</tutorial.basics.aimandfire>
+<tutorial.basics.aim>Aim</tutorial.basics.aim>
+<tutorial.basics.fire>Fire</tutorial.basics.fire>
+<tutorial.basics.holdaim>Hold the [InputType.Aim] button to aim toward the cursor.</tutorial.basics.holdaim>
+<tutorial.basics.holdaim2>While aiming, hold [InputType.Shoot] to weld.</tutorial.basics.holdaim2>
+<tutorial.basics.ladders>Use [InputType.Up] and [InputType.Down] while near a ladder to go up or down it.</tutorial.basics.ladders>
+<tutorial.basics.welding>Weld the leaking wall to continue.</tutorial.basics.welding>
+<tutorial.basics.divingsuits>Diving Suits allow you to swim underwater.\n\nEquip a Diving Suit by double clicking it, or dragging it on the highlighted slot.</tutorial.basics.divingsuits>
+<tutorial.basics.divingsuits2>Equip a diving suit by double-clicking it or dragging it onto the highlighted slot.</tutorial.basics.divingsuits2>
+<tutorial.basics.nooxygen>WARNING! Your diving suit is empty, preventing you from breathing. Quickly find an oxygen tank and insert it.</tutorial.basics.nooxygen>
+<tutorial.basics.oxygen>Wearing a diving suit slowly drains its oxygen tank.</tutorial.basics.oxygen>
+<tutorial.basics.oxygen2>When an oxygen tank is almost empty, your diving suit will sound the alarm.</tutorial.basics.oxygen2>
+<tutorial.basics.oxygen3>You're running low on oxygen! To unequip the diving suit, drag it out of the inventory slot.</tutorial.basics.oxygen3>
+<tutorial.basics.righttool>Pumps are a mechanical device. Mechanical devices require a Wrench to repair.\nFind a Wrench.</tutorial.basics.righttool>
+<tutorial.basics.wrenchrepair>Equip the wrench to be able to repair the pump.</tutorial.basics.wrenchrepair>
+<tutorial.basics.interact2>Press [InputType.Select] to interact with the pump or other interactable devices.</tutorial.basics.interact2>
+<tutorial.basics.puzzle>Using the pump's interface, see if you can get up the ladder...</tutorial.basics.puzzle>
+<tutorial.basics.puzzlehelp>By setting the pump to pump water into the room, you will be able to swim to the ladder.</tutorial.basics.puzzlehelp>
+<tutorial.basics.equipoxygentank>Drag the oxygen tank on top of your equipped diving suit in your inventory to insert the tank into it.</tutorial.basics.equipoxygentank>
+<tutorial.basics.pumpcontrols>Use the pump controls to pump water into the room. Press the power button to turn on the pump if needed.</tutorial.basics.pumpcontrols>
+<tutorial.basics.drop>You can drop items simply by dragging them out of your inventory.</tutorial.basics.drop>
+<tutorial.basics.unequipdivingsuitdrag>Unequip your diving suit by dragging it out of its inventory slot.</tutorial.basics.unequipdivingsuitdrag>
+<tutorial.basics.unequipdivingsuitclick>Unequip your diving suit by double-clicking the inventory slot or by clicking the green button above it.</tutorial.basics.unequipdivingsuitclick>
+<tutorial.basics.objective1>Press the button</tutorial.basics.objective1>
+<tutorial.basics.objective2>Obtain an ID card</tutorial.basics.objective2>
+<tutorial.basics.objective3>Open the locked door</tutorial.basics.objective3>
+<tutorial.basics.objective4>Obtain a screwdriver</tutorial.basics.objective4>
+<tutorial.basics.objective5>Repair the junction box</tutorial.basics.objective5>
+<tutorial.basics.objective6>Wait for the room to drain</tutorial.basics.objective6>
+<tutorial.basics.objective7>Obtain a welding tool</tutorial.basics.objective7>
+<tutorial.basics.objective8>Weld the damaged wall</tutorial.basics.objective8>
+<tutorial.basics.objective9>Wear a diving suit</tutorial.basics.objective9>
+<tutorial.basics.objective10>Insert oxygen into the diving suit</tutorial.basics.objective10>
+<tutorial.basics.objective11>Obtain a wrench</tutorial.basics.objective11>
+<tutorial.basics.objective12>Repair the pump</tutorial.basics.objective12>
+<tutorial.basics.objective13>Use the pump to flood the room</tutorial.basics.objective13>
+<tutorial.basics.objective14>Leave</tutorial.basics.objective14>
+<tutorial.basics.objective_screwdrivercontainer>Open the cabinet</tutorial.basics.objective_screwdrivercontainer>
+<tutorial.basics.objective_weldingfuel>Obtain welding fuel</tutorial.basics.objective_weldingfuel>
+<tutorial.basics.objective_weldingtoolequip>Equip the welding tool</tutorial.basics.objective_weldingtoolequip>
+<tutorial.basics.objective_weldingtoolfill>Fill the welding tool</tutorial.basics.objective_weldingtoolfill>
+<tutorial.basics.popup.obtainitems>Your inventory is shown at the bottom.\nTo get the screwdriver into your inventory, drag it there.\nAlternatively, double-click to obtain an item faster.</tutorial.basics.popup.obtainitems>
+<tutorial.basics.popup.deselect>Deselect opened containers by pressing [InputType.Aim]</tutorial.basics.popup.deselect>
+<tutorial.basic.description>This tutorial teaches basic controls and game concepts, such as moving and interacting with the environment.</tutorial.basic.description>
+<tutorial.basic.completed>Well done!\nYou've completed the Basics tutorial. Do you want to continue to the Roles tutorial?</tutorial.basic.completed>
+
+<!-- Roles tutorial -->
+<tutorial.roles>Roles</tutorial.roles>
+<tutorial.roles.message.1>“Oh hey—how's it floating, dude? You here to get your papers to sign on a submarine?”</tutorial.roles.message.1>
+<tutorial.roles.message.1_player>“That's right!”</tutorial.roles.message.1_player>
+<tutorial.roles.message.2>“Whoa, such enthusiasm, dude! I love it! Are you familiar with the courses we offer?”</tutorial.roles.message.2>
+<tutorial.roles.message.2_player1>“No, what courses?”</tutorial.roles.message.2_player1>
+<tutorial.roles.message.2_player2>“Yes.” Skip to tutorial.</tutorial.roles.message.2_player2>
+<tutorial.roles.message.3_skip>“All righty dude, just chill in the next room until the other students arrive. Lemme open that door for ya.”</tutorial.roles.message.3_skip>
+<tutorial.roles.message.3_skip_player>“Great!”</tutorial.roles.message.3_skip_player>
+<tutorial.roles.message.3>“Ah, you know dude, just the thingamajig politician dude in his ivory tower trying to solve a problem...without actually solving the problem, ya know?”</tutorial.roles.message.3>
+<tutorial.roles.message.3_player>“What problem?”</tutorial.roles.message.3_player>
+<tutorial.roles.message.4>“The submarine business—it ain't all that, you feel me? Ain't many that return from a trip. Ain't any that return from ten trips. So there's a 100% discount on whatever passes as education here, 'cus that'll solve things.”</tutorial.roles.message.4>
+<tutorial.roles.message.4_player>“Are you bashing your own program?”</tutorial.roles.message.4_player>
+<tutorial.roles.message.5>“I'm just the reception dude, dude. Ain't my job to get meat for the grinder. Want my advice? Take a station job—fight back against the system, dude.”</tutorial.roles.message.5>
+<tutorial.roles.message.5_player>“But I want to find adventure! Besides, there's no food here...”</tutorial.roles.message.5_player>
+<tutorial.roles.message.6a>“Suit yourself, dude... We offer five courses here:\n\nFirst off, the Captain. If ya feel like delegating all the shitty tasks, this is for you. Highly recommend.”</tutorial.roles.message.6a>
+<tutorial.roles.message.6a_player>“Like the famous Herman Pollard!”</tutorial.roles.message.6a_player>
+<tutorial.roles.message.6b>“Sure, dude. Then there's the fixin' duo.\nThe Engineer gets all the fancy toys, but with a high risk of bein' shocked. Ain't for the weak hearted.\nThen there's the Mechanic, if ya don't mind getting wet. He's doing the welding and pump-fixing kind of things. Ain't recommended for smokers, feel me?”</tutorial.roles.message.6b>
+<tutorial.roles.message.6b_player>“Sounds like important jobs!”</tutorial.roles.message.6b_player>
+<tutorial.roles.message.6c>“Yeah, awful right? Then there's the Security Officer, if you like shooting the creepies. They're usually too in love with their power, though. I actually got this tattoo that says ASOAB. Means 'All Security Officers Are Bastards.' Watch out with those dudes, dude.”</tutorial.roles.message.6c>
+<tutorial.roles.message.6c_player>“They can't all be that bad?”</tutorial.roles.message.6c_player>
+<tutorial.roles.message.6d>“Finally, there's the Medical Doctor. Most of 'em are creepier than the actual creepies, but some actually make people better, man. They're some literal saints, feel me?\nAnyhow, if ya still interested, move on to the next room.”</tutorial.roles.message.6d>
+<tutorial.roles.message.6_player>“Sign me up, sir!”</tutorial.roles.message.6_player>
+<tutorial.roles.popup.moveright>Move to the room on the right to continue.</tutorial.roles.popup.moveright>
+<tutorial.roles.popup.creworders>Use [InputType.CrewOrders] to toggle the list of crewmembers.</tutorial.roles.popup.creworders>
+<tutorial.roles.popup.creworders2>Select a trainee position from the list of crewmembers with [InputType.Select].</tutorial.roles.popup.creworders2>
+<tutorial.roles.idcarddescription>This ID card gives the trainee access to the training areas.</tutorial.roles.idcarddescription>
+<tutorial.roles.captaindescription>The Captain steers the submarine, operates the sonar and issues commands to the crew.</tutorial.roles.captaindescription>
+<tutorial.roles.engineerdescription>The Engineer operates the nuclear reactor to generate power and maintains electrical devices. Skilled engineers can add custom functionality to submarines with custom wiring and signal components.</tutorial.roles.engineerdescription>
+<tutorial.roles.mechanicdescription>The Mechanic maintains the mechanical devices, such as the engine and pumps, to keep the submarine moving smoothly. Additionally, any leaks in the hull are typically fixed by mechanics, as they have superior welding skills.</tutorial.roles.mechanicdescription>
+<tutorial.roles.securitydescription>The Security Officer protects the submarine and crew from external and internal threats. With a combination of ship-mounted and handheld weapons, and the skills to use them, they're the first line of defense.</tutorial.roles.securitydescription>
+<tutorial.roles.medicdescription>The Medical Doctor treats the ailments of the crew. This ranges from bandaging small wounds to administering drugs. In a worst-case scenario, fallen crewmembers can be saved with CPR.</tutorial.roles.medicdescription>
+<tutorial.roles.startprompt_captain>Start the tutorial for the Captain?</tutorial.roles.startprompt_captain>
+<tutorial.roles.startprompt_engineer>Start the tutorial for the Engineer?</tutorial.roles.startprompt_engineer>
+<tutorial.roles.startprompt_mechanic>Start the tutorial for the Mechanic?</tutorial.roles.startprompt_mechanic>
+<tutorial.roles.startprompt_security>Start the tutorial for the Security Officer?</tutorial.roles.startprompt_security>
+<tutorial.roles.startprompt_medic>Start the tutorial for the Medical Doctor?</tutorial.roles.startprompt_medic>
+<tutorial.roles.startprompt_yes>Yes. Start tutorial.</tutorial.roles.startprompt_yes>
+<tutorial.roles.startprompt_no>No. Choose a different tutorial.</tutorial.roles.startprompt_no>
+<tutorial.roles.reception_notification>“Hey dude, the teacher is ready for ya.”</tutorial.roles.reception_notification>
+<tutorial.roles.reception_notification_player>“On my way.”</tutorial.roles.reception_notification_player>
+<tutorial.roles.popup.start>To start the tutorial, find your instructor at the marked location.</tutorial.roles.popup.start>
+<tutorial.roles.objective.selection1>Switch character</tutorial.roles.objective.selection1>
+<tutorial.roles.objective.selection2>Leave the lounge area</tutorial.roles.objective.selection2>
+<tutorial.roles.captaininstructor>“Hi. I am Captain Sterner. I will be your instructor today. I will start with a brief explanation of what it means to be a captain, followed by a practical course. It is crucial to enforce a chain of command, so you will address me as 'Captain.' Say 'Yes, Captain' if you understand.”</tutorial.roles.captaininstructor>
+<tutorial.roles.yescaptain_player>“Yes, Captain!”</tutorial.roles.yescaptain_player>
+<tutorial.roles.commandroomdescription>“The Command Room is the brains of the submarine. From here signals are passed—either verbally or electronically—to crew and devices.”</tutorial.roles.commandroomdescription>
+<tutorial.roles.commandroomdescription2>“Using devices like the navigation terminal and status monitor, the captain can pass all these signals, for example: Order the crew to fix devices, signal the engine to move at full power, or empty the ballast tanks to raise the submarine.”</tutorial.roles.commandroomdescription2>
+<tutorial.roles.navigationterminal>“The core function of the navigation terminal is to move the submarine.”</tutorial.roles.navigationterminal>
+<tutorial.roles.navigationterminal_sonar>“Since we're in a low-light environment, sonar is the most efficient way of identifying terrain, objects and lifeforms.”</tutorial.roles.navigationterminal_sonar>
+<tutorial.roles.navigationterminal_sonar2>“Sonar is short for 'sound navigation and ranging.' Sonar has two modes: passive and active.”</tutorial.roles.navigationterminal_sonar2>
+<tutorial.roles.navigationterminal_sonar3>“While in 'passive' mode, the sonar only listens to sounds. It will still detect things, especially if these things make a lot of sound. Static objects or terrain, however, won't be detected until very close.”</tutorial.roles.navigationterminal_sonar3>
+<tutorial.roles.navigationterminal_sonar4>“While in 'active' mode, the sonar emits pulses of sound at an interval. Simply put, this means every few seconds, the sound wave will reveal terrain, objects and lifeforms. Active sonar is essential to avoid bumping into terrain while moving at any decent speed.”</tutorial.roles.navigationterminal_sonar4>
+<tutorial.roles.navigationterminal_sonar5>“Finally, there's the directional ping. While active sonar is great for spotting things, it's also great for being spotted. The directional ping limits the direction of the sound pulse, thus preventing hostiles from spotting your submarine—as long as it's not aimed at them.”</tutorial.roles.navigationterminal_sonar5>
+<tutorial.roles.navigationterminal_sonar6>“We've hooked up this navigation terminal to a sonar. Feel free to try it out.”</tutorial.roles.navigationterminal_sonar6>
+<tutorial.roles.popup.navigationterminal_sonar>Use [InputType.Select] to interact with the navigation terminal.</tutorial.roles.popup.navigationterminal_sonar>
+<tutorial.roles.popup.navigationterminal_sonar2>Try out the sonar functionalities.</tutorial.roles.popup.navigationterminal_sonar2>
+<tutorial.roles.navigationterminal_steering>“Once you have a bearing on your surroundings, it is time to move the submarine.”</tutorial.roles.navigationterminal_steering>
+<tutorial.roles.navigationterminal_steering2>“Steering is controlled with the display in the middle, which utilizes modern touchcreen and auto-pilot technologies.”</tutorial.roles.navigationterminal_steering2>
+<tutorial.roles.navigationterminal_steering3>“By default, the auto-pilot will try to maintain the submarine's position. By touching (clicking) the screen, the auto-pilot's target position will change to the indicated position.”</tutorial.roles.navigationterminal_steering3>
+<tutorial.roles.navigationterminal_steering4>“Furthermore, the auto-pilot has information on outpost locations. It attempts to automatically navigate to predefined positions. This system, however, is neither infallible nor as quick as manual steering.”</tutorial.roles.navigationterminal_steering4>
+<tutorial.roles.navigationterminal_steering5>“Speaking of manual steering: This is the preferred option for those who want more control over their submarine. By touching (clicking) the screen, you set the submarine's target velocity.”</tutorial.roles.navigationterminal_steering5>
+<tutorial.roles.navigationterminal_steering6>“For example: If you want your submarine to move slowly to the right, you touch slightly to the right of the submarine's current position. If you want to rise up quickly, you touch far above the submarine's current position.”</tutorial.roles.navigationterminal_steering6>
+<tutorial.roles.navigationterminal_steering7>“Ready to give it a try?”</tutorial.roles.navigationterminal_steering7>
+<tutorial.roles.navigationterminal_steering8>“Trick question! No you're not, cadet! A submarine is usually docked while idle, to prevent it from drifting and using fuel. First, you'll need to undock using the big red "Undock" button. Easy, right? Now, let's try it out.”</tutorial.roles.navigationterminal_steering8>
+<tutorial.roles.popup.navigationterminal_steering>Undock the drone, using the Shuttle Navigation Terminal.</tutorial.roles.popup.navigationterminal_steering>
+<tutorial.roles.popup.navigationterminal_steering2>Practice steering the drone. Re-dock the drone when ready.\nTo dock, align the docking hatches (marked in green). Press Dock once the button flashes.</tutorial.roles.popup.navigationterminal_steering2>
+<tutorial.roles.navigationterminal_commanding>“Not bad, cadet. You are ready to be a helmsman now, but being a captain is more than that.”</tutorial.roles.navigationterminal_commanding>
+<tutorial.roles.navigationterminal_commanding2>“You cannot run a large submarine by yourself. You need a crew. And a crew needs someone to lead them, or they will stumble around like headless chickens. Cluck cluck cluck. Wait, they wouldn't... Never mind.”</tutorial.roles.navigationterminal_commanding2>
+<tutorial.roles.navigationterminal_commanding3>“As captain, you're responsible for leading your crew. So you'll have to issue orders to them. Meaning, you'll need to know what needs doing!”</tutorial.roles.navigationterminal_commanding3>
+<tutorial.roles.navigationterminal_commanding4>“That's where the status monitor comes in. With the status monitor, you can see where the submarine is in need of repairs. You can then mark these rooms with tasks and pray there's someone competent enough to perform them. Don't skip the praying part.”</tutorial.roles.navigationterminal_commanding4>
+<tutorial.roles.navigationterminal_commanding5>“If you don't want shit to break down in the first place though, you'll have to tell your crew to keep it all in good order. This means issuing them orders from the get-go.”</tutorial.roles.navigationterminal_commanding5>
+<tutorial.roles.navigationterminal_commanding6>“Let's try it out on an actual submarine, shall we? The other cadets ought to be ready right about now. Follow me.”</tutorial.roles.navigationterminal_commanding6>
+<tutorial.roles.popup.captain_follow>Follow Captain Sterner into the submarine.</tutorial.roles.popup.captain_follow>
+<tutorial.roles.captaininstructor_start>“We're here. Let's start by issuing commands to the crew. Without power, nothing in the submarine will work, so first order the reactor turned on.”</tutorial.roles.captaininstructor_start>
+<tutorial.roles.popup.captain_command>Open the command interface with [InputType.Command].</tutorial.roles.popup.captain_command>
+<tutorial.roles.popup.captain_command2>Order the reactor to be turned on.</tutorial.roles.popup.captain_command2>
+<tutorial.roles.popup.captain_command3>The command interface will automatically select the most qualified crewmember for the assigned task.</tutorial.roles.popup.captain_command3>
+<tutorial.roles.popup.captain_command4>You can also give orders directly to a specific crewmember on the crew list (toggle with [InputType.CrewOrders]).</tutorial.roles.popup.captain_command4>
+<tutorial.roles.captaininstructor_repairs>“Great. Remember—captains should command respect and obedience. That's why they usually carry a firearm. Our last engineer, Stevie Dolittle, said, 'What are you going to do, shoot me?' Haha, his cousin didn't stick around long after that. Anyways, let's order some maintenance, shall we?”</tutorial.roles.captaininstructor_repairs>
+<tutorial.roles.popup.captain_commandmaintenance>Order leaks to be fixed.</tutorial.roles.popup.captain_commandmaintenance>
+<tutorial.roles.popup.captain_commandmaintenance2>Order electrical devices to be repaired.</tutorial.roles.popup.captain_commandmaintenance2>
+<tutorial.roles.popup.captain_commandmaintenance3>Order mechanical devices to be repaired.</tutorial.roles.popup.captain_commandmaintenance3>
+<tutorial.roles.captaininstructor_firearms>“And no, you won't be given a firearm yet—you'll have to complete your education first. Let's get on with that, shall we? Honkmother knows you'll need it. Speaking of firearms, it's time to get the sub's weapons operational.”</tutorial.roles.captaininstructor_firearms>
+<tutorial.roles.popup.captain_commandsecurity>Order the bottom turret to be operated.</tutorial.roles.popup.captain_commandsecurity>
+<tutorial.roles.captaininstructor_end>“That covers the basics. Now the real test: Undock from the station, get us to the next outpost, and you'll be done and graduated! Good luck, cadet!”</tutorial.roles.captaininstructor_end>
+<tutorial.roles.popup.captain_graduation>Use what you've learned to reach the next outpost.</tutorial.roles.popup.captain_graduation>
+<tutorial.roles.captain.objective.sonar>Master the sonar</tutorial.roles.captain.objective.sonar>
+<tutorial.roles.captain.objective.sonar1>Interact with the Navigation Terminal</tutorial.roles.captain.objective.sonar1>
+<tutorial.roles.captain.objective.sonar2>Try out the active sonar</tutorial.roles.captain.objective.sonar2>
+<tutorial.roles.captain.objective.sonar3>Try out directional ping</tutorial.roles.captain.objective.sonar3>
+<tutorial.roles.captain.objective.drone>Steer the drone</tutorial.roles.captain.objective.drone>
+<tutorial.roles.captain.objective.drone1>Undock the drone</tutorial.roles.captain.objective.drone1>
+<tutorial.roles.captain.objective.drone2>Try out manual steering</tutorial.roles.captain.objective.drone2>
+<tutorial.roles.captain.objective.drone3>Try out the maintain position controls</tutorial.roles.captain.objective.drone3>
+<tutorial.roles.captain.objective.drone4>Dock the drone</tutorial.roles.captain.objective.drone4>
+<tutorial.roles.captain.objective.follow>Follow the instructor</tutorial.roles.captain.objective.follow>
+<tutorial.roles.captain.objective.orders>Give orders to the crew</tutorial.roles.captain.objective.orders>
+<tutorial.roles.captain.objective.orders1>Order the reactor turned on</tutorial.roles.captain.objective.orders1>
+<tutorial.roles.captain.objective.orders2>Order leaks to be fixed</tutorial.roles.captain.objective.orders2>
+<tutorial.roles.captain.objective.orders3>Order electrical devices to be repaired</tutorial.roles.captain.objective.orders3>
+<tutorial.roles.captain.objective.orders4>Order mechanical devices to be repaired</tutorial.roles.captain.objective.orders4>
+<tutorial.roles.captain.objective.orders5>Order the bottom turret to be operated</tutorial.roles.captain.objective.orders5>
+<tutorial.roles.captain.objective.undock>Undock the submarine</tutorial.roles.captain.objective.undock>
+<tutorial.roles.captain.objective.station>Arrive and dock at the marked station</tutorial.roles.captain.objective.station>
+<tutorial.roles.engineerinstructor>“Welcome! Welcome! I'm Chief Engineer Friar, but please, call me Kayleigh.”</tutorial.roles.engineerinstructor>
+<tutorial.roles.reactorroomdescription>“The reactor room is where the heart of the submarine resides. As long as there's electrical juices flowing through the wires, there is life in the submarine. And it—the electricity—all originates from this beauty right here.”</tutorial.roles.reactorroomdescription>
+<tutorial.roles.engineerinstructor_fuelrods>“While 'nuclear reactor' may sound scary, because of the whole invisible radiation thing, there's actually nothing to worry about! Operating reactors is relatively safe.”</tutorial.roles.engineerinstructor_fuelrods>
+<tutorial.roles.engineerinstructor_fuelrods2>“Relative to the other, waaaay more dangerous dangers, that is. The reactor room is usually quite well protected, and it's centrally located!”</tutorial.roles.engineerinstructor_fuelrods2>
+<tutorial.roles.engineerinstructor_fuelrods3>“One thing to keep in mind, and I will stress this: Do NOT insert every fuel rod you have in your storage into the reactor all at once.”</tutorial.roles.engineerinstructor_fuelrods3>
+<tutorial.roles.engineerinstructor_fuelrods4>“Really. Do not. Each fuel rod increases the amount of heat generated by the reactor. Too much heat means a fire will start. Eventually a full-blown meltdown will trigger, and...KABOOM! Well, at least it's a quick death. Sure beats getting captured by pirates.”</tutorial.roles.engineerinstructor_fuelrods4>
+<tutorial.roles.engineerinstructor_fuelrods5>“For now, I'm just going to hand you one fuel rod. Let me show you how to insert it.”</tutorial.roles.engineerinstructor_fuelrods5>
+<tutorial.roles.engineerinstructor_fuelrods5_player>“Is this really safe?”</tutorial.roles.engineerinstructor_fuelrods5_player>
+<tutorial.roles.popup.engineer_fuelrods>Interact with the reactor, then drag the fuel rod into the slots on the left.</tutorial.roles.popup.engineer_fuelrods>
+<tutorial.roles.engineerinstructor_reactor>“A basic start-up of the nuclear reactor looks like this:\n1. One non-empty fuel rod inserted.\n2. Power button pressed.\n3. Automatic control toggled on.”</tutorial.roles.engineerinstructor_reactor>
+<tutorial.roles.engineerinstructor_reactor_player>“Sounds simple enough.”</tutorial.roles.engineerinstructor_reactor_player>
+<tutorial.roles.engineerinstructor_reactor2>“Give it a try then! Don't be shy!”</tutorial.roles.engineerinstructor_reactor2>
+<tutorial.roles.engineerinstructor_reactor2_player>“On it!”</tutorial.roles.engineerinstructor_reactor2_player>
+<tutorial.roles.popup.engineer_reactor>Interact with the reactor, power it up and enable automatic control.</tutorial.roles.popup.engineer_reactor>
+<tutorial.roles.engineerinstructor_reactormanual>“Great job! You're a natural! We now have power. Look at how all the lights are turning on—that was all you!”</tutorial.roles.engineerinstructor_reactormanual>
+<tutorial.roles.engineerinstructor_reactormanual_player>“That was easy enough.”</tutorial.roles.engineerinstructor_reactormanual_player>
+<tutorial.roles.engineerinstructor_reactormanual2>“Aha, getting confident, are we? Well, let's switch over to manual control then.”</tutorial.roles.engineerinstructor_reactormanual2>
+<tutorial.roles.engineerinstructor_reactormanual3>“In manual control, you're using two controls. The first one, on the left, is the fission rate and the second, on the right, is the turbine output.”</tutorial.roles.engineerinstructor_reactormanual3>
+<tutorial.roles.engineerinstructor_reactormanual4>“Increasing the fission rate makes the reactor consume more fuel and generate more heat. The heat is used to spin the turbine, which generates electricity.”</tutorial.roles.engineerinstructor_reactormanual4>
+<tutorial.roles.engineerinstructor_reactormanual5>“The higher the turbine output, the more the reactor attempts to generate electricity. If the output is too high relative to the fission rate, the reactor will cool down; too low and it'll overheat.”</tutorial.roles.engineerinstructor_reactormanual5>
+<tutorial.roles.engineerinstructor_reactormanual6>“It all boils down to: Keep the left gauge in the green, keep the right gauge in the green.”</tutorial.roles.engineerinstructor_reactormanual6>
+<tutorial.roles.engineerinstructor_reactormanual6_player>“Why bother with manual control at all?”</tutorial.roles.engineerinstructor_reactormanual6_player>
+<tutorial.roles.engineerinstructor_reactormanual7>“Great question! Ever been on a submarine and the lights suddenly turned off? That probably meant the reactor was on automatic control and the captain did some sudden maneuvering. Auto is much slower to react to and compensate for higher power needs than manual control is.”</tutorial.roles.engineerinstructor_reactormanual7>
+<tutorial.roles.engineerinstructor_reactormanual7_player>“Can I try it?”</tutorial.roles.engineerinstructor_reactormanual7_player>
+<tutorial.roles.engineer_reactormanual>Interact with the reactor, then switch to manual control.</tutorial.roles.engineer_reactormanual>
+<tutorial.roles.engineer_reactormanual2>Using the sliders, keep both needles of the gauges in the green areas.</tutorial.roles.engineer_reactormanual2>
+<tutorial.roles.engineer_backtoauto>“Good job! Now, let's move on to the next room. But first, turn the automatic control back on. It's important not to leave the reactor on manual when it's unattended!”</tutorial.roles.engineer_backtoauto>
+<tutorial.roles.engineer_followme>“All right, I think we're all done with the reactor now! Follow me.”</tutorial.roles.engineer_followme>
+<tutorial.roles.electricaldescription>“Welcome to Electrical! Things are buzzing around here, aren't they?! Don't be intimidated by all the wires; they're going exactly where they need to go. I made sure of it.”</tutorial.roles.electricaldescription>
+<tutorial.roles.electricaldescription2>“This room is usually filled with junction boxes. All the power from the reactor needs to be distributed, and that's where the jay-bees—or junction boxes—come in!”</tutorial.roles.electricaldescription2>
+<tutorial.roles.engineerinstructor_junctionboxes>“When junction boxes break down, which they will, any devices connected to them will cease to function. Your job is to keep that from happening!”</tutorial.roles.engineerinstructor_junctionboxes>
+<tutorial.roles.engineerinstructor_junctionboxes_player>“Why do they break? Can't they, like, not break?”</tutorial.roles.engineerinstructor_junctionboxes_player>
+<tutorial.roles.engineerinstructor_junctionboxes2>“Good question! Some skilled engineers at outposts can make devices more damage resistant, but let's forget about that for now.”</tutorial.roles.engineerinstructor_junctionboxes2>
+<tutorial.roles.engineerinstructor_junctionboxes3>“Most captains are the rough breakey kind of captains. They prefer to accelerate at maximum power for a few seconds, then completely idle the submarine the next minute for a cigar break. These power fluctuations are what damages the sub's electrical devices most of the time.”</tutorial.roles.engineerinstructor_junctionboxes3>
+<tutorial.roles.engineerinstructor_junctionboxes4>“The other thing is water, of course. Electricity and water don't mix so well, so any time water leaks into the submarine, there will be damage.”</tutorial.roles.engineerinstructor_junctionboxes4>
+<tutorial.roles.engineerinstructor_junctionboxes4_player>“So I just sit here with my screwdriver for the whole trip?”</tutorial.roles.engineerinstructor_junctionboxes4_player>
+<tutorial.roles.engineerinstructor_junctionboxes5>“Pretty much! Except once you learn how to fast-repair, you'll have a lot of time for other things. Let me show you!”</tutorial.roles.engineerinstructor_junctionboxes5>
+<tutorial.roles.engineerinstructor_junctionboxes5_player>“Okay.”</tutorial.roles.engineerinstructor_junctionboxes5_player>
+<tutorial.roles.popup.engineer_junctionboxes>Interact with the junction box and click the repair button in rapid succession.</tutorial.roles.popup.engineer_junctionboxes>
+<tutorial.roles.popup.engineer_junctionboxes2>Ouch! Repairing too quickly gets you shocked.</tutorial.roles.popup.engineer_junctionboxes2>
+<tutorial.roles.popup.engineer_junctionboxes3>Now try to time clicking the repair button. Click when the moving line hits the colored area of the bar.</tutorial.roles.popup.engineer_junctionboxes3>
+<tutorial.roles.engineerinstructor_wiring>“That went okay, I think. But look, this one light is still off!”</tutorial.roles.engineerinstructor_wiring>
+<tutorial.roles.engineerinstructor_wiring_player>“Why's that?”</tutorial.roles.engineerinstructor_wiring_player>
+<tutorial.roles.engineerinstructor_wiring2>“It's because I removed a wire connecting the junction box to the lamp. But I have it right here—I just need you to connect it.”</tutorial.roles.engineerinstructor_wiring2>
+<tutorial.roles.engineerinstructor_wiring2_player>“How?”</tutorial.roles.engineerinstructor_wiring2_player>
+<tutorial.roles.engineerinstructor_wiring3>“All you need is a screwdriver in one hand and a wire in the other. Let me show you!”</tutorial.roles.engineerinstructor_wiring3>
+<tutorial.roles.engineerinstructor_wiring3_player>“Sure.”</tutorial.roles.engineerinstructor_wiring3_player>
+<tutorial.roles.popup.engineer_wiring>Equip the screwdriver and the wire.</tutorial.roles.popup.engineer_wiring>
+<tutorial.roles.popup.engineer_wiring2>Rewire the junction box with [InputType.Use].</tutorial.roles.popup.engineer_wiring2>
+<tutorial.roles.popup.engineer_wiring3>Attach the wire to the POWER connection.</tutorial.roles.popup.engineer_wiring3>
+<tutorial.roles.popup.engineer_wiring4>Close the current wiring panel, then rewire the lamp with [InputType.Use].</tutorial.roles.popup.engineer_wiring4>
+<tutorial.roles.popup.engineer_wiring5>Attach the wire to the POWER connection.</tutorial.roles.popup.engineer_wiring5>
+<tutorial.roles.engineerinstructor_end>“Awesome job! That covers all the basics of engineering. The rest you can learn on your trips! You were a lovely student. Hope to see you around!”</tutorial.roles.engineerinstructor_end>
+<tutorial.roles.engineerinstructor_end_player>“Thanks Kayleigh! See you!”</tutorial.roles.engineerinstructor_end_player>
+<tutorial.roles.engineer.objective.reactor>Master the reactor</tutorial.roles.engineer.objective.reactor>
+<tutorial.roles.engineer.objective.reactor1>Insert a fuel rod into the reactor</tutorial.roles.engineer.objective.reactor1>
+<tutorial.roles.engineer.objective.reactor2>Power up the reactor</tutorial.roles.engineer.objective.reactor2>
+<tutorial.roles.engineer.objective.reactor3>Toggle automatic control on</tutorial.roles.engineer.objective.reactor3>
+<tutorial.roles.engineer.objective.reactor4>Toggle automatic control off</tutorial.roles.engineer.objective.reactor4>
+<tutorial.roles.engineer.objective.reactor5>Keep the fission rate needle on green</tutorial.roles.engineer.objective.reactor5>
+<tutorial.roles.engineer.objective.reactor6>Keep the turbine output needle on green</tutorial.roles.engineer.objective.reactor6>
+<tutorial.roles.engineer_backtoauto>“Good job! Now, let's move on to the next room. But first, turn the automatic control back on. It's important not to leave the reactor on manual when it's unattended!”</tutorial.roles.engineer_backtoauto>
+<tutorial.roles.engineer_followme>“All right, I think we're all done with the reactor now! Follow me.”</tutorial.roles.engineer_followme>
+<tutorial.roles.engineer.objective.repair>Master repairing</tutorial.roles.engineer.objective.repair>
+<tutorial.roles.engineer.objective.repair1>Attempt to fast-repair</tutorial.roles.engineer.objective.repair1>
+<tutorial.roles.engineer.objective.repair2>Repair the junction box</tutorial.roles.engineer.objective.repair2>
+<tutorial.roles.engineer.objective.rewire>Learn to rewire</tutorial.roles.engineer.objective.rewire>
+<tutorial.roles.engineer.objective.rewire1>Equip the screwdriver</tutorial.roles.engineer.objective.rewire1>
+<tutorial.roles.engineer.objective.rewire2>Equip the wire</tutorial.roles.engineer.objective.rewire2>
+<tutorial.roles.engineer.objective.rewire3>Wire the Junction Box's POWER output</tutorial.roles.engineer.objective.rewire3>
+<tutorial.roles.engineer.objective.rewire4>Connect the wire to the lamp's POWER input</tutorial.roles.engineer.objective.rewire4>
+<tutorial.roles.mechanicinstructor>“Hi, I'm Amos. I'm the mechanic around here. I'll teach you how to care for your submarine. Remember: If you take care of her, she'll take care of you.”</tutorial.roles.mechanicinstructor>
+<tutorial.roles.engineroomdescription>“This right here is the engine room. It houses the engine. Every submarine has one. The engine moves the submarine forwards and backwards.”</tutorial.roles.engineroomdescription>
+<tutorial.roles.mechanicinstructor_engine>“The engine is a mechanical device. You will be a mechanic. You take care of mechanical devices.”</tutorial.roles.mechanicinstructor_engine>
+<tutorial.roles.mechanicinstructor_engine2>“Thing is making funny sounds or smoking? You take a wrench and fix it. Here's a wrench. Now fix it.”</tutorial.roles.mechanicinstructor_engine2>
+<tutorial.roles.popup.mechanic_engine>Equip the wrench.</tutorial.roles.popup.mechanic_engine>
+<tutorial.roles.popup.mechanic_engine2>Repair the engine.</tutorial.roles.popup.mechanic_engine2>
+<tutorial.roles.mechanicinstructor_engine3>“That wasn't terrible. Anyways, the ceiling is leaking too, which is probably what caused the damage in the first place. You know how to handle a welding tool?”</tutorial.roles.mechanicinstructor_engine3>
+<tutorial.roles.mechanicinstructor_engine3_player>“I do.”</tutorial.roles.mechanicinstructor_engine3_player>
+<tutorial.roles.popup.mechanic_welding>Equip the welding tool.</tutorial.roles.popup.mechanic_welding>
+<tutorial.roles.popup.mechanic_welding2>Weld the leak.</tutorial.roles.popup.mechanic_welding2>
+<tutorial.roles.mechanicinstructor_ballast>“Hm, that will do. Now, grab a diving mask from the supply cabinet.”</tutorial.roles.mechanicinstructor_ballast>
+<tutorial.roles.mechanicinstructor_ballast_player>“All right.”</tutorial.roles.mechanicinstructor_ballast_player>
+<tutorial.roles.popup.mechanic_divingmask>Equip the diving mask.</tutorial.roles.popup.mechanic_divingmask>
+<tutorial.roles.ballastdescription>“Down this ladder and through the hatch is a ballast tank. The ballast tank fills up with water when the submarine needs to go down.”</tutorial.roles.ballastdescription>
+<tutorial.roles.mechanicinstructor_ballast2>“Inside, a pump forces the water in or out. If the pump breaks down, you get in there and fix it. Since there's usually water in the ballast tank, it helps to have some diving tools on you. Still got that wrench?”</tutorial.roles.mechanicinstructor_ballast2>
+<tutorial.roles.mechanicinstructor_ballast2_player>“Yep.”</tutorial.roles.mechanicinstructor_ballast2_player>
+<tutorial.roles.popup.mechanic_ballast>Repair the ballast pump</tutorial.roles.popup.mechanic_ballast>
+<tutorial.roles.mechanicinstructor_ballast3>“Not bad, cub. Follow me. We'll do some fabricating next.”</tutorial.roles.mechanicinstructor_ballast3>
+<tutorial.roles.mechanicinstructor_ballast3_player>“Following.”</tutorial.roles.mechanicinstructor_ballast3_player>
+<tutorial.roles.engineeringdescription>“The engineering room is where you can find the fabrication and deconstruction devices. Not all submarines have them, but most outposts and stations do, and you can use them for free.”</tutorial.roles.engineeringdescription>
+<tutorial.roles.mechanicinstructor_fabrication>“Fabricating new items with a fabricator is easy: You put in some basic ingredients, select a blueprint or recipe, press the button and you got yourself some brand new toys.”</tutorial.roles.mechanicinstructor_fabrication>
+<tutorial.roles.mechanicinstructor_fabrication2>“Deconstructing is even easier: You put in some item, plant or mineral, and you get basic materials back.\nDo note that you'll lose some materials in the process.”</tutorial.roles.mechanicinstructor_fabrication2>
+<tutorial.roles.mechanicinstructor_fabrication3>“How about you make your own wrench? There's some iron ore in the cabinet—you'll need to refine it in the deconstructor first.”</tutorial.roles.mechanicinstructor_fabrication3>
+<tutorial.roles.popup.mechanic_fabrication>Acquire the iron ore.</tutorial.roles.popup.mechanic_fabrication>
+<tutorial.roles.popup.mechanic_fabrication2>Deconstruct the iron ore.</tutorial.roles.popup.mechanic_fabrication2>
+<tutorial.roles.popup.mechanic_fabrication3>Retrieve the iron.</tutorial.roles.popup.mechanic_fabrication3>
+<tutorial.roles.popup.mechanic_fabrication4>Fabricate a wrench.</tutorial.roles.popup.mechanic_fabrication4>
+<tutorial.roles.mechanicinstructor_fabrication4>“You can keep that one if you want, cub. Anyways, almost done. Last room, then some beer.”</tutorial.roles.mechanicinstructor_fabrication4>
+<tutorial.roles.mechanicinstructor_fabrication4_player>“Thanks, chief.”</tutorial.roles.mechanicinstructor_fabrication4_player>
+<tutorial.roles.oxygendescription>“This is the oxygen generator compartment. Typically quite small, but also rather important as they keep people breathing.”</tutorial.roles.oxygendescription>
+<tutorial.roles.mechanicinstructor_oxygen>“Just remember to check up on it and repair it. If you got time to spare, use it to fill up depleted oxygen tanks.”</tutorial.roles.mechanicinstructor_oxygen>
+<tutorial.roles.mechanicinstructor_oxygen2>“How about you put your oxygen tank in there and we call it a day, eh?”</tutorial.roles.mechanicinstructor_oxygen2>
+<tutorial.roles.mechanicinstructor_oxygen2_player>“Sounds good.”</tutorial.roles.mechanicinstructor_oxygen2_player>
+<tutorial.roles.popup.mechanic_oxygen>Interact with the oxygen generator</tutorial.roles.popup.mechanic_oxygen>
+<tutorial.roles.popup.mechanic_oxygen2>Drag the used oxygen tank to the oxygen generator</tutorial.roles.popup.mechanic_oxygen2>
+<tutorial.roles.mechanicinstructor_oxygen3>“Good job, cub. You made it through. Keep your tools sorted, your workplace tidy and let's have that beer now.”</tutorial.roles.mechanicinstructor_oxygen3>
+<tutorial.roles.mechanicinstructor_oxygen3_player>“Sure, thanks chief!”</tutorial.roles.mechanicinstructor_oxygen3_player>
+<tutorial.roles.mechanic.objective.engine>Repair the engine</tutorial.roles.mechanic.objective.engine>
+<tutorial.roles.mechanic.objective.leaks>Repair the hull with the welding tool</tutorial.roles.mechanic.objective.leaks>
+<tutorial.roles.mechanic.objective.ballast1>Dive into the ballast tank</tutorial.roles.mechanic.objective.ballast1>
+<tutorial.roles.mechanic.objective.ballast2>Repair the ballast pump</tutorial.roles.mechanic.objective.ballast2>
+<tutorial.roles.mechanic.objective.ballast3>Leave the ballast tank</tutorial.roles.mechanic.objective.ballast3>
+<tutorial.roles.mechanic.objective.engineering>Learn to fabricate items</tutorial.roles.mechanic.objective.engineering>
+<tutorial.roles.mechanic.objective.engineering1>Deconstruct iron ore</tutorial.roles.mechanic.objective.engineering1>
+<tutorial.roles.mechanic.objective.engineering2>Retrieve the iron</tutorial.roles.mechanic.objective.engineering2>
+<tutorial.roles.mechanic.objective.engineering3>Fabricate a wrench</tutorial.roles.mechanic.objective.engineering3>
+<tutorial.roles.mechanic.objective.oxygen>Refill the oxygen bottle</tutorial.roles.mechanic.objective.oxygen>
+<tutorial.roles.securityinstructor>“Stand with your back straight, recruit! I’ll teach you to shoot, stab and sink your enemies. My name is Officer Pérez, but you might as well forget it now, since you’ll address me only as ma'am.”</tutorial.roles.securityinstructor>
+<tutorial.roles.securityinstructor.yesmaam1>“Yes ma'am!”</tutorial.roles.securityinstructor.yesmaam1>
+<tutorial.roles.armorydescription>“Welcome to the armory. Every crew needs an armory to store their weapons. Preferably one that's secured by a locked door to prevent the munitions from falling into the wrong hands. Armories are often situated near the command room and/or the gunnery compartment. In lieu of armories, secure cabinets are sometimes used to store handheld weaponry.”</tutorial.roles.armorydescription>
+<tutorial.roles.securityinstructor.bodyarmor>“Being such a quick learner, you might last longer than most. First of all, equip yourself with body armor. You can find some in that cabinet. Just follow the stink of sweat.”</tutorial.roles.securityinstructor.bodyarmor>
+<tutorial.roles.securityinstructor.yesmaam2>“Yes, ma'am...”</tutorial.roles.securityinstructor.yesmaam2>
+<tutorial.roles.popup.bodyarmor>Find body armor.</tutorial.roles.popup.bodyarmor>
+<tutorial.roles.securityinstructor.gun1>“Good. I think it was recruit Miller who died in that armor. A bright young man, but the worst aim you ever saw. Now get a gun and ammo from that rack. Make sure it’s loaded by hovering your mouse over it.”</tutorial.roles.securityinstructor.gun1>
+<tutorial.roles.popup.gun>Find a gun.</tutorial.roles.popup.gun>
+<tutorial.roles.popup.loadgun>Load your gun with the ammo. (Drag the ammo onto the gun)</tutorial.roles.popup.loadgun>
+<tutorial.roles.securityinstructor.gun2>“Management wants me to remind you about trigger discipline at this point. ...Now that that’s done with, let’s get to shooting. We’re fresh out of clowns, so you’ll have to make do with a husk. Proceed to the shooting range.”</tutorial.roles.securityinstructor.gun2>
+<tutorial.roles.securityinstructor.shooting1>“Enemies that manage to board your submarine are usually weak enough to be dispatched with handheld weapons. Husks can infect humans with a deadly parasite, but this one is safely contained in the range. Kill it.”</tutorial.roles.securityinstructor.shooting1>
+<tutorial.roles.popup.shooting>Kill the enemy.</tutorial.roles.popup.shooting>
+<tutorial.roles.securityinstructor.shooting2>“Nice shooting. You beat Miller’s record. Let’s find you something bigger to shoot. Proceed to the coilgun loader.”</tutorial.roles.securityinstructor.shooting2>
+<tutorial.roles.gunnerydescription>“This here's the gunnery. From here you'll be able to control various weapons situated on the hull of your submarine.”</tutorial.roles.gunnerydescription>
+<tutorial.roles.securityinstructor.subweapons>“Submarine weaponry consists of several devices. Along with the turret itself, you’ll find a loader, a supercapacitor, and a periscope.”</tutorial.roles.securityinstructor.subweapons>
+<tutorial.roles.securityinstructor.loader>“A loader should have ammunition compatible with the weapon it's linked to. Load some coilgun ammunition into this one.”</tutorial.roles.securityinstructor.loader>
+<tutorial.roles.popup.loader>Insert a coilgun ammunition box into the loader.</tutorial.roles.popup.loader>
+<tutorial.roles.securityinstructor.supercapacitor>“Supercapacitors provide power to the weapons. Turn this one on by cranking the dial. The higher it is, the faster your weapons charge. Just be careful—on red it starts to overload.”</tutorial.roles.securityinstructor.supercapacitor>
+<tutorial.roles.popup.supercapacitor>Turn on the supercapacitor.</tutorial.roles.popup.supercapacitor>
+<tutorial.roles.securityinstructor.periscope>“Periscopes are used to control turrets. While interacting with a periscope, use your mouse to aim and [InputType.Shoot] to shoot. Now see if you can’t find something to shoot with this coilgun.”</tutorial.roles.securityinstructor.periscope>
+<tutorial.roles.popup.killoutsideenemy>Kill the enemy outside the station.</tutorial.roles.popup.killoutsideenemy>
+<tutorial.roles.securityinstructor.complete>“Good one. Now I can sleep better at night. Unlike recruit Miller.”</tutorial.roles.securityinstructor.complete>
+<tutorial.roles.airlockdescription>“This is the airlock. If you need to leave the sub to perform external repairs, investigate some minerals or peel a nasty crawler off the hull, this is where you go.\nDon't forget your diving suit, though—a diving mask won't cut it out there.”</tutorial.roles.airlockdescription>
+<tutorial.roles.security.objective.gearup>Gear up</tutorial.roles.security.objective.gearup>
+<tutorial.roles.security.objective.gearup1>Equip body armor</tutorial.roles.security.objective.gearup1>
+<tutorial.roles.security.objective.gearup2>Acquire a gun</tutorial.roles.security.objective.gearup2>
+<tutorial.roles.security.objective.gearup3>Acquire ammunition</tutorial.roles.security.objective.gearup3>
+<tutorial.roles.security.objective.gearup4>Load the gun</tutorial.roles.security.objective.gearup4>
+<tutorial.roles.security.objective.turret>Operate a turret</tutorial.roles.security.objective.turret>
+<tutorial.roles.security.objective.turret1>Fill the loader</tutorial.roles.security.objective.turret1>
+<tutorial.roles.security.objective.turret2>Charge up the supercapacitor</tutorial.roles.security.objective.turret2>
+<tutorial.roles.security.objective.turret3>Look through the periscope</tutorial.roles.security.objective.turret3>
+<tutorial.roles.security.objective.turret4>Kill the target outside</tutorial.roles.security.objective.turret4>
+<tutorial.roles.medicalinstructor>“You’re here. Great. My name is Doctor James Beem and I’ll be guiding your hand today. What’s your name again? Oh, it doesn’t matter. Let’s get on with it. My head is absolutely throbbing.”</tutorial.roles.medicalinstructor>
+<tutorial.roles.medbay>“The med bay is where medical items and treatments are stored. If a submarine has a medical fabricator, it is usually situated here. Some med bays are also equipped with beds for patients to rest in. As space is limited in submarines, some vessels opt to do without a dedicated med bay.”</tutorial.roles.medbay>
+<tutorial.roles.medicalinstructor.player>“Ready to go, sir!”</tutorial.roles.medicalinstructor.player>
+<tutorial.roles.medicalinstructor.morphine>“Keep it down, will you? Grab some morphine for me. You can find it in that cabinet over there. That’s a standard medical cabinet. You can find those on board most submarines.”</tutorial.roles.medicalinstructor.morphine>
+<tutorial.roles.popup.morphine>Find morphine.</tutorial.roles.popup.morphine>
+<tutorial.roles.popup.healthui1>Open the Doctor's health interface with [InputType.Health]</tutorial.roles.popup.healthui1>
+<tutorial.roles.popup.healthui2>Drag the morphine anywhere on the body.</tutorial.roles.popup.healthui2>
+<tutorial.roles.medicalinstructor.medfabricator1>“That takes care of my headache, but the shakes are still there. We don’t have any naloxone left, do we? You’ll just have to make some. First, find morphine and stabilozine.”</tutorial.roles.medicalinstructor.medfabricator1>
+<tutorial.roles.popup.medfabricator1>Find Morphine and Stabilozine.</tutorial.roles.popup.medfabricator1>
+<tutorial.roles.medicalinstructor.medfabricator2>“You can make medicine in the medical fabricator. Like a regular fabricator, it creates new items out of materials you feed it. Try it out.”</tutorial.roles.medicalinstructor.medfabricator2>
+<tutorial.roles.popup.medfabricator2>Find naloxone on the list and click on it.</tutorial.roles.popup.medfabricator2>
+<tutorial.roles.popup.medfabricator3>Insert morphine and stabilozine into the input slots and press "Create."</tutorial.roles.popup.medfabricator3>
+<tutorial.roles.popup.medfabricator4>Take the fabricated naloxone from the output on the right-hand side of the screen.</tutorial.roles.popup.medfabricator4>
+<tutorial.roles.medicalinstructor.healthui>“Okay, bring it here. Just highlight me with your mouse and press [InputType.Health] to enter my Health interface.”</tutorial.roles.medicalinstructor.healthui>
+<tutorial.roles.medicalinstructor.healthui2>Shakes visibly.\n\n“Remember, [InputType.Health] to view my health interface. The sooner, the better.”</tutorial.roles.medicalinstructor.healthui2>
+<tutorial.roles.popup.naloxone>Administer naloxone.</tutorial.roles.popup.naloxone>
+<tutorial.roles.medicalinstructor.patients1>“That’s about all you can do for me right now. If you want to be of more use, tend to the patients next door. And turn off the lights. I’m gonna rest my eyes a bit.”</tutorial.roles.medicalinstructor.patients1>
+<tutorial.roles.medicalinstructor.patients2>“There are several patients here, each with a different affliction. To find out what ails them, I will give you this Health Scanner HUD. It will display what their issue is, before you see it by yourself up close.”</tutorial.roles.medicalinstructor.patients2>
+<tutorial.roles.medicalinstructor.patients3>“When treating a patient, the health interface will suggest treatments on the bottom. Simply clicking on a suggestion will apply it, but you can also manually drag a medicine to the wound. Cabinets should be stocked with whatever you need.”</tutorial.roles.medicalinstructor.patients3>
+<tutorial.roles.popup.treatpatients>Treat all patients.</tutorial.roles.popup.treatpatients>
+<tutorial.roles.medicalinstructor.burns>“Burns are commonly sustained from explosions and electric shocks. Bandages and plastiseal are the typical treatments. Burns are also limb-specific, which means you’ll have to apply the cure to the correct limb.”</tutorial.roles.medicalinstructor.burns>
+<tutorial.roles.popup.burns>Apply bandages to burned limb.</tutorial.roles.popup.burns>
+<tutorial.roles.medicalinstructor.psychosis>“Psychosis is usually inflicted by otherworldly sources. It is treated with haloperidol.”</tutorial.roles.medicalinstructor.psychosis>
+<tutorial.roles.popup.psychosis>Give the patient haloperidol.</tutorial.roles.popup.psychosis>
+<tutorial.roles.medicalinstructor.damage>“Blunt force trauma (and other physical damage afflictions like lacerations and bite wounds) are treated with painkillers such as morphine.”</tutorial.roles.medicalinstructor.damage>
+<tutorial.roles.popup.damage>Give the patient morphine.</tutorial.roles.popup.damage>
+<tutorial.roles.medicalinstructor.cpr1>“Well done. There’s one more thing you need to learn, and that’s how to perform CPR.”</tutorial.roles.medicalinstructor.cpr1>
+<tutorial.roles.medicalinstructor.cpr2>“When someone sustains enough damage, they enter a critical state. In this state they are immobile and will perish if they don’t receive immediate aid.”</tutorial.roles.medicalinstructor.cpr2>
+<tutorial.roles.medicalinstructor.cpr3>“To resuscitate someone before they die, open their health interface and press the ‘Perform CPR’ button. If you're successful, the patient will be stabilized. Note that the resuscitation process often takes time.”</tutorial.roles.medicalinstructor.cpr3>
+<tutorial.roles.medicalinstructor.cpr4>“Come back to the med bay. There’s a patient here in need of CPR. Take your time, though; he’s only pretending. ...This time.”</tutorial.roles.medicalinstructor.cpr4>
+<tutorial.roles.popup.cpr>Press the "Perform CPR" button.</tutorial.roles.popup.cpr>
+<tutorial.roles.medicalinstructor.complete>“Good job. Coffee is on me.”</tutorial.roles.medicalinstructor.complete>
+<tutorial.roles.medic.objective.morphine>Treat the instructor</tutorial.roles.medic.objective.morphine>
+<tutorial.roles.medic.objective.healthinterface>Open the doctor's Health Interface</tutorial.roles.medic.objective.healthinterface>
+<tutorial.roles.medic.objective.morphine1>Find morphine</tutorial.roles.medic.objective.morphine1>
+<tutorial.roles.medic.objective.morphine2>Administer morphine to the instructor</tutorial.roles.medic.objective.morphine2>
+<tutorial.roles.medic.objective.medfabricator>Fabricate and administer naloxone</tutorial.roles.medic.objective.medfabricator>
+<tutorial.roles.medic.objective.medfabricator1>Find morphine and stabilozine</tutorial.roles.medic.objective.medfabricator1>
+<tutorial.roles.medic.objective.medfabricator2>Use the medical fabricator to craft naloxone</tutorial.roles.medic.objective.medfabricator2>
+<tutorial.roles.medic.objective.medfabricator3>Treat the instructor with naloxone</tutorial.roles.medic.objective.medfabricator3>
+<tutorial.roles.medic.objective.crewquarters>Treat patients in the crew quarters</tutorial.roles.medic.objective.crewquarters>
+<tutorial.roles.medic.objective.crewquarters1>Go to crew quarters</tutorial.roles.medic.objective.crewquarters1>
+<tutorial.roles.medic.objective.crewquarters2>Treat all patients</tutorial.roles.medic.objective.crewquarters2>
+<tutorial.roles.medic.objective.cpr>Administer CPR</tutorial.roles.medic.objective.cpr>
+<tutorial.roles.description>This tutorial teaches about the different jobs aboard a submarine. There's five roles to explore:\n- Captain\n- Engineer\n- Mechanic\n- Medical Doctor\n- Security Officer</tutorial.roles.description>
+<tutorial.roles.completed>Well done!\nYou've completed the Roles tutorial. Do you want to restart and explore a different role?</tutorial.roles.completed>
+<tutorial.roles.popup.close_interface>Close the interface with [InputType.Aim].</tutorial.roles.popup.close_interface>
+<tutorial.roles.mechanic.objective.divingmask>Equip the Diving Mask</tutorial.roles.mechanic.objective.divingmask>
+<tutorial.roles.popup.mechanic_fabrication5>Acquire the Wrench</tutorial.roles.popup.mechanic_fabrication5>
+<tutorial.roles.mechanic.objective.engineering4>Acquire the Wrench</tutorial.roles.mechanic.objective.engineering4>
+<tutorial.roles.popup.medical_healthscanner>Equip the Health Scanner HUD.</tutorial.roles.popup.medical_healthscanner>
+<tutorial.roles.medic.objective.healthscanner>Equip the Health Scanner</tutorial.roles.medic.objective.healthscanner>
+<tutorial.roles.security.objective.killtarget>Kill the target</tutorial.roles.security.objective.killtarget>
+<tutorial.roles.popup.bodyarmorequip>Equip the Body Armor. Click the bar above the Body Armor's inventory slot to equip it or press the hotkey.</tutorial.roles.popup.bodyarmorequip>
+<tutorial.roles.popup.ammo>Obtain ammunition.</tutorial.roles.popup.ammo>
+
+
+<!-- Campaign tutorial -->
+<tutorial.campaign.introduction.conversation_start>[speakername]: “Finally a chance to get off this station. Can you believe there's so few people willing to crew a submarine, they just sponsored us one fresh from the shipyard?”</tutorial.campaign.introduction.conversation_start>
+<tutorial.campaign.introduction.conversation_start_reply>“I still feel like there must be some catch…”</tutorial.campaign.introduction.conversation_start_reply>
+<tutorial.campaign.introduction.conversation_2>“None as far as I can see. Supply and demand in action: They need able-bodied sailors to keep Europan society running, and the original crew of this submarine drank themselves to death before their maiden voyage. It's ours all right.”</tutorial.campaign.introduction.conversation_2>
+<tutorial.campaign.introduction.conversation_2_reply>“If you say so… Still seems fishy but it sure beats sitting around here. What do we still have to do before we go?”</tutorial.campaign.introduction.conversation_2_reply>
+<tutorial.campaign.introduction.conversation_3>“We'll need some supplies for our first voyage. Fuel Rods are a must, without them I cannot keep our submarine powered. We should make sure we have some spare. Welding Fuel, too, as without it we have no way to patch hull damage. Of course, let's try to avoid hull damage, but just in case.\nI'll transfer my last savings to the shared bank account to contribute.”</tutorial.campaign.introduction.conversation_3>
+<tutorial.campaign.introduction.conversation_3_reply>“All right, I'll get the supplies!”</tutorial.campaign.introduction.conversation_3_reply>
+<tutorial.campaign.introduction.conversation_4>“Great! Maybe while you're up there, you can check if anyone has some paid work for us? There's not much point in drifting around without a purpose, and keeping a submarine running is expensive.”</tutorial.campaign.introduction.conversation_4>
+<tutorial.campaign.introduction.conversation_4_reply>“Sure, on it.”</tutorial.campaign.introduction.conversation_4_reply>
+<tutorial.campaign.objective_missions>Find a way to make money</tutorial.campaign.objective_missions>
+<tutorial.campaign.objective_supplies>Get supplies for the submarine</tutorial.campaign.objective_supplies>
+<tutorial.campaign.objective_supplies_fuelrods>Fuel Rods</tutorial.campaign.objective_supplies_fuelrods>
+<tutorial.campaign.objective_supplies_weldingfuel>Welding Fuel</tutorial.campaign.objective_supplies_weldingfuel>
+<tutorial.campaign.objective_leave>Leave the station</tutorial.campaign.objective_leave>
+<tutorial.campaign.objective_tasks>Set orders for your crew</tutorial.campaign.objective_tasks>
+<tutorial.campaign.message_tasks>Open the command interface by pressing [InputType.Command] to give orders to your crew.</tutorial.campaign.message_tasks>
+<tutorial.campaign.objective_tasks_reactor>Power up the reactor</tutorial.campaign.objective_tasks_reactor>
+<tutorial.campaign.objective_tasks_fixleaks>Fix leaks</tutorial.campaign.objective_tasks_fixleaks>
+<tutorial.campaign.objective_tasks_repairelectrical>Repair electrical devices</tutorial.campaign.objective_tasks_repairelectrical>
+<tutorial.campaign.objective_tasks_repairmechanical>Repair mechanical devices</tutorial.campaign.objective_tasks_repairmechanical>
+<tutorial.campaign.objective_tasks_operateturret>Operate turret</tutorial.campaign.objective_tasks_operateturret>
+<tutorial.campaign.objective_move>Move the submarine</tutorial.campaign.objective_move>
+<tutorial.campaign.objective_activatesonar>Activate sonar</tutorial.campaign.objective_activatesonar>
+<tutorial.campaign.objective_reachtarget>Dock at the next station</tutorial.campaign.objective_reachtarget>
+<tutorial.campaign.objective_restock>Restock supplies</tutorial.campaign.objective_restock>
+<tutorial.campaign.objective_restock_fuel>Fuel Rods</tutorial.campaign.objective_restock_fuel>
+<tutorial.campaign.objective_restock_coilgunammo>Coilgun Ammo Box</tutorial.campaign.objective_restock_coilgunammo>
+<tutorial.campaign.objective_restock_handheldammo>Revolver Rounds</tutorial.campaign.objective_restock_handheldammo>
+<tutorial.campaign.objective_3missions>Obtain mission leads</tutorial.campaign.objective_3missions>
+<tutorial.campaign.outro.conversation_start>[speakername]: “Looks like you settled into the routines of submarining pretty well!”</tutorial.campaign.outro.conversation_start>
+<tutorial.campaign.outro.conversation_start_reply>“So far it seems the risk has been exaggerated. Smooth sailing!”</tutorial.campaign.outro.conversation_start_reply>
+<tutorial.campaign.outro.conversation_2>“From what I've heard, things get riskier the further down we go. The money's better though. No risk, no reward…”</tutorial.campaign.outro.conversation_2>
+<tutorial.campaign.outro.conversation_2_reply>“I do have some urge to go deeper… I mean, who could say no to more money?”</tutorial.campaign.outro.conversation_2_reply>
+<tutorial.campaign.outro.conversation_3>“Money and adventure, exploring the unknown… Sign me up cap'n!”</tutorial.campaign.outro.conversation_3>
+<tutorial.campaign.outro.conversation_3_reply>“Down we go!”</tutorial.campaign.outro.conversation_3_reply>
+<campaignexittutorialoutpostprompt>Do you want to skip the remaining tutorial objectives and exit [locationname]?</campaignexittutorialoutpostprompt>
+
+
+<tutorial.airlocktitle>Airlock</tutorial.airlocktitle>
+<tutorial.airlockdescription>Every submarine should be equipped with a secure airlock where the crew can exit the sub safely and without too much flooding.\n\nTo safely exit the submarine, equip a diving suit and other necessary items (usually a handheld sonar, weapons and extra oxygen tank or two). Then make your way to the airlock. Be sure to close all the doors behind you to stop the water’s flow before too much of it gets inside.\n\nWhen coming back inside, use water pumps to drain all of the water before going deeper into the submarine. It is also helpful to return all of the equipment back to their proper places and refill used oxygen tanks at the oxygen generator.</tutorial.airlockdescription>
+<tutorial.railguntitle>Railgun</tutorial.railguntitle>
+<tutorial.railgundescription>The railgun works like a coilgun, except it fires big shells that can be upgraded with explosives.\n\nRailgun loaders are loaded with single railgun shells instead of boxes of ammunition. Otherwise, operating them is the same: Interact with the periscope to aim with the turret, then press {0} to fire. Press {1} to stop aiming.</tutorial.railgundescription>
+<tutorial.syringeguntitle>Syringe gun</tutorial.syringeguntitle>
+<tutorial.syringegundescription>A ranged weapon of choice for medics, the syringe gun uses medicine as ammunition. This allows for administering cures from afar. Be aware: Medicines fired from long range are less effective than those used in the medical interface.\n\nA tactical choice in combat would be to load the syringe gun with poison and fire it at enemies. Aim the syringe gun the same way you would other long-range weapons: {0} to aim, {1} to fire.</tutorial.syringegundescription>
+<tutorial.plasmacuttertitle>Plasma cutter</tutorial.plasmacuttertitle>
+<tutorial.plasmacutterdescription>The plasma cutter is a device used to cut through walls and doors. It functions like the welding tool: {0} to aim, {1} to fire.\n\nWhile the plasma cutter is primarily a tool, it does inflict burns on anyone who gets in the way, which makes it a handy makeshift weapon.</tutorial.plasmacutterdescription>
+<tutorial.crowbartitle>Crowbar</tutorial.crowbartitle>
+<tutorial.crowbardescription>A heavy instrument that can be used to force open doors. Handy when someone has been tampering with door wiring or when you need to get to rooms you’re not allowed in. Use ({0}) the crowbar on a closed door to start prying it open. The crowbar must be equipped to do this.</tutorial.crowbardescription>
+<tutorial.mineralstitle>Minerals</tutorial.mineralstitle>
+<tutorial.mineralsdescription>The basic materials for crafting can be bought, deconstructed or found in the world.\n\nMinerals are spawned in the cave and ice walls, and they can be cut out using the plasma cutter and then picked up. Raw minerals can be deconstructed to create craftable elements.</tutorial.mineralsdescription>
+<tutorial.psychosistitle>Psychosis</tutorial.psychosistitle>
+<tutorial.psychosisdescription>When in contact with certain performance-enhancing drugs or under some extraterrestrial influence, players may be afflicted with psychosis, causing them to experience visual and auditory hallucinations and phantom pains.\n\nPsychosis may be cured using haloperidol.</tutorial.psychosisdescription>
+<tutorial.opiatestitle>Opiate addiction and withdrawals</tutorial.opiatestitle>
+<tutorial.opiatesdescription>Overuse of pain medication causes addiction and, in time, withdrawal. Withdrawal symptoms can be reduced by feeding the addiction, but to truly be rid of the effects, one must either stop taking the drugs entirely or use naloxone.</tutorial.opiatesdescription>
+<tutorial.oxygentitle>Oxygen</tutorial.oxygentitle>
+<tutorial.oxygendescription>Oxygen is a valuable commodity in underwater Europa. It must be readily available during long transits aboard submarines, which is made possible by oxygen generators. They pump air through ventilation to different rooms and can be used to refill oxygen tanks.\n\nTo refill oxygen tanks, interact ([InteractType.Use]) with the generator to open its inventory. Insert an empty oxygen tank into one of the slots to start refilling it. When the tank is full, drag it back to your inventory or into your diving suit/mask.</tutorial.oxygendescription>
+<tutorial.laddertitle>Ladders</tutorial.laddertitle>
+<tutorial.ladderdescription>To grab onto a ladder, press {0}. Use {1} and {2} buttons to climb the ladder. Let go of the ladder by pressing {3} again.</tutorial.ladderdescription>
+
+<!-- Submarine -->
+<engineer.repairelectricalroom>Electrical room</engineer.repairelectricalroom>
+<engineer.repairelectricalroomobjective>Repair the electrical room</engineer.repairelectricalroomobjective>
+<engineer.repairelectricalroomtext>Find the sub’s electrical room and repair the junction boxes by interacting with them while holding a screwdriver, then pressing the “Repair” button.</engineer.repairelectricalroomtext>
+<engineer.powerupreactor>Reactor</engineer.powerupreactor>
+<engineer.powerupreactorobjective>Power up submarine’s reactor</engineer.powerupreactorobjective>
+<engineer.powerupreactortext>Nuclear reactors provide power to submarines and outposts. They require fuel to create heat and a crewmember to regulate the output.\n\nDrag a fuel rod to the item slot on the left side. Multiple fuel rods create more heat, but in normal circumstances one is enough and any more might cause the reactor to overheat.\n\nStart by setting the fission rate so that the needle is on green, then do the same for turbine output. You can see load and output values to the right. Try to keep the output as close to load as possible; a lower output can lead to power outages, and higher to overvoltage and fires.\n\nWhen the reactor operator leaves the interface, consider turning on automatic control. With automatic control, the reactor responds to any fluctuations in grid load, but it is considerably slower than a human operator.</engineer.powerupreactortext>
+
+<!-- Captain tutorial -->
+<captain.docktext>To dock the submarine, maneuver the ship’s and outpost’s docking ports close to each other and toggle the docking clamps. Ports are displayed in green on the sonar display.\n\nWhen the ports are close to each other, a line will be shown on the sonar display. When the line is fully green, close the clamps by pressing the “Dock” button. The submarine will then be locked into position until undocked.\n\nWhen positioning the submarine for docking, radical movements can easily cause you to overshoot your target. Using autopilot and “maintain position” is helpful in setting the position you want the submarine to move to.</captain.docktext>
+
+<!-- Karma system -->
+<karma>Karma</karma>
+<karmaexplanation>Karma reflects the helpful and harmful actions you've taken while playing. Actions such as repairing the submarine, operating devices and killing monsters increase Karma, while actions such as attacking members of your crew or damaging the submarine decrease it. If your Karma drops too low, you may not get assigned to certain jobs anymore, or, in more extreme cases, you may be banned from the server.</karmaexplanation>
+<resetkarma>Reset Karma</resetkarma>
+<karmadecreased>Your Karma decreased by [karmadecrease].</karmadecreased>
+<karmaincreased>Your Karma increased by [karmaincrease].</karmaincreased>
+<karmabanwarning>WARNING: Your karma is dangerously low. You will be banned from the server if it decreases further.</karmabanwarning>
+<karmabanned>You have been banned from the server because your Karma decreased below [banthreshold].</karmabanned>
+<karmajobdisallowed>You are not allowed to select this job because your Karma is too low ([yourkarma]/[minkarma]).</karmajobdisallowed>
+<karma.kickbanthreshold>Kick/Ban threshold</karma.kickbanthreshold>
+<karma.kickbanthresholdtooltip>The players whose karma decrease below this threshold get automatically kicked and/or banned from the server (depending on the kick/ban settings below).</karma.kickbanthresholdtooltip>
+<karma.karmadecay>Karma decay speed</karma.karmadecay>
+<karma.karmadecaytooltip>How much karma decreases per second when it's above the decay threshold.</karma.karmadecaytooltip>
+<karma.karmadecaythreshold>Karma decay threshold</karma.karmadecaythreshold>
+<karma.karmadecaythresholdtooltip>Karma gradually decreases when it's above this threshold.</karma.karmadecaythresholdtooltip>
+<karma.karmaincrease>Karma increase speed</karma.karmaincrease>
+<karma.karmaincreasetooltip>How much karma increases per second when it's below the increase threshold.</karma.karmaincreasetooltip>
+<karma.karmaincreasethreshold>Karma increase threshold</karma.karmaincreasethreshold>
+<karma.karmaincreasethresholdtooltip>Karma gradually increases when it's below this threshold.</karma.karmaincreasethresholdtooltip>
+<karma.structurerepairkarmaincrease>Structure repaired</karma.structurerepairkarmaincrease>
+<karma.structurerepairkarmaincreasetooltip>How much karma increases when repairing structures (per amount of damage repaired—for example, a value of 0.05 would mean you get 5 points of karma when you repair a wall from 0 health to 100).</karma.structurerepairkarmaincreasetooltip>
+<karma.structuredamagekarmadecrease>Structure damaged</karma.structuredamagekarmadecrease>
+<karma.structuredamagekarmadecreasetooltip>How much karma decreases when damaging structures (per amount of damage done—for example, a value of 0.05 would mean that karma decreases by 5 when taking a wall from 100 health to 0).</karma.structuredamagekarmadecreasetooltip>
+<karma.itemrepairkarmaincrease>Device repaired</karma.itemrepairkarmaincrease>
+<karma.itemrepairkarmaincreasetooltip>How much karma increases when repairing devices (per amount of damage repaired—for example, a value of 0.05 would mean you get 5 points of karma when you repair a device from 0 health to 100).</karma.itemrepairkarmaincreasetooltip>
+<karma.damageenemykarmaincrease>Damage to enemy</karma.damageenemykarmaincrease>
+<karma.damageenemykarmaincreasetooltip>How much karma increases when damaging enemies (per amount of damage done).</karma.damageenemykarmaincreasetooltip>
+<karma.healfriendlykarmaincrease>Heal friendly</karma.healfriendlykarmaincrease>
+<karma.healfriendlykarmaincreasetooltip>How much karma increases when healing other members of the crew (per amount of damage healed).</karma.healfriendlykarmaincreasetooltip>
+<karma.damagefriendlykarmadecrease>Damage to friendly</karma.damagefriendlykarmadecrease>
+<karma.damagefriendlykarmadecreasetooltip>How much karma decreases when damaging other members of the crew (per amount of damage done).</karma.damagefriendlykarmadecreasetooltip>
+<karma.reactormeltdownkarmadecrease>Reactor meltdown</karma.reactormeltdownkarmadecrease>
+<karma.reactormeltdownkarmadecreasetooltip>How much karma decreases if the player causes a reactor meltdown.</karma.reactormeltdownkarmadecreasetooltip>
+<karma.reactoroverheatkarmadecrease>Reactor overheat</karma.reactoroverheatkarmadecrease>
+<karma.reactoroverheatkarmadecreasetooltip>How much karma decreases per second if a reactor's temperature stays critical while the player is operating it.</karma.reactoroverheatkarmadecreasetooltip>
+<karma.extinguishfirekarmaincrease>Extinguish fires</karma.extinguishfirekarmaincrease>
+<karma.extinguishfirekarmaincreasetooltip>How much karma increases per second when attempting to extinguish fires.</karma.extinguishfirekarmaincreasetooltip>
+<karma.allowedwiredisconnectionsperminute>Allowed wire disconnections per minute</karma.allowedwiredisconnectionsperminute>
+<karma.allowedwiredisconnectionsperminutetooltip>How many wires a player is allowed to disconnect per minute before they start losing karma.</karma.allowedwiredisconnectionsperminutetooltip>
+<karma.wiredisconnectionkarmadecrease>Disconnect lots of wires</karma.wiredisconnectionkarmadecrease>
+<karma.wiredisconnectionkarmadecreasetooltip>How much karma decreases if a player disconnects more than the allowed number of wires per minute.</karma.wiredisconnectionkarmadecreasetooltip>
+<karma.spamfilterkarmadecrease>Triggering the spam filter</karma.spamfilterkarmadecrease>
+<karma.spamfilterkarmadecreasetooltip>How much karma decreases if a player triggers the spam filter of the text chat.</karma.spamfilterkarmadecreasetooltip>
+<karma.herpesthreshold>Space herpes threshold</karma.herpesthreshold>
+<karma.herpesthresholdtooltip>How low does the karma have to decrease for the player to get space herpes.</karma.herpesthresholdtooltip>
+<karma.positiveactions>Helpful actions</karma.positiveactions>
+<karma.negativeactions>Harmful actions</karma.negativeactions>
+<karmapreset.default>Default</karmapreset.default>
+<karmapreset.strict>Strict</karmapreset.strict>
+<karmapreset.custom>Custom</karmapreset.custom>
+<karmadecreasedunknownamount>Your karma has decreased.</karmadecreasedunknownamount>
+<karmaincreasedunknownamount>Your karma has increased.</karmaincreasedunknownamount>
+<afflictionname.spaceherpes>Space herpes</afflictionname.spaceherpes>
+<afflictiondescription.spaceherpes>They look as ugly on the outside as they are on the inside. Karma strikes back?</afflictiondescription.spaceherpes>
+<afflictionname.invertcontrols>Disoriented</afflictionname.invertcontrols>
+<afflictiondescription.invertcontrols>The patient's eyes are darting around and they seem to be having trouble orienting to their surroundings.</afflictiondescription.invertcontrols>
+<karmakicked>You have been kicked from the server because your Karma decreased below [banthreshold].</karmakicked>
+<karma.kicksbeforeban>Number of kicks before a ban</karma.kicksbeforeban>
+<karma.kicksbeforebantooltip>If the player has been kicked from the server due to low karma this many times, they will be banned if their karma drops below the kick/ban threshold again. A value of 0 means players will always get banned if their karma drops below the threshold.</karma.kicksbeforebantooltip>
+<karma.resetkarmabetweenrounds>Reset karma between rounds</karma.resetkarmabetweenrounds>
+<karma.stunfriendlykarmadecrease>Stun friendly</karma.stunfriendlykarmadecrease>
+<karma.stunfriendlykarmadecreasetooltip>How much karma decreases based on how long an inflicted stun lasts.</karma.stunfriendlykarmadecreasetooltip>
+<karma.stunfriendlykarmadecreasethreshold>Stun karma decrease threshold</karma.stunfriendlykarmadecreasethreshold>
+<karma.stunfriendlykarmadecreasethresholdtooltip>How long the average stun in the past minute lasts until karma begins decreasing.</karma.stunfriendlykarmadecreasethresholdtooltip>
+<karma.dangerousitemstealkarmadecrease>Stealing dangerous items</karma.dangerousitemstealkarmadecrease>
+<karma.dangerousitemstealkarmadecreasetooltip>How much karma decreases when stealing weapons and ID cards from unconscious or handcuffed players.</karma.dangerousitemstealkarmadecreasetooltip>
+<karma.dangerousitemstealbots>Stealing dangerous items from bots.</karma.dangerousitemstealbots>
+<karma.dangerousitemstealbotstooltip>Apply a karma penalty when stealing dangerous items from bots.</karma.dangerousitemstealbotstooltip>
+<karma.ballastflorakarmaincrease>Ballast flora damage</karma.ballastflorakarmaincrease>
+<karma.ballastflorakarmaincreasetooltip>How much karma increases when damaging ballast flora.</karma.ballastflorakarmaincreasetooltip>
+<karma.dangerousitemcontainkarmadecrease>Containing dangerous items</karma.dangerousitemcontainkarmadecrease>
+<karma.dangerousitemcontainkarmadecreasetooltip>How much karma decreases when containing dangerous items, e.g. putting an oxygen tank inside a welding tool.</karma.dangerousitemcontainkarmadecreasetooltip>
+<karma.isdangerousitemcontainkarmadecreaseincremental>Incremental penalty for containing dangerous items</karma.isdangerousitemcontainkarmadecreaseincremental>
+<karma.isdangerousitemcontainkarmadecreaseincrementaltooltip>When enabled, the base karma penalty is multiplied by the amount of times the player has contained a dangerous item.</karma.isdangerousitemcontainkarmadecreaseincrementaltooltip>
+<karma.maxdangerousitemcontainkarmadecrease>Max penalty for containing dangerous items</karma.maxdangerousitemcontainkarmadecrease>
+<karma.maxdangerousitemcontainkarmadecreasetooltip>How much is the maximum karma penalty for containing dangerous items.</karma.maxdangerousitemcontainkarmadecreasetooltip>
+
+<!-- Disclaimers -->
+<editordisclaimertitle>Editors</editordisclaimertitle>
+<editordisclaimertext>The submarine and character editors are modding tools that can be used to expand the core game by creating your own submarines and monsters. The custom creations can be shared in the Steam Workshop.\n\nAt the moment the editors are only available in English. The process of building a fully playable submarine or a functional monster can be quite involved, and unfortunately we don’t offer in-game tutorials or documentation for the editors yet. If you want to take a shot at creating your own custom content with the editors, you may be able to find help through the following links:</editordisclaimertext>
+<editordisclaimerwikilink>Barotrauma Wiki</editordisclaimerwikilink>
+<editordisclaimerdiscordlink>Barotrauma Discord Server</editordisclaimerdiscordlink>
+<editordisclaimerforumlink>Barotrauma Forums</editordisclaimerforumlink>
+<bugreportgithubform>GitHub issue form</bugreportgithubform>
+<bugreportfeedbackform>Help and technical support</bugreportfeedbackform>
+<bugreportbutton>Report a bug</bugreportbutton>
+<centerarealockedheader>Mysteries lie ahead...</centerarealockedheader>
+<centerarealockedtext>This area is unreachable in this version of Barotrauma. Please wait for future updates!</centerarealockedtext>
+<statisticspromptheader>Do you want to help us make Barotrauma better?</statisticspromptheader>
+<statisticsprompttext>Do you allow Barotrauma to send usage statistics and error reports to the developers? The data is anonymous, does not contain any personal information and is only used to help us diagnose issues and improve Barotrauma.</statisticsprompttext>
+<wikinotice>NOTICE: The wiki is maintained by volunteers, so it's possible some information is outdated. Please feel free to join and contribute yourself!</wikinotice>
+<statisticsconsentheader>Permission to use your information to develop Barotrauma</statisticsconsentheader>
+<statisticsconsenttext>Hello and welcome to Barotrauma! By default, we do not collect any information about you. If you would like to keep it that way, please click "No" below.\n\nIf you would like to click "Yes" and give us permission to collect some data, we will be able to use your gameplay statistics to improve Barotrauma. See a full list of gameplay data we will collect further down. We will store your consent and a hash of your Steam ID in our own database, but your information will always be handled anonymously when we use it for development.\n\nTo be able to use these statistics, we use the services of GameAnalytics Ltd. and comply with their terms of service. Thus, if you give us permission to use your gameplay data, you must also give permission to GameAnalytics to use your data for quality management and analytics purposes.\n\nYou can always change your choice regarding this consent in the game settings. For more information about privacy related to GameAnalytics Ltd., please see the following webpage: ‖color:255,255,255,255‖https://gameanalytics.com/privacy/‖end‖\n\nPlease review our privacy policy below:</statisticsconsenttext>
+<statisticsconsentstatement>I consent that the Developer has the right to collect, store and process my personal data and share such data with GameAnalytics Ltd. for quality management and analytics purposes.</statisticsconsentstatement>
+<statisticsconsenttickbox>Send user statistics</statisticsconsenttickbox>
+<gameanalyticsstatus.unknown>GameAnalytics hasn't been initialized.</gameanalyticsstatus.unknown>
+<gameanalyticsstatus.error>GameAnalytics could not be initialized due to an error.</gameanalyticsstatus.error>
+<gameanalyticsstatus.ask>GameAnalytics hasn't been initialized.</gameanalyticsstatus.ask>
+<gameanalyticsstatus.no>GameAnalytics has been disabled by user request.</gameanalyticsstatus.no>
+<gameanalyticsstatus.yes>GameAnalytics is active.</gameanalyticsstatus.yes>
+
+<!-- Connections -->
+<connection.power>power</connection.power>
+<connection.powerin>power_in</connection.powerin>
+<connection.powerout>power_out</connection.powerout>
+<connection.setstate>set_state</connection.setstate>
+<connection.togglestate>toggle_state</connection.togglestate>
+<connection.setpumpingspeed>set_speed</connection.setpumpingspeed>
+<connection.settargetwaterlevel>set_targetlevel</connection.settargetwaterlevel>
+<connection.signalin>signal_in</connection.signalin>
+<connection.signalout>signal_out</connection.signalout>
+<connection.signalinx>signal_in_[num]</connection.signalinx>
+<connection.signaloutx>signal_out_[num]</connection.signaloutx>
+<connection.turretaimingin>position_in</connection.turretaimingin>
+<connection.turrettriggerin>trigger_in</connection.turrettriggerin>
+<connection.togglelight>toggle_light</connection.togglelight>
+<connection.setcolor>set_color</connection.setcolor>
+<connection.shutdown>shutdown</connection.shutdown>
+<connection.temperatureout>temperature_out</connection.temperatureout>
+<connection.meltdownwarning>meltdown_warning</connection.meltdownwarning>
+<connection.signalr>signal_r</connection.signalr>
+<connection.signalg>signal_g</connection.signalg>
+<connection.signalb>signal_b</connection.signalb>
+<connection.signala>signal_a</connection.signala>
+<connection.setoutput>set_output</connection.setoutput>
+<connection.signalstore>signal_store</connection.signalstore>
+<connection.settargetsignal>set_targetsignal</connection.settargetsignal>
+<connection.setfrequency>set_frequency</connection.setfrequency>
+<connection.setoutputtype>set_outputtype</connection.setoutputtype>
+<connection.controlin>control_in</connection.controlin>
+<connection.setforce>set_force</connection.setforce>
+<connection.sonartransducerin>transducer_in</connection.sonartransducerin>
+<connection.steeringvelocityin>velocity_in</connection.steeringvelocityin>
+<connection.velocityxout>velocity_x_out</connection.velocityxout>
+<connection.velocityyout>velocity_y_out</connection.velocityyout>
+<connection.toggledocking>toggle_docking</connection.toggledocking>
+<connection.waterdatain>water_data_in</connection.waterdatain>
+<connection.oxygendatain>oxygen_data_in</connection.oxygendatain>
+<connection.activate>activate</connection.activate>
+<connection.dockingproximitysensor>proximity_sensor</connection.dockingproximitysensor>
+<connection.signalx>signal_[num]</connection.signalx>
+<connection.set_text>set_text</connection.set_text>
+<connection.stateout>state_out</connection.stateout>
+<connection.turretaimingout>position_out</connection.turretaimingout>
+<connection.turrettriggerout>trigger_out</connection.turrettriggerout>
+<connection.sonardataout>data_out</connection.sonardataout>
+<connection.batterychargestatusout>charge_out</connection.batterychargestatusout>
+<connection.batterychargepercentage>charge_%</connection.batterychargepercentage>
+<connection.batterysetrechargespeed>set_charge_rate</connection.batterysetrechargespeed>
+<connection.batteryrechargespeedout>charge_rate_out</connection.batteryrechargespeedout>
+<connection.setmodulus>set_modulus</connection.setmodulus>
+<connection.setexponent>set_exponent</connection.setexponent>
+<connection.setfissionrate>set_fissionrate</connection.setfissionrate>
+<connection.setturbineoutput>set_turbineoutput</connection.setturbineoutput>
+<connection.setchannel>set_channel</connection.setchannel>
+<connection.availablefuelout>fuel_out</connection.availablefuelout>
+<connection.setlight>set_light</connection.setlight>
+<connection.waterpercentageout>water_%</connection.waterpercentageout>
+<connection.lockstate>lock_state</connection.lockstate>
+<connection.settextcolor>set_text_color</connection.settextcolor>
+<connection.cleartext>clear_text</connection.cleartext>
+<connection.fuelpercentageout>fuel_percentage_left</connection.fuelpercentageout>
+<connection.setdelay>set_delay</connection.setdelay>
+<connection.conditionout>condition_out</connection.conditionout>
+<connection.highpressureout>high_pressure</connection.highpressureout>
+<connection.currentvelocityx>current_velocity_x</connection.currentvelocityx>
+<connection.currentvelocityy>current_velocity_y</connection.currentvelocityy>
+<connection.currentpositionx>current_position_x</connection.currentpositionx>
+<connection.currentpositiony>current_position_y</connection.currentpositiony>
+<connection.setdistancebasedforce>set_distancebasedforce</connection.setdistancebasedforce>
+<connection.setforcefluctuation>set_forcefluctuation</connection.setforcefluctuation>
+<connection.setforcefluctuationstrength>set_forcefluctuationstrength</connection.setforcefluctuationstrength>
+<connection.setforcefluctuationfrequency>set_forcefluctuationfrequency</connection.setforcefluctuationfrequency>
+<connection.setforcefluctuationinterval>set_forcefluctuationinterval</connection.setforcefluctuationinterval>
+<connection.loadvalueout>load_value_out</connection.loadvalueout>
+<connection.powervalueout>power_value_out</connection.powervalueout>
+<connection.low_oxygen>low_oxygen</connection.low_oxygen>
+<receivedsignal>Input: [signal]</receivedsignal>
+<sentsignal>Output: [signal]</sentsignal>
+
+<!-- Traitor system -->
+<sabotagebutton>Sabotage</sabotagebutton>
+<sabotaging>Sabotaging</sabotaging>
+
+<!-- Traitor objectives -->
+<traitorobjectivestartmessage>You have a new objective. The following goals need to be completed:\n[traitorgoalinfos]</traitorobjectivestartmessage>
+<traitorobjectivestartmessageserver>[traitorname] is the traitor and has the following goals:\n[traitorgoalinfos]</traitorobjectivestartmessageserver>
+<traitorobjectiveendmessagesuccess>[traitorname] was a traitor and succeeded in completing the given goals:\n [traitorgoalinfos]</traitorobjectiveendmessagesuccess>
+<traitorobjectiveendmessagesuccessdead>[traitorname] was a traitor and succeeded in completing the given goals but regrettably died in the process. Goals:\n[traitorgoalinfos]</traitorobjectiveendmessagesuccessdead>
+<traitorobjectiveendmessagesuccessdetained>[traitorname] was a traitor and succeeded in completing the given goals but was detained. Goals:\n[traitorgoalinfos]</traitorobjectiveendmessagesuccessdetained>
+<traitorobjectiveendmessagefailure>[traitorname] was a traitor but failed to complete the given goals:\n[traitorgoalinfos]</traitorobjectiveendmessagefailure>
+<traitorobjectiveendmessagefailuredead>[traitorname] was a traitor but died while failing to complete the given goals:\n[traitorgoalinfos]</traitorobjectiveendmessagefailuredead>
+<traitorobjectiveendmessagefailuredetained>[traitorname] was a traitor but got detained while failing to complete the given goals:\n[traitorgoalinfos]</traitorobjectiveendmessagefailuredetained>
+<traitorobjectivegoalinfoformat>- [statustext]\n</traitorobjectivegoalinfoformat>
+
+<!-- Component labels -->
+<addercomponent.timeframe>Timeframe</addercomponent.timeframe>
+<addercomponent.clampmin>Clamp min</addercomponent.clampmin>
+<addercomponent.clampmax>Clamp max</addercomponent.clampmax>
+<equalscomponent.timeframe>Timeframe</equalscomponent.timeframe>
+<equalscomponent.output>Output</equalscomponent.output>
+<equalscomponent.falseoutput>False output</equalscomponent.falseoutput>
+<andcomponent.timeframe>Timeframe</andcomponent.timeframe>
+<andcomponentcomponent.output>Output</andcomponentcomponent.output>
+<andcomponentcomponent.falseoutput>False output</andcomponentcomponent.falseoutput>
+<oscillatorcomponent.timeframe>Timeframe</oscillatorcomponent.timeframe>
+<oscillatorcomponent.outputtype>Output type</oscillatorcomponent.outputtype>
+<delaycomponent.delay>Delay</delaycomponent.delay>
+<delaycomponent.resetwhensignalreceived>Reset when signal received</delaycomponent.resetwhensignalreceived>
+<delaycomponent.resetwhendifferentsignalreceived>Reset when different signal received</delaycomponent.resetwhendifferentsignalreceived>
+<regexfindcomponent.output>Output</regexfindcomponent.output>
+<regexfindcomponent.falseoutput>False output</regexfindcomponent.falseoutput>
+<regexfindcomponent.expression>Expression</regexfindcomponent.expression>
+<regexfindcomponent.continuousoutput>Continuous output</regexfindcomponent.continuousoutput>
+<memorycomponent.value>Value</memorycomponent.value>
+<motionsensor.output>Output</motionsensor.output>
+<motionsensor.falseoutput>False output</motionsensor.falseoutput>
+<motionsensor.rangex>Range X</motionsensor.rangex>
+<motionsensor.rangey>Range Y</motionsensor.rangey>
+<signalcheckcomponent.targetsignal>Target signal</signalcheckcomponent.targetsignal>
+<signalcheckcomponent.output>Output</signalcheckcomponent.output>
+<signalcheckcomponent.falseoutput>False output</signalcheckcomponent.falseoutput>
+<waterdetector.output>Output</waterdetector.output>
+<waterdetector.falseoutput>False output</waterdetector.falseoutput>
+<wificomponent.channel>Channel</wificomponent.channel>
+
+<!-- Personality traits -->
+<personalitytrait>Trait</personalitytrait>
+<personalitytrait.professional>Professional</personalitytrait.professional>
+<personalitytrait.laid-back>Laid-back</personalitytrait.laid-back>
+<personalitytrait.rude>Rude</personalitytrait.rude>
+<personalitytrait.tough>Tough</personalitytrait.tough>
+<personalitytrait.joker>Joker</personalitytrait.joker>
+<personalitytrait.brokenenglish>Broken English</personalitytrait.brokenenglish>
+<personalitytrait.fearful>Fearful</personalitytrait.fearful>
+<personalitytrait.crazy>Crazy</personalitytrait.crazy>
+
+<!-- Event texts -->
+<eventtext.givingdirections.c1>You almost run into someone wearing a captain’s uniform. You can tell by their appearance that they are a visitor here and their time hasn’t been pleasant. They’re studying a map closely and seem deeply concerned about what they see. A revolver hangs loosely from their belt. They mutter a quick apology before returning to the map.</eventtext.givingdirections.c1>
+<eventtext.givingdirections.o1>“Hey, can I see that map? What’s the fastest route out of this shithole?”</eventtext.givingdirections.o1>
+<eventtext.givingdirections.o1.c1>They scratch the back of their head. “That’s what I’m trying to find out. The problem is that there’s a long way to where we’re going and we’re short on supplies. Can’t exactly afford to go back either.”</eventtext.givingdirections.o1.c1>
+<eventtext.givingdirections.o1.o1>“Let me take a look. We might be headed in the same direction.”</eventtext.givingdirections.o1.o1>
+<eventtext.givingdirections.o1.o1.c1>Together you manage to find a shortcut to the next outpost. It’s a little on the dangerous side, but what isn’t? You bid the captain farewell.</eventtext.givingdirections.o1.o1.c1>
+<eventtext.givingdirections.o1.o1.o1>A job well done.</eventtext.givingdirections.o1.o1.o1>
+<eventtext.givingdirections.o1.o1.c2>Even with two pairs of eyes, you can’t find an easier route. You leave the captain, hoping their fortune turns soon.</eventtext.givingdirections.o1.o1.c2>
+<eventtext.givingdirections.o1.o1.o2>A shame.</eventtext.givingdirections.o1.o1.o2>
+<eventtext.givingdirections.o1.o2>“Sucks to be you. Bon voyage!”</eventtext.givingdirections.o1.o2>
+<eventtext.givingdirections.o2>Attempt to grab the revolver when their back is turned.</eventtext.givingdirections.o2>
+<eventtext.givingdirections.o2.c1>You deftly liberate the gun from its holster and stuff it in your pocket. Your heart skips a beat when the captain turns toward you, but they only give you a quick glance and continue pacing back and forth. You decide it’s best to put some distance between the two of you.</eventtext.givingdirections.o2.c1>
+<eventtext.givingdirections.o2.o1>Neat, free gun.</eventtext.givingdirections.o2.o1>
+<eventtext.givingdirections.o2.c2>Just as you’re about to lift the gun, the captain suddenly turns around. Your eyes meet and theirs widen as the situation dawns on them. They reach for the gun.</eventtext.givingdirections.o2.c2>
+<eventtext.givingdirections.o2.o2>Uh oh.</eventtext.givingdirections.o2.o2>
+<eventtext.givingdirections.o3>Ignore them and keep walking.</eventtext.givingdirections.o3>
+<eventtext.soundinthevent.c1>You hear a strange scraping sound coming from a nearby vent. Curious, you peer through the slats of the vent cover, but it’s far too dark in there to see anything... A moment later you hear the sound again, you’re sure of it!</eventtext.soundinthevent.c1>
+<eventtext.soundinthevent.o1>Unscrew the vent cover to take a better look inside.</eventtext.soundinthevent.o1>
+<eventtext.soundinthevent.o1.c1>You manage to get the vent off easily enough and spot the source of the noise right away: The fan blade is brushing against a small metal box. Carefully retrieving it, you open it and find 1,000 marks!</eventtext.soundinthevent.o1.c1>
+<eventtext.soundinthevent.o1.c2>You fumble the vent cover as you’re removing it and brush against the spinning blade. It slices into your hand before you can pull away, nicking an artery.</eventtext.soundinthevent.o1.c2>
+<eventtext.soundinthevent.o2>Shine your flashlight through the vent slats and see if you can spot anything unusual.</eventtext.soundinthevent.o2>
+<eventtext.soundinthevent.o2.c1>An enraged mudraptor bursts from the vent!</eventtext.soundinthevent.o2.c1>
+<eventtext.soundinthevent.o2.c2>Three enraged mudraptors burst from the vent!</eventtext.soundinthevent.o2.c2>
+<eventtext.soundinthevent.o3>Ignore it.</eventtext.soundinthevent.o3>
+<eventtext.soundinthevent.o3.c1>Seems it might have just been in your head... These outposts can get on your nerves after a while.</eventtext.soundinthevent.o3.c1>
+<eventtext.soundinthevent.o3.o1>Take a deep breath.</eventtext.soundinthevent.o3.o1>
+<eventtext.soundinthevent.o3.c2>You decide you don’t have time for this nonsense and creep past the noisy vent. Not your problem! Whatever it is, someone else will sort that out!</eventtext.soundinthevent.o3.c2>
+<eventtext.soundinthevent.o3.o2>Bah!</eventtext.soundinthevent.o3.o2>
+<eventtext.soundinthevent.o3.c3>You decide you don’t have time for this nonsense and creep past the noisy vent, but you get the nagging feeling you've not seen the end of this yet...</eventtext.soundinthevent.o3.c3>
+<eventtext.soundinthevent.o3.o3>A foreshadowing?</eventtext.soundinthevent.o3.o3>
+<eventtext.impromptuengineering.c1>A nearby research terminal draws your attention. It flickers on and off rapidly for a while, then goes dark.</eventtext.impromptuengineering.c1>
+<eventtext.impromptuengineering.o1>Diagnose.</eventtext.impromptuengineering.o1>
+<eventtext.impromptuengineering.o1.c1>You try pressing a couple buttons. No response. Opening a side panel reveals a tangle of wires and some kind of a processing unit seemingly in perfect condition.</eventtext.impromptuengineering.o1.c1>
+<eventtext.impromptuengineering.o1.o1>Scavenge for parts.</eventtext.impromptuengineering.o1.o1>
+<eventtext.impromptuengineering.o1.o1.c1>You quickly unscrew the parts that look the most useful, carefully place them in your pocket and then put the panel back.</eventtext.impromptuengineering.o1.o1.c1>
+<eventtext.impromptuengineering.o1.o1.o1>Finders keepers.</eventtext.impromptuengineering.o1.o1.o1>
+<eventtext.impromptuengineering.o1.o1.c2>Whoever put this thing together did a poor job. You deem it impossible to salvage anything without taking the whole thing apart. While you’re elbow deep in the wiring, you hear footsteps approach. Panicking, you yank some wires out and slam the panel back in its place.</eventtext.impromptuengineering.o1.o1.c2>
+<eventtext.impromptuengineering.o1.o1.o2>Act natural.</eventtext.impromptuengineering.o1.o1.o2>
+<eventtext.impromptuengineering.o1.o2>Attempt to repair the terminal.</eventtext.impromptuengineering.o1.o2>
+<eventtext.impromptuengineering.o1.o2.c1>You jiggle some display cables and the terminal comes back to life. Poking around the system reveals some opportunities. Looks like it’s connected to the outpost’s outfitting service. What do you want to do?</eventtext.impromptuengineering.o1.o2.c1>
+<eventtext.impromptuengineering.o1.o2.o1>Request free coilgun ammunition.</eventtext.impromptuengineering.o1.o2.o1>
+<eventtext.impromptuengineering.o1.o2.o1.c1>After clicking around a bit, you successfully order two boxes of coilgun ammunition for your vessel, free of charge.</eventtext.impromptuengineering.o1.o2.o1.c1>
+<eventtext.impromptuengineering.o1.o2.o1.o1>This is what they have insurance for, right?</eventtext.impromptuengineering.o1.o2.o1.o1>
+<eventtext.impromptuengineering.o1.o2.o2>Install an old-school first-person shooter on the system.</eventtext.impromptuengineering.o1.o2.o2>
+<eventtext.impromptuengineering.o1.o2.o2.c1>You carry on the age-old tradition of installing the game on any platform possible. This accomplishes nothing except to give you a good feeling as you chuckle to yourself.</eventtext.impromptuengineering.o1.o2.o2.c1>
+<eventtext.impromptuengineering.o1.o2.o2.o1>Mission complete.</eventtext.impromptuengineering.o1.o2.o2.o1>
+<eventtext.impromptuengineering.o1.o2.c2>You try turning the terminal off and on again. Nothing. Now what? That’s the only thing you were taught to do and it usually solves the problem. Frustrated, you jiggle some wires behind the terminal when you feel a sharp pain shoot up your arm, along with a shower of sparks. You decide that’s enough injury for now.</eventtext.impromptuengineering.o1.o2.c2>
+<eventtext.impromptuengineering.o1.o2.o3>Ouch.</eventtext.impromptuengineering.o1.o2.o3>
+<eventtext.impromptuengineering.o1.o3>Back away. There have to be some nerds around here who get paid to fix these things.</eventtext.impromptuengineering.o1.o3>
+<eventtext.impromptuengineering.o2>Ignore.</eventtext.impromptuengineering.o2>
+
+<eventtext.clownrelations1.o1>Inspect.</eventtext.clownrelations1.o1>
+<eventtext.clownrelations1.o1.c1>The box contains bike horns, masks and oversized shoes. As you’re rummaging through it, a posse of people dressed in clown suits march down the hallway. One of them walks straight up to the box, picks it up and stares at you, then at your hand. You realize you’re still holding a bike horn in your hand.</eventtext.clownrelations1.o1.c1>
+<eventtext.clownrelations1.o1.o1>Apologize and put the horn back in the box.</eventtext.clownrelations1.o1.o1>
+<eventtext.clownrelations1.o1.o1.c1>The jester turns around stoically and continues on with the group, leaving you to scratch your head.</eventtext.clownrelations1.o1.o1.c1>
+<eventtext.clownrelations1.o1.o2>Honk the horn.</eventtext.clownrelations1.o1.o2>
+<eventtext.clownrelations1.o1.o2.c1>You raise the horn to your eye level and squeeze it. Instantly, chaos erupts among the group of clowns. They applaud, prance around and giggle uncontrollably, as if the sound of the horn were the funniest thing imaginable. One of them ruffles your hair approvingly.</eventtext.clownrelations1.o1.o2.c1>
+<eventtext.clownrelations1.o2>Better not.</eventtext.clownrelations1.o2>
+<eventtext.clownrelations2.c1>A clown is loitering nearby. When he sees you approach, he perks up and tries to get your attention.</eventtext.clownrelations2.c1>
+<eventtext.clownrelations2.o1>See what he has to say.</eventtext.clownrelations2.o1>
+<eventtext.clownrelations2.o1.c1>The jester reaches out to you. In a similar motion, you raise your own arm and simultaneously you both honk each other’s noses. Twice, as is tradition when meeting a new brother. Without saying a word, he reaches into his pack and hands you a brand new bike horn. He salutes you and leaves, his footsteps squeaking rhythmically.</eventtext.clownrelations2.o1.c1>
+<eventtext.clownrelations2.o1.c2>Before you can react, the loathsome harlequin reaches out and painfully honks your nose.</eventtext.clownrelations2.o1.c2>
+<eventtext.clownrelations2.o1.o1>Truly, they are a scourge on Europa.</eventtext.clownrelations2.o1.o1>
+<eventtext.clownrelations2.o2>Avoid eye contact.</eventtext.clownrelations2.o2>
+<eventtext.goodsamaritan.c1>You come across an unconscious worker. There are no signs of violence and nobody else is around.</eventtext.goodsamaritan.c1>
+<eventtext.goodsamaritan.o1>Diagnose.</eventtext.goodsamaritan.o1>
+<eventtext.goodsamaritan.o1.c1>The patient’s lips are blue, their breaths are short and shallow and their heart is beating very slowly. Telltale signs of Fentanyl overdose. Injection marks on their arm confirm your diagnosis.</eventtext.goodsamaritan.o1.c1>
+<eventtext.goodsamaritan.o1.o1>Treat the overdose with Naloxone.</eventtext.goodsamaritan.o1.o1>
+<eventtext.goodsamaritan.o1.o1.c1>You treat the overdose with Naloxone. The patient is still unconscious, but their condition is stable.</eventtext.goodsamaritan.o1.o1.c1>
+<eventtext.goodsamaritan.o1.o1.c2>You have no Naloxone. All you can do at this point is make sure the patient's life is not in immediate danger and alert the local officials.</eventtext.goodsamaritan.o1.o1.c2>
+<eventtext.goodsamaritan.o1.o2>Give them basic first aid and alert the outpost doctor.</eventtext.goodsamaritan.o1.o2>
+<eventtext.goodsamaritan.o1.o2.c1>You make sure the patient is stable and decide to let the local officials deal with the rest.</eventtext.goodsamaritan.o1.o2.c1>
+<eventtext.goodsamaritan.o1.o2.o1>Good job.</eventtext.goodsamaritan.o1.o2.o1>
+<eventtext.goodsamaritan.o1.c2>Well, he's unconscious all right. Probably just sleeping off a hangover or something.</eventtext.goodsamaritan.o1.c2>
+<eventtext.goodsamaritan.o1.o3>Eh, that's the best I can do for now.</eventtext.goodsamaritan.o1.o3>
+<eventtext.goodsamaritan.o2>Check their pockets.</eventtext.goodsamaritan.o2>
+<eventtext.goodsamaritan.o2.c1>You find some spare change in their pocket, but a passerby catches you in the act. It seems looting injured people is frowned upon here.</eventtext.goodsamaritan.o2.c1>
+<eventtext.goodsamaritan.o3>Step over their body and continue on.</eventtext.goodsamaritan.o3>
+<eventtext.propaganda.c1>A row of posters line the wall. It looks like the outpost directorial election is coming up. A gallery of stern-looking people are observing the hallway, conveniently grouped according to their political affiliation.</eventtext.propaganda.c1>
+<eventtext.propaganda.o1>Inspect the posters.</eventtext.propaganda.o1>
+<eventtext.propaganda.o1.c1>Some of the Coalition Party’s boards have fallen victim to vandalism. “Bring power back to the hands of the people!” and “Down with the oligarchy!” are some of the catchphrases spray-painted on candidates’ faces. Separatists up to their usual tricks.</eventtext.propaganda.o1.c1>
+<eventtext.propaganda.o1.o1>Add some of your own flair too.</eventtext.propaganda.o1.o1>
+<eventtext.propaganda.o1.o1.c1>You draw some vulgar art of your own, then quickly move on before the fascists catch you in the act.</eventtext.propaganda.o1.o1.c1>
+<eventtext.propaganda.o1.o1.o1>That'll show them.</eventtext.propaganda.o1.o1.o1>
+<eventtext.propaganda.o1.o2>Keep walking.</eventtext.propaganda.o1.o2>
+<eventtext.propaganda.o2>Not interested in outpost politics.</eventtext.propaganda.o2>
+<eventtext.goblincooking1.c1>As you’re walking down the hallway, you catch a whiff of something sweet.</eventtext.goblincooking1.c1>
+<eventtext.goblincooking1.o1>“Who’s cooking?”</eventtext.goblincooking1.o1>
+<eventtext.goblincooking1.o1.c1>You sniff around and find the aroma coming from a nearby vent. Suddenly you feel very hungry.</eventtext.goblincooking1.o1.c1>
+<eventtext.goblincooking1.o1.o1>Try to find the source.</eventtext.goblincooking1.o1.o1>
+<eventtext.goblincooking1.o1.o1.c1>You peer into the dark vent, trying to find out where it leads. No avail—the vents here are all connected. Even if you were to, say, climb in and follow the smell, you’d stand no chance of finding the sau–, er…source.</eventtext.goblincooking1.o1.o1.c1>
+<eventtext.goblincooking1.o1.o1.o1>“Climb in the vent? Good idea!”</eventtext.goblincooking1.o1.o1.o1>
+<eventtext.goblincooking1.o1.o1.o1.c1>It takes you no effort to remove the vent cover and wriggle inside. The smell is now intoxicating and it seems to come from every direction. Desperate, you start crawling. Eventually the vent splits into two paths. Something clicks in your head. This isn’t right.</eventtext.goblincooking1.o1.o1.o1.c1>
+<eventtext.goblincooking1.o1.o1.o1.o1>“I’ve come this far. Might as well keep going.”</eventtext.goblincooking1.o1.o1.o1.o1>
+<eventtext.goblincooking1.o1.o1.o1.o1.c1>You pick a direction and crawl on. Suddenly it doesn’t smell so good anymore. The aroma has gradually turned into a sickly sweet, rotten stink. You start panicking as the tight walls begin closing in. Your vision blurs and everything goes dark. The last thing you see is a vaguely humanoid shape squirming toward your helpless body.</eventtext.goblincooking1.o1.o1.o1.o1.c1>
+<eventtext.goblincooking1.o1.o1.o1.o1.o1>Goodbye.</eventtext.goblincooking1.o1.o1.o1.o1.o1>
+<eventtext.goblincooking1.o1.o1.o1.o1.o1.c1>The next thing you know, you wake up outside the vent. Strangely, the vent is screwed shut and there are no signs of anyone having entered it. A quick inspection reveals you're uninjured, but your pockets are empty of change.</eventtext.goblincooking1.o1.o1.o1.o1.o1.c1>
+<eventtext.goblincooking1.o1.o1.o1.o2>Turn back.</eventtext.goblincooking1.o1.o1.o1.o2>
+<eventtext.goblincooking1.o1.o1.o1.o2.c1>With great effort, you manage to turn around and make your way back to where you entered. While unhurt, you have a feeling you brought back something with you from the vents.</eventtext.goblincooking1.o1.o1.o1.o2.c1>
+<eventtext.goblincooking1.o1.o1.o1.o2.o1>“At least it's over now.”</eventtext.goblincooking1.o1.o1.o1.o2.o1>
+<eventtext.goblincooking1.o1.o1.o2>“What a fool I would be if I climbed in there…”</eventtext.goblincooking1.o1.o1.o2>
+<eventtext.goblincooking1.o1.o1.o2.c1>You chuckle at the idea of climbing into an air vent in a strange outpost in search of food. Even so, it takes some effort to leave the vent and the alluring aroma within.</eventtext.goblincooking1.o1.o1.o2.c1>
+<eventtext.goblincooking1.o1.o1.o2.o1>Now to get back to business.</eventtext.goblincooking1.o1.o1.o2.o1>
+<eventtext.goblincooking1.o1.o2>Ignore the siren call of the scent.</eventtext.goblincooking1.o1.o2>
+<eventtext.goblincooking1.o2>Ignore the aroma.</eventtext.goblincooking1.o2>
+<eventtext.outbreak.c1>You overhear someone nearby talking to a radio. “Yeah, I gave them the eggs. Uh huh… Yeah. I made sure they swallowed ‘em. ...I don’t know, maybe three minutes ago?” That’s weird, you think to yourself. Hopefully nothing weird comes out of this.</eventtext.outbreak.c1>
+<eventtext.outbreak.o1>OK.</eventtext.outbreak.o1>
+<eventtext.miketheidiot1.c1>Someone has set up shop in their dorm room. A sign on the door says “Mike the Scryer: He’ll divine answers to all your questions!”</eventtext.miketheidiot1.c1>
+<eventtext.miketheidiot1.o1>Step inside.</eventtext.miketheidiot1.o1>
+<eventtext.miketheidiot1.o1.c1>You peek inside. Heavy curtains line the walls that are otherwise full of crudely drawn pictures of monsters, expensive submarines and well-endowed women. In the middle of the room is a round table with a couple of empty bottles of Europan moonshine and a crystal ball. A man wearing thick glasses and a sloppily tied turban is sitting behind the table. He squints and motions you to take a seat. “I’m Mike,” he croaks. “5 marks to ask me anything.”</eventtext.miketheidiot1.o1.c1>
+<eventtext.miketheidiot1.o1.o1>Pay him.</eventtext.miketheidiot1.o1.o1>
+<eventtext.miketheidiot1.o1.o1.c1>You sit down at the table opposite Mike. A pungent smell of alcohol wafts from him. “Come on, then. What d’you wanna know about?”</eventtext.miketheidiot1.o1.o1.c1>
+<eventtext.miketheidiot1.o1.o1.o1>“What’s the meaning of life?”</eventtext.miketheidiot1.o1.o1.o1>
+<eventtext.miketheidiot1.o1.o1.o1.c1>Mike conjures up a bottle of booze. “Real original.” He takes a swig. “There are a few schools of thought, but basically it boils down to this: Either you make life good for yourself or do good by others.” He reaches over the table to offer you a drink and knocks down a few bottles in the process. They shatter on the floor. “Shit.” Mike slumps down dejectedly. “There’s no God,” he mutters as he pushes himself up and starts for the cleaning closet. “Session’s over.”</eventtext.miketheidiot1.o1.o1.o1.c1>
+<eventtext.miketheidiot1.o1.o1.o1.o1>All right.</eventtext.miketheidiot1.o1.o1.o1.o1>
+<eventtext.miketheidiot1.o1.o1.o2>“What do you reckon is in the center of Europa?”</eventtext.miketheidiot1.o1.o1.o2>
+<eventtext.miketheidiot1.o1.o1.o2.c1>Mike blinks. “What? I don’t know. Lava? Or is it magma in this case?” He turns toward a bunk. “Hey Jimmy! Is it lava if it’s underground or magma?” A bundle of sheets stirs a bit. “What is–? Fuck off Mike, I’m sleeping,” it mumbles back. Mike scratches the back of his head. “It’s gotta be one or the other. What else could it be?” He chuckles and flashes his rotting teeth. “A gateway to Earth? Ridiculous.”</eventtext.miketheidiot1.o1.o1.o2.c1>
+<eventtext.miketheidiot1.o1.o1.o2.o1>Yeah, I guess it is.</eventtext.miketheidiot1.o1.o1.o2.o1>
+<eventtext.miketheidiot1.o1.o1.o3>“What’s up with the clowns?”</eventtext.miketheidiot1.o1.o1.o3>
+<eventtext.miketheidiot1.o1.o1.o3.c1>“Funny little fuckers, aren’t they?” Mike leans back in his chair. It squeaks in protest. “The legend has it that a cargo ship carrying entertainment supplies wrecked somewhere near Uusi-Turcu. They recovered a single survivor weeks later. She was wearing a striped shirt, rubber mask and gibbering something about a 'Honkmother' who had kept her company.” He picks his nose and pensively inspects his findings. “Ever since, there’s been a group of ‘em what worships the Honkmother.” “Really?” you ask, enthralled. He flicks the booger off. “No. But that’s all I got.”</eventtext.miketheidiot1.o1.o1.o3.c1>
+<eventtext.miketheidiot1.o1.o1.o3.o1>...I want my money back.</eventtext.miketheidiot1.o1.o1.o3.o1>
+<eventtext.miketheidiot1.o1.o2>Back out.</eventtext.miketheidiot1.o1.o2>
+<eventtext.miketheidiot1.o2>Ignore all charlatans.</eventtext.miketheidiot1.o2>
+<eventtext.miketheidiot2.c1>You run into a familiar face. It seems Mike the fortune teller has found his way here. This time he’s wearing a janitor’s overalls and is in the process of mopping up a puddle of what seems like someone’s former breakfast.</eventtext.miketheidiot2.c1>
+<eventtext.miketheidiot2.o1>“Moving up in the world, eh?”</eventtext.miketheidiot2.o1>
+<eventtext.miketheidiot2.o1.c1>“Oh, hey. Yeah, I figured it was time to bounce after the... You know, the incident. With the reactor.” You decide not to delve deeper. “I still have plenty of wisdom to dispense. 5 marks or a pack of cigarettes.”</eventtext.miketheidiot2.o1.c1>
+<eventtext.miketheidiot2.o1.o1>Pay up.</eventtext.miketheidiot2.o1.o1>
+<eventtext.miketheidiot2.o1.o1.c1>He leans on his mop. “So what can I help you with?”</eventtext.miketheidiot2.o1.o1.c1>
+<eventtext.miketheidiot2.o1.o1.o1>“How’s Earth?”</eventtext.miketheidiot2.o1.o1.o1>
+<eventtext.miketheidiot2.o1.o1.o1.c1>Mike takes out a cigarette and puts it in his mouth. “Guess it’s still out there. A bit worse for wear though, am I right?” He flashes a toothless smile and fishes out a lighter from his pocket. “I had a pen pal there a few years back, you know? A real prolific writer. No wonder, you ought to get a lot of writing done with twelve fingers.” He lights the cigarette, takes a drag and coughs his lungs out. “Fuck me!” He exclaims after the fit subsides. “People really smoke these things?” He tosses the whole pack in the trash. “Not for me.”</eventtext.miketheidiot2.o1.o1.o1.c1>
+<eventtext.miketheidiot2.o1.o1.o1.o1>Good to know.</eventtext.miketheidiot2.o1.o1.o1.o1>
+<eventtext.miketheidiot2.o1.o1.o2>“What happened to Mantises?”</eventtext.miketheidiot2.o1.o1.o2>
+<eventtext.miketheidiot2.o1.o1.o2.c1>“Oh, them? Natural selection. Some things are just better suited for survival.” He rolls up his sleeve, revealing a crude tattoo that states: “I fuck with boots on.” He continues: “Tougher. Faster. Prettier. Only the strong come out on top.” A passerby tosses a soda can on the floor and Mike bends to pick it up. “Apex predators, that’s what we are,” he declares as he places the can in the trash.</eventtext.miketheidiot2.o1.o1.o2.c1>
+<eventtext.miketheidiot2.o1.o1.o2.o1>Truth.</eventtext.miketheidiot2.o1.o1.o2.o1>
+<eventtext.miketheidiot2.o1.o1.o3>“Why would someone shoot a man before throwing him out of an airlock?”</eventtext.miketheidiot2.o1.o1.o3>
+<eventtext.miketheidiot2.o1.o1.o3.c1>“It’s all part of the plan,” Mike muses. “Sending a message. You gotta assert dominance, otherwise you get no respect.” He gets back to mopping the puke off of the floor. “It’s how you survive on a submarine, same as in prison.” “You were incarcerated?” you ask. “Oh, I’ve been all around. I tell you, the things you have to do to get respect... I still have trouble walking straight.”</eventtext.miketheidiot2.o1.o1.o3.c1>
+<eventtext.miketheidiot2.o1.o1.o3.o1>That's too much info.</eventtext.miketheidiot2.o1.o1.o3.o1>
+<eventtext.miketheidiot2.o1.o2>Act like someone’s calling you on the radio.</eventtext.miketheidiot2.o1.o2>
+<eventtext.miketheidiot2.o2>Sneak by.</eventtext.miketheidiot2.o2>
+<eventtext.miketheidiot.nomoney>“Mike knows many things, and he'll tell you some. But only if you have the coin.”</eventtext.miketheidiot.nomoney>
+<eventtext.firefighting.c1>You notice a thin trail of smoke rising from a trash can.</eventtext.firefighting.c1>
+<eventtext.firefighting.o1>Investigate.</eventtext.firefighting.o1>
+<eventtext.firefighting.o1.c1>There is a lit cigarette in the trash. It seems dangerously close to igniting a larger flame.</eventtext.firefighting.o1.c1>
+<eventtext.firefighting.o1.o1>Put it out.</eventtext.firefighting.o1.o1>
+<eventtext.firefighting.o1.o1.c1>You get some minor burns when you fish the cigarette out and stomp out the fledgling fire, but nothing major.</eventtext.firefighting.o1.o1.c1>
+<eventtext.firefighting.o1.o2>See what happens.</eventtext.firefighting.o1.o2>
+<eventtext.firefighting.o2>Not my problem.</eventtext.firefighting.o2>
+<eventtext.sleightofhand.c1>Some workers are huddled together, playing a game with dice. They have piled various items together, presumably as prizes for the winner. Among them is a shiny, symmetrical item. You recognize it as alien, and probably worth more than the other items combined.</eventtext.sleightofhand.c1>
+<eventtext.sleightofhand.o1>Join the game and attempt to win the item for yourself.</eventtext.sleightofhand.o1>
+<eventtext.sleightofhand.o1.c1>You quickly deduce that it’s a game of pure luck. You take a few careful risks and it pays off. You walk away with the prized alien ornament.</eventtext.sleightofhand.o1.c1>
+<eventtext.sleightofhand.o1.c2>Unsurprisingly, the other players are more experienced in the game than you. After betting a sizeable amount of cash, you walk away with nothing. You have lost 500 marks.</eventtext.sleightofhand.o1.c2>
+<eventtext.sleightofhand.o2>Create a distraction and try to snatch it without anyone noticing.</eventtext.sleightofhand.o2>
+<eventtext.sleightofhand.o2.c1>You start yelling “Fire! Fire!” and quickly grab the item in the ensuing chaos. You hide it deep in your pocket. It’s time to go before they’re any wiser.</eventtext.sleightofhand.o2.c1>
+<eventtext.sleightofhand.o2.c2>You start yelling “Fire! Fire!” and quickly grab the item in the ensuing chaos. However, one of them catches you in the act and calls security.</eventtext.sleightofhand.o2.c2>
+<eventtext.sleightofhand.o3>Keep moving.</eventtext.sleightofhand.o3>
+<eventtext.foreshadowing.c1>You feel the faintest of tugs near your pants. When you finally get some space, you find someone has slipped a note in your pocket.</eventtext.foreshadowing.c1>
+<eventtext.foreshadowing.o1>Read it.</eventtext.foreshadowing.o1>
+<eventtext.foreshadowing.o1.c1>It states: “The truth is out there. cbspusbvnbhbnf.dpn/efsfmjdu/beweht.htm”</eventtext.foreshadowing.o1.c1>
+<eventtext.foreshadowing.o2>Toss it.</eventtext.foreshadowing.o2>
+<eventtext.separatistrelations.c1>You run into some separatists. Being on friendly terms with them, you receive some insight into how this place functions.</eventtext.separatistrelations.c1>
+<eventtext.separatistrelations.c2>You see some separatists creating their trademark art on an unsuspecting trash can.</eventtext.separatistrelations.c2>
+<eventtext.separatistrelations.o1>Confront them.</eventtext.separatistrelations.o1>
+<eventtext.separatistrelations.o1.c1>“Hey! That’s official property!” you decide to yell. The youngsters stop what they’re doing and attack you.</eventtext.separatistrelations.o1.c1>
+<eventtext.separatistrelations.o2>Help them.</eventtext.separatistrelations.o2>
+<eventtext.separatistrelations.o2.c1>You act as a lookout for the two activists. When they finish their masterpiece, you exchange a few words. They deem you loyal to their cause and promise to put a good word in for you.</eventtext.separatistrelations.o2.c1>
+<eventtext.separatistrelations.o3>Ignore them.</eventtext.separatistrelations.o3>
+<eventtext.huskcultrelations.c1>Someone is handing out flyers advertising some kind of a communion. You spot a familiar-looking logo in the corner. It’s just the local husk cult members proselytizing. It might be fun to check out the ritual.</eventtext.huskcultrelations.c1>
+<eventtext.huskcultrelations.o1>Sure, what’s the worst that could happen?</eventtext.huskcultrelations.o1>
+<eventtext.huskcultrelations.o1.c1>You make your way into the advertised dorm. It’s the usual stuff: “Fleshbags” this and “ascension” that. The local chapter guys are very friendly and they invite you to partake of the communion.</eventtext.huskcultrelations.o1.c1>
+<eventtext.huskcultrelations.o1.o1>“Don’t mind if I do.”</eventtext.huskcultrelations.o1.o1>
+<eventtext.huskcultrelations.o1.o1.c1>You gulp down some husk eggs. A bit salty. Afterwards you joke around with the folks a bit and you part in good spirits. You’ve made some lifelong friends here tonight. That reminds you to pick up some husk antidote at the counter and take some of it pretty soon-ish.</eventtext.huskcultrelations.o1.o1.c1>
+<eventtext.huskcultrelations.o1.o2>Make up an excuse to leave.</eventtext.huskcultrelations.o1.o2>
+<eventtext.huskcultrelations.o2>Suicide cults are fun but not for me.</eventtext.huskcultrelations.o2>
+<eventtext.engineers_are_special.c1>The engineering crew chief working on a beaten-up old shuttle engine scowls at you for a moment, as if sizing you up.</eventtext.engineers_are_special.c1>
+<eventtext.engineers_are_special.c1.c1>You there, you look halfway competent. Give me a hand with this engine.</eventtext.engineers_are_special.c1.c1>
+<eventtext.engineers_are_special.c1.o1>Refuse.</eventtext.engineers_are_special.c1.o1>
+<eventtext.engineers_are_special.c1.o1.c1>You decline as tactfully as you can but he’s clearly not happy. He shakes his head and silently goes back to work, trying to refit the engine.</eventtext.engineers_are_special.c1.o1.c1>
+<eventtext.engineers_are_special.c1.o2>Help him with his engine.</eventtext.engineers_are_special.c1.o2>
+<eventtext.engineers_are_special.c1.o2.c1>You roll up your sleeves and get to work refitting the engine with him. After a few minutes of work you both manage to get it running. “Thanks. I’m sure I’d have got it going on my own eventually but you’ve saved me some time. Let me know if you want any work done on your sub and I’ll see about giving you a little discount for your trouble.”</eventtext.engineers_are_special.c1.o2.c1>
+<eventtext.engineers_are_special.c1.o2.c2>You roll up your sleeves and get to work refitting the engine with him. In spite of your best efforts though, the engine refuses to start. He slams shut the access panel. “Well I guess this is one for the scrappers. Thanks for the help anyhow.”</eventtext.engineers_are_special.c1.o2.c2>
+<eventtext.engineers_are_special.c1.c2>He clearly doesn’t care much for what he sees and returns to his work. Apparently you’ve somehow not passed muster.</eventtext.engineers_are_special.c1.c2>
+<eventtext.mediator.c1>Two workers are arguing loudly. What once might have been a civil discussion about inter-Europan politics has devolved into a shouting match—it isn’t readily apparent how the other guy’s mother factors into it.</eventtext.mediator.c1>
+<eventtext.mediator.o1>Try to calm the situation down.</eventtext.mediator.o1>
+<eventtext.mediator.o1.c1>You move a bit closer. For a moment, the two loudmouths stop arguing and look at you.</eventtext.mediator.o1.c1>
+<eventtext.mediator.o1.o1>“Hey fellas. Not my place to interrupt, but they can hear your conversation back in Versas.”</eventtext.mediator.o1.o1>
+<eventtext.mediator.o1.o1.c1>The two workers are humbled by your parental demeanor. They quiet down and get back to their duties.</eventtext.mediator.o1.o1.c1>
+<eventtext.mediator.o1.o1.c2>They are even more pissed off now, but this time at you. Your condescending manner of speaking does you no favors.</eventtext.mediator.o1.o1.c2>
+<eventtext.mediator.o1.o2>“I suggest you two shut your traps before I finish counting to three. One…”</eventtext.mediator.o1.o2>
+<eventtext.mediator.o1.o2.c1>They get the feeling you have the means to back up your words. The two workers go quiet in a record time.</eventtext.mediator.o1.o2.c1>
+<eventtext.mediator.o1.o2.c2>They look at you bemusedly.</eventtext.mediator.o1.o2.c2>
+<eventtext.mediator.o1.o2.o1>Two...</eventtext.mediator.o1.o2.o1>
+<eventtext.mediator.o1.o2.o1.c1>They look at each other. Clearly, they’re shaking in their boots.</eventtext.mediator.o1.o2.o1.c1>
+<eventtext.mediator.o1.o2.o1.o1>Three.</eventtext.mediator.o1.o2.o1.o1>
+<eventtext.mediator.o1.o2.o1.o1.c1>A smile appears on the other’s face and you smile at him in turn. You feel powerful. Your smile quickly turns into a frown when they grab their tools and walk toward you with ill intent.</eventtext.mediator.o1.o2.o1.o1.c1>
+<eventtext.mediator.o2>Egg them on.</eventtext.mediator.o2>
+<eventtext.mediator.o2.c1>You don’t know exactly what’s going on, but join in the shouting anyway. “Remember what he said about your mom?” “That shit doesn’t fly where I’m from!” You feel giddy as the shouting crescendos into a fistfight and the two workers start reaching for their tools. It might be a good time to vanish from the area.</eventtext.mediator.o2.c1>
+<eventtext.mediator.o3>Nothing to see here. Keep walking.</eventtext.mediator.o3>
+<eventtext.blackmarket.c1>“Hey! Got something for ya here if you’re interested…”</eventtext.blackmarket.c1>
+<eventtext.blackmarket.o1>Listen to what they have to say.</eventtext.blackmarket.o1>
+<eventtext.blackmarket.o1.c1>“I happened to find some nice alien contraband. It’s yours for 1,000 marks. I’ll throw in a power cell too. What do you say?” He opens his coat to reveal a pistol that looks like genuine alien tech.</eventtext.blackmarket.o1.c1>
+<eventtext.blackmarket.o1.c1.c1>Do you want to buy the pistol for 1,000 marks?</eventtext.blackmarket.o1.c1.c1>
+<eventtext.blackmarket.o1.c1.o1>Yes, please.</eventtext.blackmarket.o1.c1.o1>
+<eventtext.blackmarket.o1.c1.o1.c1>He hands you the pistol. It’s a genuine article.</eventtext.blackmarket.o1.c1.o1.c1>
+<eventtext.blackmarket.o1.c1.o1.c2>He shoves the pistol in your hand and quickly shuffles off. On a closer look, the pistol is actually a children’s toy. You angrily toss it aside.</eventtext.blackmarket.o1.c1.o1.c2>
+<eventtext.blackmarket.o1.c1.o2>No thanks.</eventtext.blackmarket.o1.c1.o2>
+<eventtext.blackmarket.o1.c2>“I found some weird eggs in the vents. Dunno what they are but figured they’d mean something for someone like you.” He flashes some eggs but it’s too dark to make out which species. He quickly hides them before you can ascertain their nature. “500 marks.”</eventtext.blackmarket.o1.c2>
+<eventtext.blackmarket.o1.c2.c2>Do you want to buy the eggs for 500 marks?</eventtext.blackmarket.o1.c2.c2>
+<eventtext.blackmarket.o1.c2.o1>Yes, please.</eventtext.blackmarket.o1.c2.o1>
+<eventtext.blackmarket.o1.c2.o1.c1>He carefully places the eggs in your hand. Most of them are actually oversized marbles, but one is a genuine mudraptor egg. “This can potentially cause a lot of damage,” you think to yourself as you stow it safely inside your jacket.</eventtext.blackmarket.o1.c2.o1.c1>
+<eventtext.blackmarket.o1.c2.o1.c2>In the light, the eggs are instantly recognizable as “Velonaceps calyx,” otherwise known as husk eggs.</eventtext.blackmarket.o1.c2.o1.c2>
+<eventtext.blackmarket.o1.c2.o2>No thanks.</eventtext.blackmarket.o1.c2.o2>
+<eventtext.blackmarket.o2>Ignore.</eventtext.blackmarket.o2>
+<eventtext.blackmarket.nomoney>“Not enough cash? I thought the submarine business paid well...”</eventtext.blackmarket.nomoney>
+<eventtext.huskcultist.c1>“Hello, fellow traveler!” a pale figure greets you. You’re slightly taken aback by their cheerfulness. “Would you happen to have any eggs of the species Velonaceps calyx? I’ll pay good money for each one you come across in your travels.” Their facade momentarily slips and you can hear them muttering under their breath. You can make out “disgusting meatsack” and something about “ascending.”</eventtext.huskcultist.c1>
+<eventtext.huskcultist.o1>Check your pockets for eggs.</eventtext.huskcultist.o1>
+<eventtext.huskcultist.o1.c1>You check your pockets. As luck would have it, you have some husk eggs on you.</eventtext.huskcultist.o1.c1>
+<eventtext.huskcultist.o1.o1>Sell the eggs for 1,000 marks.</eventtext.huskcultist.o1.o1>
+<eventtext.huskcultist.o1.o1.c1>You exchange the eggs for money, which you count immediately. It's all there.</eventtext.huskcultist.o1.o1.c1>
+<eventtext.huskcultist.o1.o2>Give the eggs for free.</eventtext.huskcultist.o1.o2>
+<eventtext.huskcultist.o1.o2.c1>You decide to donate the eggs for free. The person seems overjoyed.</eventtext.huskcultist.o1.o2.c1>
+<eventtext.huskcultist.o1.o3>Actually, I'll keep these for now.</eventtext.huskcultist.o1.o3>
+<eventtext.huskcultist.o1.c2>You check your pockets. You're fresh out of husk eggs.</eventtext.huskcultist.o1.c2>
+<eventtext.huskcultist.o1.o4>“I don't have the eggs on me but I'll go get some.”</eventtext.huskcultist.o1.o4>
+<eventtext.huskcultist.o1.o4.c1>“I'll be here,” the person whispers. It sends shivers down your spine.</eventtext.huskcultist.o1.o4.c1>
+<eventtext.huskcultist.o1.o5>“Sorry, don't have any.”</eventtext.huskcultist.o1.o5>
+<eventtext.huskcultist.o2>Uhh...probably best to keep moving.</eventtext.huskcultist.o2>
+<eventtext.fanclub.c1>A crowd of teens has gathered to observe the newcomers to their outpost. They’re loudly arguing about which is the coolest job on board a submarine.</eventtext.fanclub.c1>
+<eventtext.fanclub.o1>Talk to them.</eventtext.fanclub.o1>
+<eventtext.fanclub.o1.c1>They have an endless amount of questions. You answer them diligently, and in the end you have the feeling a few of them are going to grow up to be seafarers. Remember: If they wind up as crawler food, it’ll be blood on your hands.</eventtext.fanclub.o1.c1>
+<eventtext.fanclub.o2>Ignore them.</eventtext.fanclub.o2>
+<eventtext.huskcultambush.c1>Two pale characters with bags under their eyes approach. They’re reaching for something under their clothes. You feel threatened.</eventtext.huskcultambush.c1>
+<eventtext.huskcultambush.o1>“Hey, fellas. What’s—uh... What’s this?”</eventtext.huskcultambush.o1>
+<eventtext.huskcultambush.o1.c1>The two figures draw out sharp knives and lunge at you.</eventtext.huskcultambush.o1.c1>
+<eventtext.huskcultambush.o2>“Easy, dear brothers. My time for ascension isn’t here yet.”</eventtext.huskcultambush.o2>
+<eventtext.huskcultambush.o2.c1>They stop their approach, apologize for the confusion and the three of you grab some crawler cocktails and laugh it off. They share information on this outpost.</eventtext.huskcultambush.o2.c1>
+<eventtext.huskcultambush.o2.c2>The two figures draw out sharp knives and lunge at you.</eventtext.huskcultambush.o2.c2>
+<eventtext.missionevent_cargo_campaignstart.c1>“We've sold some basic construction materials to the neighbouring outpost, but delivery is on us. A simple transport job; perfect for a new crew like yourselves. What say you?”</eventtext.missionevent_cargo_campaignstart.c1>
+<eventtext.missionevent_cargo1.c1>“We hired a crew to transport these materials, but they never showed. The stuff is still here if you want the job.”</eventtext.missionevent_cargo1.c1>
+<eventtext.missionevent_cargo2.c1>“Got some real 'handle with care' cargo sitting in the bay. Normally I wouldn't trust them with any new face but I hear you've proved yourselves.”</eventtext.missionevent_cargo2.c1>
+<eventtext.missionevent_cargo3.c1>“These research materials are sorely needed in the neighboring outpost. It's imperative they get to their destination intact.”</eventtext.missionevent_cargo3.c1>
+<eventtext.missionevent_killswarm.c1>“No transport ship can leave without running into a swarm of monsters. Take care of the problem and there's a reward in it for you.”</eventtext.missionevent_killswarm.c1>
+<eventtext.missionevent_killmonstercommon.c1>“There's this especially mean monster terrorizing the caves near here. I've put a little reward aside for the crew that takes it down.”</eventtext.missionevent_killmonstercommon.c1>
+<eventtext.missionevent_killmonsterrare.c1>“I've heard reports of a gargantuan monster somewhere in the vicinity. If you want to try hunting it down, be my guest. Just make sure you're prepared. It's a dangerous one.”</eventtext.missionevent_killmonsterrare.c1>
+<eventtext.missionevent_salvageartifact.c1>“We picked up a signal nearby. The eggheads say it could be something alien. If you check it out, there'd be some marks in it for you.”</eventtext.missionevent_salvageartifact.c1>
+<eventtext.missionevent_salvagewreck.c1>“We received a distress signal from a vessel that was carrying some sensitive cargo. The contents are probably long gone by now but the captain's logbook should shed some light on what happened to it. I want you to recover it.”</eventtext.missionevent_salvagewreck.c1>
+<eventtext.missionevent_killmonster.c1>“I posted about an assignment earlier. Sent the details to your onboard navigation system too, in case you're interested.”</eventtext.missionevent_killmonster.c1>
+<eventtext.missionevent_cargo.c1>“I posted about an assignment earlier. Sent the details to your onboard navigation system too, in case you're interested.”</eventtext.missionevent_cargo.c1>
+<eventtext.missionevent_salvage.c1>“I posted about an assignment earlier. Sent the details to your onboard navigation system too, in case you're interested.”</eventtext.missionevent_salvage.c1>
+<eventtext.missionevent_clownoutbreak.c1>There are flyers with notices for various jobs. One of them is for ferrying a few boxes of clowning equipment to a neighboring outpost. It states: “If interested, imitate your favorite bird.”</eventtext.missionevent_clownoutbreak.c1>
+<eventtext.missionevent_clownoutbreak.o1>“Krruu!”</eventtext.missionevent_clownoutbreak.o1>
+<eventtext.missionevent_clownoutbreak.o1.c1>A distant sound of a bike horn confirms you as the recipient of the assignment. A container is waiting for you when you leave the outpost.</eventtext.missionevent_clownoutbreak.o1.c1>
+<eventtext.missionevent_clownoutbreak.o2>“Caw! Caw!”</eventtext.missionevent_clownoutbreak.o2>
+<eventtext.missionevent_clownoutbreak.o2.c1>A distant sound of a bike horn confirms you as the recipient of the assignment. A container is waiting for you when you leave the outpost.</eventtext.missionevent_clownoutbreak.o2.c1>
+<eventtext.missionevent_clownoutbreak.o3>Stay silent.</eventtext.missionevent_clownoutbreak.o3>
+<eventtext.bigbrother.c1>An announcement comes over the PA. “Calling the crew of the vessel that just docked. Please send a representative to see the security chief in administration.”</eventtext.bigbrother.c1>
+<eventtext.bigbrother.c1.c1>“You're one of the new arrivals? Good. I have a sensitive issue I can't trust any of my own employees with.” The chief pauses for a second, sizing you up, then continues. “In usual circumstances, I wouldn't ask for help from just anyone, but I'm running out of options. Needless to say, I need you to keep this to yourself. Are you interested?”</eventtext.bigbrother.c1.c1>
+<eventtext.bigbrother.c1.o1>“Tell me more.”</eventtext.bigbrother.c1.o1>
+<eventtext.bigbrother.c1.o1.c1>The chief nods. “According to intel we managed to gather earlier, we can expect a separatist prison break soon,” they state, matter-of-factly. “Prison breaks are already a nasty business, but to complicate matters I have reason to believe they have a man on the inside.”</eventtext.bigbrother.c1.o1.c1>
+<eventtext.bigbrother.c1.o1.o1>“Pun intended?”</eventtext.bigbrother.c1.o1.o1>
+<eventtext.bigbrother.c1.o1.o1.c1>“I'm talking about inside the security force.” It seems like sense of humor isn't how one makes it to chief of security. “To cut to the chase, I need to make sure all my personnel are on the level and take precautions. Here's what I want you to do. Take these microphones and hide them in the crew quarters.”</eventtext.bigbrother.c1.o1.o1.c1>
+<eventtext.bigbrother.c1.o1.o1.o1>Accept the mission.</eventtext.bigbrother.c1.o1.o1.o1>
+<eventtext.bigbrother.c1.o1.o1.o1.c1>You pick up some small surveillance microphones. “One more thing. I can't permit this kind of surveillance in an official capacity. If you get caught, you're on your own.”</eventtext.bigbrother.c1.o1.o1.o1.c1>
+<eventtext.bigbrother.c1.o1.o1.o2>“I'd rather not get involved.”</eventtext.bigbrother.c1.o1.o1.o2>
+<eventtext.bigbrother.c1.o2>“I'd rather not get involved.”</eventtext.bigbrother.c1.o2>
+<eventtext.bigbrother.c1.c1.c1>These must be the quarters the chief was talking about.</eventtext.bigbrother.c1.c1.c1>
+<eventtext.bigbrother.c1.c1.o1>Hide microphones under the bunks.</eventtext.bigbrother.c1.c1.o1>
+<eventtext.bigbrother.c1.c1.o1.c1>You quickly stuff the mics in footlockers under the bunks. The sound coming through is a bit muffled but serviceable. Return to the chief to receive your payment.</eventtext.bigbrother.c1.c1.o1.c1>
+<eventtext.bigbrother.c1.c1.o1.c1.c1>“Good work. Here's your payment. We never spoke.”</eventtext.bigbrother.c1.c1.o1.c1.c1>
+<eventtext.bigbrother.c1.c1.o1.c2>You toss the mics under a bunk. When you turn around to leave, you run into a security guard. “What are you up to?” they ask.</eventtext.bigbrother.c1.c1.o1.c2>
+<eventtext.bigbrother.c1.c1.o1.o1>“Oh, just some calisthenics. Need to stay in shape for emergencies.”</eventtext.bigbrother.c1.c1.o1.o1>
+<eventtext.bigbrother.c1.c1.o1.o1.c1>The guard seems satisfied with the explanation and goes back to their rounds. Return to the chief to receive your payment.</eventtext.bigbrother.c1.c1.o1.o1.c1>
+<eventtext.bigbrother.c1.c1.o1.o1.c1.c1>“Good work. Here's your payment. We never spoke.”</eventtext.bigbrother.c1.c1.o1.o1.c1.c1>
+<eventtext.bigbrother.c1.c1.o1.o1.c2>“You look like you've never done an honest day's work in your life.” They start inspecting undersides of the bunks. Now would be a good time to vanish before they get any wiser. This mission is a failure.</eventtext.bigbrother.c1.c1.o1.o1.c2>
+<eventtext.bigbrother.c1.c1.o1.o1.c2.c2>The guard draws their weapon. “Microphones, huh? You need to come with me.” Now would be a REALLY good time to run.</eventtext.bigbrother.c1.c1.o1.o1.c2.c2>
+<eventtext.bigbrother.c1.c1.o1.o2>“Just installing some surveillance mics.”</eventtext.bigbrother.c1.c1.o1.o2>
+<eventtext.bigbrother.c1.c1.o1.o2.c1>The guard lets out a brief chuckle. “A funny guy. You shouldn't be here. Go on, git.” The guard then turns their attention to the cameras. Now would be a good time to vanish before they get any wiser. This mission is a failure.</eventtext.bigbrother.c1.c1.o1.o2.c1>
+<eventtext.bigbrother.c1.c1.o1.o2.c1.c1>The guard draws their weapon. “Microphones, huh? You need to come with me.” Now would be a REALLY good time to run.</eventtext.bigbrother.c1.c1.o1.o2.c1.c1>
+<eventtext.bigbrother.c1.c1.o2>Hide microphones inside some electronics.</eventtext.bigbrother.c1.c1.o2>
+<eventtext.bigbrother.c1.c1.o2.c1>You open up a nearby transistor radio and install a microphone inside the speaker, out of sight. Return to the chief to receive your payment.</eventtext.bigbrother.c1.c1.o2.c1>
+<eventtext.bigbrother.c1.c1.o2.c1.c1>“Good work. Here's your payment. We never spoke.”</eventtext.bigbrother.c1.c1.o2.c1.c1>
+<eventtext.bigbrother.c1.c1.o2.c2>You spot a transistor radio that could possibly hold a microphone. As you're fiddling with it, a security guard calls out. “You! Come here!” You decide to comply for now. “What were you doing?” the guard demands.</eventtext.bigbrother.c1.c1.o2.c2>
+<eventtext.bigbrother.c1.c1.o2.o1>“Fixing the radio antenna.”</eventtext.bigbrother.c1.c1.o2.o1>
+<eventtext.bigbrother.c1.c1.o2.o1.c1>“Finally. Make sure K-Rawler comes through loud and clear.” Something will come through all right, you think to yourself. Return to the chief to receive your payment.</eventtext.bigbrother.c1.c1.o2.o1.c1>
+<eventtext.bigbrother.c1.c1.o2.o1.c1.c1>“Good work. Here's your payment. We never spoke.”</eventtext.bigbrother.c1.c1.o2.o1.c1.c1>
+<eventtext.bigbrother.c1.c1.o2.o2>“Just installing some surveillance mics.”</eventtext.bigbrother.c1.c1.o2.o2>
+<eventtext.bigbrother.c1.c1.o2.o2.c1>The guard lets out a brief chuckle. “A funny guy. You shouldn't be here. Go on, git.” The guard then turns their attention to the cameras. Now would be a good time to vanish before they get any wiser. This mission is a failure.</eventtext.bigbrother.c1.c1.o2.o2.c1>
+<eventtext.bigbrother.c1.c1.o2.o2.c1.c1>The guard draws their weapon. “Microphones, huh? You need to come with me.” Now would be a REALLY good time to run.</eventtext.bigbrother.c1.c1.o2.o2.c1.c1>
+<eventtext.tastetest.c1>In a nearby trash can, there are two small bottles of clear liquid. Both of them are labeled with a different chemical formula.</eventtext.tastetest.c1>
+<eventtext.tastetest.o1>Take a closer look at the bottles.</eventtext.tastetest.o1>
+<eventtext.tastetest.o1.c1>Neither solution is anything you’re especially familiar with, but you are reasonably sure one of them is strongly acidic. You decide to leave the acid be. The other bottle is a total mystery to you.</eventtext.tastetest.o1.c1>
+<eventtext.tastetest.o1.o1>Bottoms up!</eventtext.tastetest.o1.o1>
+<eventtext.tastetest.o1.o1.c1>The solution has a slightly mellow and sweet quality to it and it leaves a lingering aftertaste of apricot. It seems to have no other effects. You decide to leave the bottles in the trash and continue on.</eventtext.tastetest.o1.o1.c1>
+<eventtext.tastetest.o1.o1.o1>Not bad.</eventtext.tastetest.o1.o1.o1>
+<eventtext.tastetest.o1.o1.o1.c1>After a while, you realize drinking the solution has made all your pains disappear. For the first time in forever, you feel good. You don't know what the solution is but you wish you had some more. Maybe there's some more in the trash?</eventtext.tastetest.o1.o1.o1.c1>
+<eventtext.tastetest.o1.o1.o1.o1>Maybe I should take another look in there.</eventtext.tastetest.o1.o1.o1.o1>
+<eventtext.tastetest.o1.o1.o1.o1.c1>You return to the trash can and find a couple more bottles. None of them are the same as the one you drank but maybe they can be of some other use.</eventtext.tastetest.o1.o1.o1.o1.c1>
+<eventtext.tastetest.o1.o2>Not a very sensible thing to do...</eventtext.tastetest.o1.o2>
+<eventtext.tastetest.o1.c2>Chemistry makes no sense to you; it might as well be an alien language. After a quick shake test, either liquid seems perfectly safe to you. One of them has a blue label, the other green. Do you want to try one of them?</eventtext.tastetest.o1.c2>
+<eventtext.tastetest.o1.o3>Blue label.</eventtext.tastetest.o1.o3>
+<eventtext.tastetest.o1.o3.c1>The solution has a slightly mellow and sweet quality to it and it leaves a lingering aftertaste of apricot. It seems to have no other effects. You decide to leave the bottles in the trash and continue on.</eventtext.tastetest.o1.o3.c1>
+<eventtext.tastetest.o1.o3.o1>Not bad.</eventtext.tastetest.o1.o3.o1>
+<eventtext.tastetest.o1.o3.o1.c1>After a while, you realize drinking the solution has made all your pains disappear. For the first time in forever, you feel good. You don't know what the solution is but you wish you had some more. Maybe there's some more in the trash?</eventtext.tastetest.o1.o3.o1.c1>
+<eventtext.tastetest.o1.o3.o1.o1>Maybe I should take another look in there.</eventtext.tastetest.o1.o3.o1.o1>
+<eventtext.tastetest.o1.o3.o1.o1.c1>You return to the trash can and find a couple more bottles. Maybe one of these is the same miracle solution!</eventtext.tastetest.o1.o3.o1.o1.c1>
+<eventtext.tastetest.o1.o4>Green label.</eventtext.tastetest.o1.o4>
+<eventtext.tastetest.o1.o4.c1>The liquid burns your throat a bit when you swallow it. At first, the effect isn’t unlike a good Jovian vodka, and the prospect of getting buzzed while spending no money appeals to you greatly. The situation suddenly takes a turn for the worse when you feel like your stomach is on fire. A sharp pain causes you to double over in agony. Who would’ve thought drinking something out of the trash was a bad idea?</eventtext.tastetest.o1.o4.c1>
+<eventtext.tastetest.o1.o4.o1>Not good.</eventtext.tastetest.o1.o4.o1>
+<eventtext.tastetest.o1.o5>No, of course not!</eventtext.tastetest.o1.o5>
+<eventtext.tastetest.o2>Ignore.</eventtext.tastetest.o2>
+<eventtext.crawleroutbreak.c1>A panicked researcher runs past you. “God dammit Jimmy, I told you we should’ve went with padlocks instead of these electronic pieces of shit!”</eventtext.crawleroutbreak.c1>
+<eventtext.consultant.c1>As you step inside the office, the manager notices you. “I suppose you're here about the situation in the mines?” he asks.</eventtext.consultant.c1>
+<eventtext.consultant.o1>“Uh...sure. Remind me what the situation was, again?”</eventtext.consultant.o1>
+<eventtext.consultant.o1.c1>It turns out the miners have halted the work in the mines because of a toxic gas leak. “They're demanding ridiculous hazard pay and we just don't have the budget for that. That's why you're here, right? To negotiate a better deal?”</eventtext.consultant.o1.c1>
+<eventtext.consultant.o1.o1>“Yes, that's right. Get me in contact with the foreman.”</eventtext.consultant.o1.o1>
+<eventtext.consultant.o1.o1.c1>“They can probably be found near the main mineshaft. Good luck.”</eventtext.consultant.o1.o1.c1>
+<eventtext.consultant.o1.o1.c1.c1>The foreman is pacing back and forth, loudly arguing with someone on the radio. You only catch the tail end of their discussion. “There aren't enough diving masks for the whole crew. Even if there were, we couldn't waste the oxygen keeping them on all day long. ...No, the ventilation in the mines is connected to the rest of the outpost so we can't risk pumping it out either.” Exasperated, he looks at you. “Are you here about the gas leaks?”</eventtext.consultant.o1.o1.c1.c1>
+<eventtext.consultant.o1.o1.c1.o1>Haggle for lower hazard pay for miners.</eventtext.consultant.o1.o1.c1.o1>
+<eventtext.consultant.o1.o1.c1.o1.c1>You successfully explain that not everyone can be paid extra for hazardous work. This will probably result in most of the crew walking out and the rest having to work their asses off, but at least you got paid a hefty consultant fee.</eventtext.consultant.o1.o1.c1.o1.c1>
+<eventtext.consultant.o1.o1.c1.o1.c2>The foreman stands their ground. No hazard pay, no digging. At least you tried.</eventtext.consultant.o1.o1.c1.o1.c2>
+<eventtext.consultant.o1.o1.c1.o2>“What kind of gases are we talking about?”</eventtext.consultant.o1.o1.c1.o2>
+<eventtext.consultant.o1.o1.c1.o2.c1>“Mercury gases. Colorless, odorless, gives you breathing problems real quick.”</eventtext.consultant.o1.o1.c1.o2.c1>
+<eventtext.consultant.o1.o1.c1.o2.o1>Come up with a solution to help with mercury exposure.</eventtext.consultant.o1.o1.c1.o2.o1>
+<eventtext.consultant.o1.o1.c1.o2.o1.c1>“A combination of iron, Stabilozine and crawler liver should keep your lungs clean of mercury. Take two pills every six hours.” The foreman thanks you for your advice. You collect a considerable reward from the outpost manager.</eventtext.consultant.o1.o1.c1.o2.o1.c1>
+<eventtext.consultant.o1.o1.c1.o2.o1.c2>You can't come up with anything that could help the situation.</eventtext.consultant.o1.o1.c1.o2.o1.c2>
+<eventtext.consultant.o1.o1.c1.o2.o2>Haggle for lower hazard pay for miners.</eventtext.consultant.o1.o1.c1.o2.o2>
+<eventtext.consultant.o1.o1.c1.o2.o2.c1>You successfully explain that not everyone can be paid extra for hazardous work. This will probably result in most of the crew walking out and the rest having to work their asses off, but at least you got paid a hefty consultant fee.</eventtext.consultant.o1.o1.c1.o2.o2.c1>
+<eventtext.consultant.o1.o1.c1.o2.o2.c2>The foreman stands their ground. No hazard pay, no digging. At least you tried.</eventtext.consultant.o1.o1.c1.o2.o2.c2>
+<eventtext.consultant.o1.o1.c1.o3>“Tell me more about the ventilation problem.”</eventtext.consultant.o1.o1.c1.o3>
+<eventtext.consultant.o1.o1.c1.o3.c1>“The ducts reach from here all the way to the mess hall and dorms, meaning we can't pump the vapors out. I don't know who installed them originally, but I'd like to have a word with 'em.”</eventtext.consultant.o1.o1.c1.o3.c1>
+<eventtext.consultant.o1.o1.c1.o3.o1>Attempt to solve the ventilation problem.</eventtext.consultant.o1.o1.c1.o3.o1>
+<eventtext.consultant.o1.o1.c1.o3.o1.c1>You study a map of ventilation ducts. “Why not install an extra air filtration system right here?” you suggest, pointing to a junction near the dorms. “Should pump out all the mercury before it spreads farther.” And sure enough, it does. You collect a fee from the manager for solving the problem.</eventtext.consultant.o1.o1.c1.o3.o1.c1>
+<eventtext.consultant.o1.o1.c1.o3.o1.c2>You can't come up with anything that could help the situation.</eventtext.consultant.o1.o1.c1.o3.o1.c2>
+<eventtext.consultant.o1.o1.c1.o3.o2>Haggle for lower hazard pay for miners.</eventtext.consultant.o1.o1.c1.o3.o2>
+<eventtext.consultant.o1.o1.c1.o3.o2.c1>You successfully explain that not everyone can be paid extra for hazardous work. This will probably result in most of the crew walking out and the rest having to work their asses off, but at least you got paid a hefty consultant fee.</eventtext.consultant.o1.o1.c1.o3.o2.c1>
+<eventtext.consultant.o1.o1.c1.o3.o2.c2>The foreman stands their ground. No hazard pay, no digging. At least you tried.</eventtext.consultant.o1.o1.c1.o3.o2.c2>
+<eventtext.consultant.o1.o2>“This is above my pay grade. Goodbye.”</eventtext.consultant.o1.o2>
+<eventtext.consultant.o2>“No, you must be mistaken.”</eventtext.consultant.o2>
+<eventtext.huskcultist_return.c1>“Do you have the eggs with you now?”</eventtext.huskcultist_return.c1>
+<eventtext.huskcultist_return.o1>Yes.</eventtext.huskcultist_return.o1>
+<eventtext.huskcultist_return.o1.c1>You check your pockets. As luck would have it, you have some husk eggs on you.</eventtext.huskcultist_return.o1.c1>
+<eventtext.huskcultist_return.o1.o1>Sell the eggs for 1,000 marks.</eventtext.huskcultist_return.o1.o1>
+<eventtext.huskcultist_return.o1.o1.c1>You exchange the eggs for money, which you count immediately. It's all there.</eventtext.huskcultist_return.o1.o1.c1>
+<eventtext.huskcultist_return.o1.o2>Give the eggs for free.</eventtext.huskcultist_return.o1.o2>
+<eventtext.huskcultist_return.o1.o2.c1>You decide to donate the eggs for free. The person seems overjoyed.</eventtext.huskcultist_return.o1.o2.c1>
+<eventtext.huskcultist_return.o1.o3>Actually, I'll keep these for now.</eventtext.huskcultist_return.o1.o3>
+<eventtext.huskcultist_return.o1.c2>“No, you don't. Please stop wasting my time.”</eventtext.huskcultist_return.o1.c2>
+<eventtext.huskcultist_return.o2>No.</eventtext.huskcultist_return.o2>
+<eventtext.missionevent_collectminerals.c1>“There's been talk of valuable mineral clusters nearby. We'd like you to see if there's any truth to the rumors.”</eventtext.missionevent_collectminerals.c1>
+<eventtext.missionevent_mudraptornest.c1>“A couple of divers stumbled upon a mudraptor nest full of eggs in a nearby cave. We obviously don't want a swarm of raptors in our backyard, so if you can get rid of those eggs we'd happily pay you.”</eventtext.missionevent_mudraptornest.c1>
+<eventtext.missionevent_crawlernest.c1>“A couple of divers discovered a bunch of crawler eggs in a nearby cave. We don't need any more crawlers near the station, so I've put a little reward aside for the crew that wipes out the nest.”</eventtext.missionevent_crawlernest.c1>
+<eventtext.missionevent_tigerthreshernest.c1>“A couple of divers discovered a thresher nest full of eggs in a nearby cave. We don't want to see those things hatching, and there's a reward in it for any crew that makes sure they won't.”</eventtext.missionevent_tigerthreshernest.c1>
+<eventtext.missionevent_clearruin.c1>“We're conducting research into the nearby ruins, but their guardians are hindering progress. Clear them out for us, would you?”</eventtext.missionevent_clearruin.c1>
+<eventtext.missionevent_scanruin.c1>“A request from the science wing. A nearby ruin needs to be mapped. For a reward, of course.”</eventtext.missionevent_scanruin.c1>
+<eventtext.missionevent_beacon.c1>“We could use a hand getting one of our beacon stations back online and transmitting so we can start building a new outpost out there. There's some marks in it for you and your crew if you can set it right.”</eventtext.missionevent_beacon.c1>
+<eventtext.missionevent_escort2.c1>“A highly esteemed medical expert and their armed escort are looking for transportation to a nearby station. Their safety is of utmost importance.”</eventtext.missionevent_escort2.c1>
+<eventtext.missionevent_pirate1.c1>“A rogue vessel has been preying on our cargo shipments. Eliminate its crew, and we will show our graditude. Take care though, the ship is heavily armed.”</eventtext.missionevent_pirate1.c1>
+<eventtext.missionevent_escort4.c1>“We believe that Separatist terrorists have snuck among the innocent civilians looking to leave on the next transport ship. If you're willing to have your ship act as that transport, you might be able to draw the terrorists out into the open and detain them. Just make sure the civilians survive.”</eventtext.missionevent_escort4.c1>
+<eventtext.missionevent_escort3.c1>“We have a few prisoners that need to be transferred to a prison on another station. You'll be paid well for their transportation, but be aware that they need to be closely guarded.”</eventtext.missionevent_escort3.c1>
+<eventtext.missionevent_escort1.c1>“Some of the commoners here are looking for safe passage to a nearby station. Escort them over there safely and you'll be paid.”</eventtext.missionevent_escort1.c1>
+<eventtext.missionevent_cargohuskcult>“Looking for work? We've got some…let's say, research materials that are sorely needed in the neighboring outpost. Get them there, don't ask questions, and we'll pay you.”</eventtext.missionevent_cargohuskcult>
+<eventtext.unlockpathgeneric.c1>“I've heard a lot about your crew's recent endeavours, and I must say the Coalition appreciates the work you're doing. Not every sub is allowed to pass through this outpost to the deeper regions, but you and your crew are more than welcome to pass.”</eventtext.unlockpathgeneric.c1>
+<eventtext.unlockpathgeneric.c2>“Looking to pass through the outpost to the deeper regions? The Coalition won't grant a novice crew passage there, and judging by your reputation, you're definitely not someone I'd let pass. Of course if you happened to have 5,000 marks to share with me, my opinion of you would almost certainly improve...”</eventtext.unlockpathgeneric.c2>
+<eventtext.unlockpathgeneric.o1>Pay 5,000 marks.</eventtext.unlockpathgeneric.o1>
+<eventtext.unlockpathgeneric.o1.c1>“On a second thought, you seem like someone with potential, so perhaps I'll let you pass after all. Pleasure doing business with you.”</eventtext.unlockpathgeneric.o1.c1>
+<eventtext.unlockpathgeneric.o2>No thanks.</eventtext.unlockpathgeneric.o2>
+<eventtext.unlockpathgeneric.o2.c1>“Your choice. Maybe it's better for you to play in the kiddie pool a little longer anyway.”</eventtext.unlockpathgeneric.o2.c1>
+<eventtext.unlockpathgeneric.nomoney>“Not enough cash? Well, tough luck. Maybe you should play in the kiddie pool a little longer to prove us you have what it takes to make it out there.”</eventtext.unlockpathgeneric.nomoney>
+<eventtext.unlockpath.refusebribe>Don't give them anything.</eventtext.unlockpath.refusebribe>
+<eventtext.unlockpathcoldcaverns.c1>“You've certainly kept yourself busy in the Cold Caverns. I must say the Coalition appreciates the work you've put in. As you may be aware, this is the last stop before the Europan Ridge. Not every sub is allowed to pass through this outpost to the deeper regions, but you and your crew are more than welcome to pass.”</eventtext.unlockpathcoldcaverns.c1>
+<eventtext.unlockpathcoldcaverns.c2>“Looking to pass through the outpost to the deeper regions? The Coalition won't grant a novice crew passage there, and judging by your reputation, you're definitely not someone I'd let pass. Of course, if you happened to have some marks to share with me, my opinion of you would almost certainly improve.”</eventtext.unlockpathcoldcaverns.c2>
+<eventtext.unlockpathcoldcaverns.o1.c1>“On second thought, you seem like someone with potential. Perhaps I'll let you pass after all. Pleasure doing business with you.”</eventtext.unlockpathcoldcaverns.o1.c1>
+<eventtext.unlockpathcoldcaverns.o2.c1>“Your choice. Maybe it's better for you to play in the kiddie pool a little longer anyway.”</eventtext.unlockpathcoldcaverns.o2.c1>
+<eventtext.unlockpathcoldcaverns.o1.nomoney>“Not enough cash? Well, tough luck. Maybe you should play in the kiddie pool a little longer to prove to us you have what it takes to make it out there.”</eventtext.unlockpathcoldcaverns.o1.nomoney>
+<eventtext.unlockpatheuropanridge.c1>“It says here you've been helping the effort to colonize the Ridge. For that, we've decided to grant you access to the Aphotic Plateau. Bon voyage!”</eventtext.unlockpatheuropanridge.c1>
+<eventtext.unlockpatheuropanridge.c2>“Looking to pass through to the Plateau? I don't know... I haven't seen much effort from your side to prove your loyalty to the cause. A donation would go a long way.”</eventtext.unlockpatheuropanridge.c2>
+<eventtext.unlockpatheuropanridge.o1.c1>“Ah yes, that will work. You shall now pass.”</eventtext.unlockpatheuropanridge.o1.c1>
+<eventtext.unlockpatheuropanridge.o2.c1>“Oh? You're welcome to stay in the Europan Ridge for as long as you want, in that case.”</eventtext.unlockpatheuropanridge.o2.c1>
+<eventtext.unlockpatheuropanridge.o1.nomoney>“I'm sorry. I can't accept anything less than four thousand marks. Maybe you should salvage a couple more wrecks. Or whatever it is you do.”</eventtext.unlockpatheuropanridge.o1.nomoney>
+<eventtext.unlockpathaphoticplateau.c1>“I'll have to congratulate you. Not many make it through the Plateau, much less while being so useful. I'll radio ahead to let you move to the Great Sea.”</eventtext.unlockpathaphoticplateau.c1>
+<eventtext.unlockpathaphoticplateau.c2>“I'm sorry, I know you've made it this far, but we can't take the risk to let an unknown crew to wander around the Great Sea. For your protection, you understand.”</eventtext.unlockpathaphoticplateau.c2>
+<eventtext.unlockpathaphoticplateau.o1.c1>“I'm sure it will. That is not an official guarantee by the Coalition nor an endorsement. I'll let the guard know you can take care of yourself.”</eventtext.unlockpathaphoticplateau.o1.c1>
+<eventtext.unlockpathaphoticplateau.o2.c1>“I'm sure you'll find a nice duplex to live out your retirement. The radiation shouldn't reach here for a few days at least.”</eventtext.unlockpathaphoticplateau.o2.c1>
+<eventtext.unlockpathgreatsea.c1>“So you want to enter the Hydrothermal Wastes? Why on Europa would you do such a thing? I suppose it's none of my business. A friend of the Coalition is a friend of mine. Go ahead.”</eventtext.unlockpathgreatsea.c1>
+<eventtext.unlockpathgreatsea.c2>“Do you have clearance to enter the Hydrothermal Wastes? Didn't think so. As luck would have it, we're having a clearance sale right now, if you know what I mean.”</eventtext.unlockpathgreatsea.c2>
+<eventtext.unlockpathgreatsea.o1.c1>“Come back anytime, if you can.”</eventtext.unlockpathgreatsea.o1.c1>
+<eventtext.unlockpathgreatsea.o2.c1>“At least you might live longer.”</eventtext.unlockpathgreatsea.o2.c1>
+<eventtext.unlockpathcoldcaverns.o1>Give them 2,000 marks.</eventtext.unlockpathcoldcaverns.o1>
+<eventtext.unlockpatheuropanridge.o1>“Would a donation of 4,000 suffice?”</eventtext.unlockpatheuropanridge.o1>
+<eventtext.unlockpathaphoticplateau.o1>“Would 8,000 be enough to protect us?”</eventtext.unlockpathaphoticplateau.o1>
+<eventtext.unlockpathaphoticplateau.o1.nomoney>“8,000 will convince me. No less. Come back when you have it.”</eventtext.unlockpathaphoticplateau.o1.nomoney>
+<eventtext.unlockpathgreatsea.o1>“16,000? What a steal! Here you go.”</eventtext.unlockpathgreatsea.o1>
+<eventtext.unlockpathgreatsea.o1.nomoney>“This isn't enough. I can't go below 16,000. Come back when you have it.”</eventtext.unlockpathgreatsea.o1.nomoney>
+<eventtext.healreaperstax.c1>“I heard one of your crewmates has developed a rather unusual condition as of late, something we usually refer to as the 'Reaper's Tax.' If they're interested, I could take a shot at treating them.”</eventtext.healreaperstax.c1>
+<eventtext.healreaperstax.c2>“Oh, I see you're the unfortunate sailor in question! I could rid you of the condition for a measly sum of say, 1,000 marks. How's that sound?”</eventtext.healreaperstax.c2>
+<eventtext.healreaperstax.o1>Cure Reaper's Tax for 1,000 marks</eventtext.healreaperstax.o1>
+<eventtext.healreaperstax.o2>No thanks.</eventtext.healreaperstax.o2>
+<eventtext.healreaperstax.o1.nomoney>Not enough money? Tough luck, this ain't a charity.</eventtext.healreaperstax.o1.nomoney>
+<eventtext.stowaway1.c1>Hmm. This box wasn't here before.</eventtext.stowaway1.c1>
+<eventtext.stowaway1.o1>Investigate.</eventtext.stowaway1.o1>
+<eventtext.stowaway1.o1.c1>It is a regular storage crate found all over Europa, identical to the ones you receive your supplies in. You bend down and try to open it. However, as you start lifting the lid, something slams it back down.</eventtext.stowaway1.o1.c1>
+<eventtext.stowaway1.o1.o1>“Hello?”</eventtext.stowaway1.o1.o1>
+<eventtext.stowaway1.o1.o1.c1>No response.</eventtext.stowaway1.o1.o1.c1>
+<eventtext.stowaway1.o1.o1.o1>Listen closely.</eventtext.stowaway1.o1.o1.o1>
+<eventtext.stowaway1.o1.o1.o1.c1>You hold your breath and put your ear next to the crate. You can hear rustling from inside.</eventtext.stowaway1.o1.o1.o1.c1>
+<eventtext.stowaway1.o1.o1.o1.o1>Forcefully remove the lid.</eventtext.stowaway1.o1.o1.o1.o1>
+<eventtext.stowaway1.o1.o1.o1.o1.c1>You successfully wrestle the lid off. To your surprise, a small crawler jumps out ready to claw your eyes out!</eventtext.stowaway1.o1.o1.o1.o1.c1>
+<eventtext.stowaway1.o1.o1.o1.o1.c2>You successfully wrestle the lid off. Lying on top of a saline shipment is a small creature. It eyes you carefully, then crawls out of the crate and looks at you expectantly. It seems like you have made a friend.</eventtext.stowaway1.o1.o1.o1.o1.c2>
+<eventtext.stowaway2.c1>Noises are coming out of this cabinet. As you approach it, they grow quiet.</eventtext.stowaway2.c1>
+<eventtext.stowaway2.o1>Investigate.</eventtext.stowaway2.o1>
+<eventtext.stowaway2.o1.c1>When you open the cabinet door, a harlequin in unusual garb steps out. They greet you formally and explain that they are a messenger.</eventtext.stowaway2.o1.c1>
+<eventtext.stowaway2.o1.o1>“What is your message?”</eventtext.stowaway2.o1.o1>
+<eventtext.stowaway2.o1.o1.c1>The jester explains that there is a sunken submarine nearby. It was carrying an item of tremendous value to the Honkmother. The messenger doesn't wait for your answer. Instead, they turn on their heels and leave you to ponder.</eventtext.stowaway2.o1.o1.c1>
+<eventtext.stowaway2.o1.c2>You carefully open the cabinet door, only to reveal a mouth-agape, wide-eyed young person hiding in it. By the looks of them, they are in their late teens.</eventtext.stowaway2.o1.c2>
+<eventtext.stowaway2.o1.o2>“Who are you?”</eventtext.stowaway2.o1.o2>
+<eventtext.stowaway2.o1.o2.c1>“N-nobody special, I guess,” the teen stammers.</eventtext.stowaway2.o1.o2.c1>
+<eventtext.stowaway2.o1.o2.o1>“What are you doing in there?”</eventtext.stowaway2.o1.o2.o1>
+<eventtext.stowaway2.o1.o2.o1.c1>“Me and a couple of friends snuck on board while you were visiting [location]. I was stuffed in here by them, as a joke.” They sniff. “I guess they heard you coming and ran back into the station. I swear I didn't mean to stay here for this long.”</eventtext.stowaway2.o1.o2.o1.c1>
+<eventtext.stowaway2.o1.o2.o1.o1>“What am I going to do with you?”</eventtext.stowaway2.o1.o2.o1.o1>
+<eventtext.stowaway2.o1.o2.o1.o1.c1>“W-well, I'd like to go back home. If you don't want to go back, I guess I can hop onto a shuttle on the next station.”</eventtext.stowaway2.o1.o2.o1.o1.c1>
+<eventtext.stowaway2.o1.o2.o1.o1.o1>“I'm taking you back home.”</eventtext.stowaway2.o1.o2.o1.o1.o1>
+<eventtext.stowaway2.o1.o2.o1.o1.o1.c1>The teen climbs out of the cabinet. “Thanks. I'll stay out of trouble, I promise.”</eventtext.stowaway2.o1.o2.o1.o1.o1.c1>
+<eventtext.stowaway2.o1.o2.o1.o1.o2>“You'll get off at the next stop.”</eventtext.stowaway2.o1.o2.o1.o1.o2>
+<eventtext.stowaway2.o1.o2.o1.o1.o3>“Come out. You're working for me now.”</eventtext.stowaway2.o1.o2.o1.o1.o3>
+<eventtext.stowaway2.o1.o2.o1.o1.o3.c1>“Are you serious?” the teen whines. Yes, you are. That'll teach them to sneak on board strange vessels.</eventtext.stowaway2.o1.o2.o1.o1.o3.c1>
+<eventtext.stowaway2.o1.o2.o2>“Stay there. I'll be back later.”</eventtext.stowaway2.o1.o2.o2>
+<eventtext.shockjock.c1>A radio is blaring nearby. A man with a raspy voice is yelling about something.</eventtext.shockjock.c1>
+<eventtext.shockjock.o1>Listen.</eventtext.shockjock.o1>
+<eventtext.shockjock.o1.c1>“Well we've all heard about this nonsense about so-called clown brutality. As if for some reason clowns are being sought out and roughed up because of how they look. Let me tell you, it's got nothing to do with the color of their makeup and everything to do with how they choose to carry themselves!”</eventtext.shockjock.o1.c1>
+<eventtext.shockjock.o1.o1.c1>In fact, in this latest incident, I can only imagine how it would have unfolded if the jester in question had been wearing a suit and a tie instead of oversized shoes and a ridiculous wig! And instead of running away, they could've gone 'Yes, sir,' 'No, sir,' and they'd be on their merry way right now! But no. The take-away here, dear listeners, is: Clown around and your brains will end up all over the walls.”</eventtext.shockjock.o1.o1.c1>
+<eventtext.shockjock.signoff>“And that's all the time we have for now. Remember, listen and obey. Maurice! Hold the cards up! Maur— No! What does that even mean?” The person in the booth sounds very irate. “Maurice, I swear to— What do I even pay you for?” The broadcast suddenly stops and is replaced by static.</eventtext.shockjock.signoff>
+<eventtext.shockjock.o1.c2>“Recreational drug use is on the rise, people. Have you heard about “Cult of the Husk”? A bunch of weirdos abusing biohazardous materials? And the establishment does nothing about it!”</eventtext.shockjock.o1.c2>
+<eventtext.shockjock.o1.o2.c1>“And don't get me started on casual opioid use that's rampant everywhere! According to trusted sources, the Coalition is putting something in them, making them addicting! Before too long, it'll be your children, squatting away in abandoned outposts, wearing dirty robes, doing whatever substances they can get their grubby hands on.”</eventtext.shockjock.o1.o2.c1>
+<eventtext.shockjock.o1.c3>“Dear listeners, if I was the Coalition president, I would walk right into the crew quarters, set up my little podium and say, 'Listen, citizens, if you vote against military spending and a separatist army marches in and blows you up, we're not going to do anything about it.'”</eventtext.shockjock.o1.c3>
+<eventtext.shockjock.o1.o3.c1>“You want to cry about your ruined little station? Give us your money next time! Anyway, that's what I would say, if I was the president.”</eventtext.shockjock.o1.o3.c1>
+<eventtext.shockjock.o1.c4>“What a bunch of bullshit. Don't believe everything you hear on the radio.”</eventtext.shockjock.o1.c4>
+<eventtext.shockjock.o1.o4>“What was that broadcast about?”</eventtext.shockjock.o1.o4>
+<eventtext.shockjock.o1.o4.c1>“It's some weird hermit who's built a makeshift radio station somewhere. Nobody knows where, otherwise somebody would have put a stop to it already. The guy gets on everybody's nerves.”</eventtext.shockjock.o1.o4.c1>
+<eventtext.assassinationofjacovsubra1.c1>(Hmm? What's this?)</eventtext.assassinationofjacovsubra1.c1>
+<eventtext.assassinationofjacovsubra1.o1>Take a look at the ID card.</eventtext.assassinationofjacovsubra1.o1>
+<eventtext.assassinationofjacovsubra1.o1.c1>(The ID card belongs to one Jacov Subra. Where have I heard that name before? Oh well.)</eventtext.assassinationofjacovsubra1.o1.c1>
+<eventtext.assassinationofjacovsubra1.o2>Ignore the card.</eventtext.assassinationofjacovsubra1.o2>
+<eventtext.assassinationofjacovsubra2.c1>A worker, presumably on break, is reading the paper. “Hey, you hear about that Subra guy?”</eventtext.assassinationofjacovsubra2.c1>
+<eventtext.assassinationofjacovsubra2.o1>“No, who's that?”</eventtext.assassinationofjacovsubra2.o1>
+<eventtext.assassinationofjacovsubra2.o1.c1>“Jacov Subra. He's a weird guy who put together these—how should I put it—'themed' festivals.” The person rolls their eyes. “Full of husks. Multiple fatalities. He had a high profile trial a while back. You might have read about it on the Europan. Anyway.”</eventtext.assassinationofjacovsubra2.o1.c1>
+<eventtext.assassinationofjacovsubra2.o1.o1.c1>“They caught him here a week ago. From what I heard, he had held another disastrous festival nearby, and was sent to the mines.”</eventtext.assassinationofjacovsubra2.o1.o1.c1>
+<eventtext.assassinationofjacovsubra2.o1.o1.o1>“That's good news.”</eventtext.assassinationofjacovsubra2.o1.o1.o1>
+<eventtext.assassinationofjacovsubra2.o1.o1.o1.c1>“Good news, until he slipped away again.” A tone signals that the break is over. The worker puts the paper away and starts toward the dock. “I hear they put up a reward for whoever brings him to custody,” they yell over their shoulder.</eventtext.assassinationofjacovsubra2.o1.o1.o1.c1>
+<eventtext.assassinationofjacovsubra2.o2>“What's he done now?”</eventtext.assassinationofjacovsubra2.o2>
+<eventtext.assassinationofjacovsubra2.o3>“Don't address me, trash.”</eventtext.assassinationofjacovsubra2.o3>
+<eventtext.assassinationofjacovsubra3.c1>“Welcome to the annual 'Church of the Mollusc' festival! Featuring: Sonata Aquatica, Jethro Hull, Irma-Donna, Draft Bunk and many more! With a special appearance by Sacov Jubra!” The word “mollusc” is written on top of a scribbled out “husk.” Seems like the festival is being held nearby. A passerby exclaims: “Draft Bunk is playing! Sweet!”</eventtext.assassinationofjacovsubra3.c1>
+<eventtext.assassinationofjacovsubra3.o1>Interesting.</eventtext.assassinationofjacovsubra3.o1>
+<eventtext.assassinationofjacovsubra4.c1>“You'll never take me alive!”</eventtext.assassinationofjacovsubra4.c1>
+<eventtext.assassinationofjacovsubra4.o1>“Give up, Jacov! You're coming with me!”</eventtext.assassinationofjacovsubra4.o1>
+<eventtext.assassinationofjacovsubra4.o1.c1>“I'm not going anywhere! I'm innocent! Look, I'll pay you!”</eventtext.assassinationofjacovsubra4.o1.c1>
+<eventtext.assassinationofjacovsubra4.o1.o1>“Save it for the judge.”</eventtext.assassinationofjacovsubra4.o1.o1>
+<eventtext.assassinationofjacovsubra4.o1.o1.c1>“Been there, done that.” Jacov smiles devilishly. “What makes you think I won't run away again?”</eventtext.assassinationofjacovsubra4.o1.o1.c1>
+<eventtext.assassinationofjacovsubra4.o1.o1.o1>“Not my problem.”</eventtext.assassinationofjacovsubra4.o1.o1.o1>
+<eventtext.assassinationofjacovsubra4.o1.o1.o1.c1>“I can see your heart isn't in this. I'll give you three thousand marks and you let me walk out of here. Deal?”</eventtext.assassinationofjacovsubra4.o1.o1.o1.c1>
+<eventtext.assassinationofjacovsubra4.deal>“Deal.”</eventtext.assassinationofjacovsubra4.deal>
+<eventtext.assassinationofjacovsubra4.neversaw>“Here's the money. We never saw each other.”</eventtext.assassinationofjacovsubra4.neversaw>
+<eventtext.assassinationofjacovsubra4.nodeal>“No deal. Come along now, quietly.”</eventtext.assassinationofjacovsubra4.nodeal>
+<eventtext.assassinationofjacovsubra4.run>As soon as the words leave your lips, Jacov hurls a fistful of coins at your head and turns to run away.</eventtext.assassinationofjacovsubra4.run>
+<eventtext.assassinationofjacovsubra4.o1.o1.o2>“Maybe I'll put a bullet in your leg.”</eventtext.assassinationofjacovsubra4.o1.o1.o2>
+<eventtext.assassinationofjacovsubra4.o1.o1.o2.c1>Jacov is sweating profusely. “Surely you wouldn't shoot an unarmed man?”</eventtext.assassinationofjacovsubra4.o1.o1.o2.c1>
+<eventtext.assassinationofjacovsubra4.o1.o1.o2.o1>“Absolutely I would.” (Attack)</eventtext.assassinationofjacovsubra4.o1.o1.o2.o1>
+<eventtext.assassinationofjacovsubra4.o1.o1.o2.o2>“Last chance.”</eventtext.assassinationofjacovsubra4.o1.o1.o2.o2>
+<eventtext.assassinationofjacovsubra4.o1.o1.o2.o2.c1>Fine, I'll come quietly.</eventtext.assassinationofjacovsubra4.o1.o1.o2.o2.c1>
+<eventtext.assassinationofjacovsubra4.o1.o2>“How much?”</eventtext.assassinationofjacovsubra4.o1.o2>
+<eventtext.assassinationofjacovsubra4.o1.o2.c1>“Three thousand for you and we part as friends, right here.”</eventtext.assassinationofjacovsubra4.o1.o2.c1>
+<eventtext.assassinationofjacovsubra4.o2>“Wasn't trying to. (Attack)”</eventtext.assassinationofjacovsubra4.o2>
+<eventtext.infiltration.c1>The station manager looks at you with haggard eyes. “You're one of the new arrivals? Man, am I glad to see a non-masked face.”</eventtext.infiltration.c1>
+<eventtext.infiltration.o1>“Now that you mention it, there are a lot of masks around.”</eventtext.infiltration.o1>
+<eventtext.infiltration.o1.c1>“A bunch of clowns. Let me ask you, you ever wake up in the middle of the night to a sound of bike horns? They don't even attempt any kind of melody, just honking away all willy-nilly. I haven't had a full night's sleep in...days?” They stare blankly into space. “Weeks?”</eventtext.infiltration.o1.c1>
+<eventtext.infiltration.o1.o1>“Sounds horrible. What do they want?”</eventtext.infiltration.o1.o1>
+<eventtext.infiltration.o1.o1.c1>“Who knows? I've tried talking to them, offering money, threatening to kick them out, you name it, I've tried it. I think they're content with torturing me and the rest of the crew.”</eventtext.infiltration.o1.o1.c1>
+<eventtext.infiltration.o1.o1.o1>Offer to help.</eventtext.infiltration.o1.o1.o1>
+<eventtext.infiltration.o1.o1.o1.c1>“The manager scoffs. “Tell you what. You get them to leave, there's a...” Their eyes narrow as they study you. “Thousand marks for you. One more thing. No physical violence. While I personally wouldn't shed any tears for roughed up clowns, we have rules here we adhere to.”</eventtext.infiltration.o1.o1.o1.c1>
+<eventtext.infiltration.o1.o1.o1.o1>“Not even a little?”</eventtext.infiltration.o1.o1.o1.o1>
+<eventtext.infiltration.o1.o1.o1.o1.c1>“No.”</eventtext.infiltration.o1.o1.o1.o1.c1>
+<eventtext.infiltration.o1.o1.o1.o2>“Got it.”</eventtext.infiltration.o1.o1.o1.o2>
+<eventtext.infiltration.o1.o1.o1.o2.c1>You approach a clown. They stare at you.</eventtext.infiltration.o1.o1.o1.o2.c1>
+<eventtext.infiltration.o1.o1.o1.o2.o1>Threaten the clown.</eventtext.infiltration.o1.o1.o1.o2.o1>
+<eventtext.infiltration.o1.o1.o1.o2.o1.c1>You stare the clown down for a minute. They try to grab your nose but you slap their arm away. You point to the direction of the airlock. With slumped shoulders, the clown shuffles away, their friends in tow.</eventtext.infiltration.o1.o1.o1.o2.o1.c1>
+<eventtext.infiltration.o1.o1.o1.o2.o1.o1>Mission complete.</eventtext.infiltration.o1.o1.o1.o2.o1.o1>
+<eventtext.infiltration.o1.o1.o1.o2.o1.o1.c1>It's suddenly very quiet. You report your success to the manager on the radio and one thousand marks are deposited to your account.</eventtext.infiltration.o1.o1.o1.o2.o1.o1.c1>
+<eventtext.infiltration.o1.o1.o1.o2.o1.c2>You strain to flex your biceps. For some reason this only succeeds in making the clown laugh in your face and continue their merriments.</eventtext.infiltration.o1.o1.o1.o2.o1.c2>
+<eventtext.infiltration.o1.o1.o1.o2.o1.o2>Mission failed.</eventtext.infiltration.o1.o1.o1.o2.o1.o2>
+<eventtext.infiltration.o1.o1.o1.o2.o1.o2.c1>You have missed your chance at making an impactful impression and dejectedly report failure to the station manager.</eventtext.infiltration.o1.o1.o1.o2.o1.o2.c1>
+<eventtext.infiltration.o1.o1.o1.o2.o2>Build rapport.</eventtext.infiltration.o1.o1.o1.o2.o2>
+<eventtext.infiltration.o1.o1.o1.o2.o2.c1>You try to reason with the clowns, explaining that their behaviour is disrupting the lives of the crew here and frankly, quite unacceptable. Your words fall to deaf ears.</eventtext.infiltration.o1.o1.o1.o2.o2.c1>
+<eventtext.infiltration.o1.o1.o2>“Well, good luck with that.”</eventtext.infiltration.o1.o1.o2>
+<eventtext.infiltration.o2>“Don't speak to me, you harlequin-hater.”</eventtext.infiltration.o2>
+<eventtext.badvibrations1.c1>A sound of shattering glass makes you jump. Someone is slouched against the wall, shards of glass at her feet. By the looks of it, it might have been a bottle of rum she was holding. She's muttering under her breath.</eventtext.badvibrations1.c1>
+<eventtext.badvibrations1.o1>“You okay?”</eventtext.badvibrations1.o1>
+<eventtext.badvibrations1.o1.c1>No response. You notice she's repeating the same thing over and over. “Bad vibrations, man. Bad vibes.” Drool is slowly dripping from the corner of her mouth onto her jacket.</eventtext.badvibrations1.o1.c1>
+<eventtext.badvibrations1.o1.o1>Try to help her.</eventtext.badvibrations1.o1.o1>
+<eventtext.badvibrations1.o1.o1.c1>You're wondering about the person's mental health, when they unexpectedly swing around and grab you by the collar. “Bad vibrations, do you hear me?” A sudden realization dawns on her when she recognizes you as a member of a submarine crew. “You can help me,” she pleads. “We found a relic. Turned it on. In the structure. Deep.” She lets up her grasp on you for a second.</eventtext.badvibrations1.o1.o1.c1>
+<eventtext.badvibrations1.o1.o1.o1>“You're making no sense.”</eventtext.badvibrations1.o1.o1.o1>
+<eventtext.badvibrations1.o1.o1.o1.c1>The madness seems to have found it's way back to cloud her mind. “I was first! I know! I got the trophy!”</eventtext.badvibrations1.o1.o1.o1.c1>
+<eventtext.badvibrations1.stepback>Take a step back.</eventtext.badvibrations1.stepback>
+<eventtext.badvibrations1.raving>You wonder what the person is raving about. A relic inside a structure? Something in the ruins? You make a note to check it out if you have time.</eventtext.badvibrations1.raving>
+<eventtext.badvibrations1.notmyproblem>Not my problem.</eventtext.badvibrations1.notmyproblem>
+<eventtext.badvibrations2.c1>Touching the artifact's etched surface causes an almost imperceptible itch inside your head.</eventtext.badvibrations2.c1>
+<eventtext.badvibrations2.o1>Drop the artifact.</eventtext.badvibrations2.o1>
+<eventtext.badvibrations2.o1.c1>For some reason, you find it very difficult to drop the item, and it remains in your hands. The itch builds up into a slight vibrating feeling in your skull.</eventtext.badvibrations2.o1.c1>
+<eventtext.badvibrations2.o1.o1>Throw away the artifact.</eventtext.badvibrations2.o1.o1>
+<eventtext.badvibrations2.o1.o1.c1>It's as if you've forgotten how to move your arms. Your head feels uncomfortably warm and numb. It's getting more and more challenging to keep your focus on anything.</eventtext.badvibrations2.o1.o1.c1>
+<eventtext.badvibrations2.o1.o1.o1>Sleep.</eventtext.badvibrations2.o1.o1.o1>
+<eventtext.badvibrations2.o1.o1.o1.c1>You close your eyes. This seems like as good a place as any to have a nap. Jupiter knows you've earned one. You let yourself fall back into a dreamless sleep.</eventtext.badvibrations2.o1.o1.o1.c1>
+<eventtext.badvibrations2.inspect>Inspect the artifact more closely.</eventtext.badvibrations2.inspect>
+<eventtext.badvibrations2.protrusion>As you run your hands across the item's surface, you hit a protrusion. At once, the numbness inside subsides and you are again fully aware of your surroundings. Time to get this artifact somewhere it can be kept safe.</eventtext.badvibrations2.protrusion>
+<eventtext.badvibrations3.c1>Somebody is trying to get your attention. “Hey! I've been looking for you.” She looks vaguely familiar. “You don't remember me, do you?”</eventtext.badvibrations3.c1>
+<eventtext.badvibrations3.o1>“Oh yeah, you're the one with the, uh, vibrations.”</eventtext.badvibrations3.o1>
+<eventtext.badvibrations3.gotbetter>“So, I got better. Suppose that is because you turned the thing off?” She crosses her arms. “Wanted to come say thanks.”</eventtext.badvibrations3.gotbetter>
+<eventtext.badvibrations3.welcome>“You're welcome.”</eventtext.badvibrations3.welcome>
+<eventtext.badvibrations3.anotherthing>“There's another thing. Because I was...unwell, I got booted from the crew I was with back then. I was thinking I could join up with you guys? I'm pretty handy with all things mechanical or electrical.” She looks strong and capable now that she's not being hindered by an external influence.</eventtext.badvibrations3.anotherthing>
+<eventtext.badvibrations3.merrier>“Sure. The more the merrier.”</eventtext.badvibrations3.merrier>
+<eventtext.badvibrations3.seeyouonboard>“Great. I'll see you on board.”</eventtext.badvibrations3.seeyouonboard>
+<eventtext.badvibrations3.full>“Sorry, we're full for now.”</eventtext.badvibrations3.full>
+<eventtext.badvibrations3.hangout>“Well, I guess I'll hang out here 'til I find something.”</eventtext.badvibrations3.hangout>
+<eventtext.badvibrations3.reward>Ask for a reward.</eventtext.badvibrations3.reward>
+<eventtext.badvibrations3.scrounge>“Oh. Uh, I can scrounge up a few hundred marks if you like. I'll send 'em to you as soon as possible.”</eventtext.badvibrations3.scrounge>
+<eventtext.badvibrations3.o2>“You're the fortuneteller, right?”</eventtext.badvibrations3.o2>
+<eventtext.badvibrations3.o2.c1>“Huh?” She looks confused and mildly annoyed. “No, you're mistaking me with someone else. I ran into you earlier when I was still having...trouble with a certain relic. You know, with the 'bad vibes' and all.”</eventtext.badvibrations3.o2.c1>
+<eventtext.badvibrations3.o2.o1>“Now I remember.”</eventtext.badvibrations3.o2.o1>
+<eventtext.manandhisraptor1.c1>A distressed looking person is pacing in circles in the hall. When they see you, their eyes light up. “You're from that sub that just docked, aren't you? Do you take passengers?”</eventtext.manandhisraptor1.c1>
+<eventtext.manandhisraptor1.o1>“I am indeed. What type of passengers?”</eventtext.manandhisraptor1.o1>
+<eventtext.manandhisraptor1.o1.c1>“Just me and Rex. We're supposed to visit nana in the next town over, but for some reason nobody wants us on board.” The person can't keep eye contact for more than a second and keeps glancing over their shoulder.</eventtext.manandhisraptor1.o1.c1>
+<eventtext.manandhisraptor1.o1.o1>Be suspicious.</eventtext.manandhisraptor1.o1.o1>
+<eventtext.manandhisraptor1.o1.o1.c1>There are always vessels traveling these waters, eager to make some extra moolah by taking on passengers. You open your mouth, trying to voice your suspicions about the situation. “Wh—” you start, but the person interrupts you. “I'll pay you three thousand. One when we leave, two when we get there.”</eventtext.manandhisraptor1.o1.o1.c1>
+<eventtext.manandhisraptor1.takeonboard>Take the person on board.</eventtext.manandhisraptor1.takeonboard>
+<eventtext.manandhisraptor1.great>“Great!” they exclaim. “I'll get Rex and we'll meet you on board!” What a happy fellow. Hopefully their money is good.</eventtext.manandhisraptor1.great>
+<eventtext.manandhisraptor1.o2>“Nope.”</eventtext.manandhisraptor1.o2>
+<eventtext.manandhisraptor2.c1>You're inspecting the sub when the person you talked to at the station peeks out from a cabin, with a wide smile on their face. “You ready to meet Rex?” Before you can utter a response, the biggest mudraptor you've ever seen jumps out behind them.</eventtext.manandhisraptor2.c1>
+<eventtext.manandhisraptor2.o1>“Watch out!”</eventtext.manandhisraptor2.o1>
+<eventtext.manandhisraptor2.o1.c1>You yell out and reach for a weapon, but the creature only tilts its head and looks at you quizzically. “Isn't he a cutie?” This is Rex? They brought a mudraptor on board? “Be careful, though. Rex gets ornery on long trips. Don't you, boy? Yes you do!” Great.</eventtext.manandhisraptor2.o1.c1>
+<eventtext.manandhisraptor2.c1.c1>Rex is pacing back and forth.</eventtext.manandhisraptor2.c1.c1>
+<eventtext.heartofgold.c1>As you approach, this bandit throws down their weapon. “Ah fuck it, I give up. Don't shoot!”</eventtext.heartofgold.c1>
+<eventtext.heartofgold.o1>“Too late for that. Say your prayers.”</eventtext.heartofgold.o1>
+<eventtext.heartofgold.o1.c1>The bandit reaches for their weapon on the ground. “Do your worst!”</eventtext.heartofgold.o1.c1>
+<eventtext.heartofgold.o2>Talk to them.</eventtext.heartofgold.o2>
+<eventtext.heartofgold.o2.c1>“Thanks for not offing me, I guess.” The bandit squats down and wipes sweat off his brow. “I've never fired that, you know,” he says, pointing to the gun on the floor. “Not cut out for this shit.”</eventtext.heartofgold.o2.c1>
+<eventtext.heartofgold.goodluck>“Well, good luck with everything.”</eventtext.heartofgold.goodluck>
+<eventtext.heartofgold.wait>“Wait!” The bandit cries out and jumps to their feet. “Can I come with you? I know a lot about chemistry. I could cook you meds!”</eventtext.heartofgold.wait>
+<eventtext.heartofgold.okay>“Okay, I suppose.”</eventtext.heartofgold.okay>
+<eventtext.heartofgold.signingbonus>“All right! We can sort out a signing bonus later.”</eventtext.heartofgold.signingbonus>
+<eventtext.heartofgold.whatamigonnado>“Well what am I gonna do then? Wait 'till another sub comes through guns blazing?”</eventtext.heartofgold.whatamigonnado>
+<eventtext.heartofgold.onyourown>“You're on your own.”</eventtext.heartofgold.onyourown>
+<eventtext.heartofgold.o2.o2>“What are you even doing here?”</eventtext.heartofgold.o2.o2>
+<eventtext.heartofgold.o2.o2.c1>“I was captured along with the rest of my crew and sub. They're all gone now.” They scowl. “Eaten. They were used as bait for the crawlers that used to inhabit this place. I was spared because I know how to make morphine and fent.”</eventtext.heartofgold.o2.o2.c1>
+<eventtext.heartofgold.o2.o2.o1>“You're a drug dealer?”</eventtext.heartofgold.o2.o2.o1>
+<eventtext.heartofgold.o2.o2.o1.c1>“Give me a break. Like you haven't done any opiates yourself? The way I see it I provided a service and, in return, nobody pointed a gun my way.” A dry smile creeps on their face. “Until you, that is.”</eventtext.heartofgold.o2.o2.o1.c1>
+<eventtext.bombscare.c1>“Hey, you there.”</eventtext.bombscare.c1>
+<eventtext.bombscare.o1>“Me?”</eventtext.bombscare.o1>
+<eventtext.bombscare.o1.c1>The guard takes a long look at you. “Never mind. I thought you looked like someone else. You're free to go.”</eventtext.bombscare.o1.c1>
+<eventtext.bombscare.o1.o1>“What's going on?”</eventtext.bombscare.o1.o1>
+<eventtext.bombscare.o1.o1.c1>“Just be careful,” the guard cautions. “We received a bomb threat a few hours ago, by some usual suspects. It's been a while and no bomb has been found, but we advise caution.”</eventtext.bombscare.o1.o1.c1>
+<eventtext.bombscare.o1.o1.o1>“Usual suspects?”</eventtext.bombscare.o1.o1.o1>
+<eventtext.bombscare.o1.o1.o1.c1>The guard lowers their voice. “Look, you better stay clear of this separatist business. There have been some serious attacks lately. Just come to me if you see something suspicious.”</eventtext.bombscare.o1.o1.o1.c1>
+<eventtext.bombscare.o1.o1.o1.c1.c1>Out of the corner of your eye, you see a pile of scrap electronics.</eventtext.bombscare.o1.o1.o1.c1.c1>
+<eventtext.bombscare.o1.o1.o1.c1.o1>Salvage.</eventtext.bombscare.o1.o1.o1.c1.o1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.c1>To your surprise, the pile of scrap turns out to be a homemade pipe bomb. As luck would have it some wires have come loose, preventing the bomb from going off. You carefully remove the detonator, pick up the bomb and place it in your bag. The guard from earlier should be interested in seeing this.</eventtext.bombscare.o1.o1.o1.c1.o1.c1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.c1.c1>You thrust the bomb to the arms of the guard, who flinches a bit. You recount your experience and the guard thanks you for finding the bomb and gives you a small reward for dismantling it.</eventtext.bombscare.o1.o1.o1.c1.o1.c1.c1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.c2>To your surprise, the pile of scrap is wired to a timer. You turn it around and see “00:01” displayed on the timer.</eventtext.bombscare.o1.o1.o1.c1.o1.c2>
+<eventtext.bombscare.o1.o1.o1.c1.o1.o1>Take cover.</eventtext.bombscare.o1.o1.o1.c1.o1.o1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1>You drop the bomb and dive down onto the floor, covering your head with your hands. Seconds pass by, but nothing happens. Gingerly, you stand up and dust yourself off. Seems like this bomb is a dud. The guard from earlier should be interested in seeing this.</eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1>
+<eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1.c1>You report finding a bomb in the hallway and the guard immediately springs to action. They thank you for finding and reporting the bomb.</eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1.c1>
+<eventtext.bombscare.o1.o2>Leave the guard.</eventtext.bombscare.o1.o2>
+<eventtext.terrorism101.c1>You see a person crouched next to a vending machine, assembling or fixing something.</eventtext.terrorism101.c1>
+<eventtext.terrorism101.o1>Find out what they're working on.</eventtext.terrorism101.o1>
+<eventtext.terrorism101.o1.c1>You sneak behind the person and crane your neck. It seems they're fiddling with some kind of a device with lots of wires. They glance back and jump up when they see you. “Shit! Don't just stand there!”</eventtext.terrorism101.o1.c1>
+<eventtext.terrorism101.o1.o1>“Sorry.”</eventtext.terrorism101.o1.o1>
+<eventtext.terrorism101.o1.o1.c1>“It's all right, I guess.” They check their pulse and exhale deeply. “I've been a wreck ever since my medication was pulled. Couldn't afford it, they said. Then they went ahead and installed these fuckin' things.” Irate, the dweller kicks the vending machine.</eventtext.terrorism101.o1.o1.c1>
+<eventtext.terrorism101.o1.o1.o1>“So what are you doing?”</eventtext.terrorism101.o1.o1.o1>
+<eventtext.terrorism101.excuse>“I, uh...” Their eyes dart around, looking for something. “I'm building a, um...” They're sweating profusely.</eventtext.terrorism101.excuse>
+<eventtext.terrorism101.abomb>“A bomb?”</eventtext.terrorism101.abomb>
+<eventtext.terrorism101.shh>“SHHH! Not so loud!” they hiss. Then they continue, whispering. “Yes, it's a bomb. But it's also so much more. It's a symbol of discontent against our overlords. We must topple the monuments of oppression, like this one here.” They spit on the vending machine. “But that's hypothetical at this point, 'cause I don't actually know how to arm this symbol.”</eventtext.terrorism101.shh>
+<eventtext.terrorism101.help>“I could help you with that.”</eventtext.terrorism101.help>
+<eventtext.terrorism101.novice>The novice terrorist scrutinizes you for a minute, then warily hands you a bunch of wires. “I think I can trust you,” they say.</eventtext.terrorism101.novice>
+<eventtext.terrorism101.armbomb>Arm the bomb.</eventtext.terrorism101.armbomb>
+<eventtext.terrorism101.bombarmed>It's only a matter of connecting the detonator wire to get the bomb armed. You hand the bomb to the person and they give you some change and a promise to talk you up to their Separatist friends.</eventtext.terrorism101.bombarmed>
+<eventtext.terrorism101.dismantlebomb>Quietly dismantle the bomb.</eventtext.terrorism101.dismantlebomb>
+<eventtext.terrorism101.bombdismantled>You pretend to arm the bomb, but instead you remove some of the wires, making sure the bomb can't go off. The person hands you some change as a reward and promises to talk you up to their Separatist friends.</eventtext.terrorism101.bombdismantled>
+<eventtext.terrorism101.o1.o1.o1.o1.o2>“Keep it that way. Terrorism is no way of life.”</eventtext.terrorism101.o1.o1.o1.o1.o2>
+<eventtext.terrorism101.o1.o1.o1.o2>“Never mind. I'm getting the guards.”</eventtext.terrorism101.o1.o1.o1.o2>
+<eventtext.terrorism101.o1.o1.o2>“Sorry to hear that. See you later.”</eventtext.terrorism101.o1.o1.o2>
+<eventtext.terrorism101.o1.o2>“What's that you're working on?”</eventtext.terrorism101.o1.o2>
+<eventtext.terrorism101.o1.o2.o1.o2>“Keep it that way. Terrorism is no way of life.”</eventtext.terrorism101.o1.o2.o1.o2>
+<eventtext.terrorism101.o1.o2.o2>“Never mind. I'm getting the guards.”</eventtext.terrorism101.o1.o2.o2>
+<eventtext.stuckinthemiddle.c1>This colony is in a hurry. Lots of workers are loading supplies onto submarines.  You see a pair of them arguing quietly and gesturing toward you.</eventtext.stuckinthemiddle.c1>
+<eventtext.stuckinthemiddle.o1>Walk up to them.</eventtext.stuckinthemiddle.o1>
+<eventtext.stuckinthemiddle.o1.c1>On your approach, the pair instantly quiets down. Up close you can see an anarchist patch on one of their jackets, revealing them to be separatists. “Didn't you help us out earlier?” the other asks.</eventtext.stuckinthemiddle.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1>“Yep, that's me.”</eventtext.stuckinthemiddle.o1.o1>
+<eventtext.stuckinthemiddle.o1.o1.c1>“You see all that crew running around? A lot of subs here are readying for a dive.”</eventtext.stuckinthemiddle.o1.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1>“I wonder where they're going.”</eventtext.stuckinthemiddle.o1.o1.o1>
+<eventtext.stuckinthemiddle.o1.o1.o1.c1>“Yeah, so do we. We sent one of ours to the office to find out.” The speaker shifts their weight and pauses for a bit. “They haven't come back yet, and I'm getting worried. Might've been caught doing something they shouldn't have.”</eventtext.stuckinthemiddle.o1.o1.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1>“I could find out.”</eventtext.stuckinthemiddle.o1.o1.o1.o1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.c1>“Not a bad idea. Officials here don't know you yet. Just sneak in, see what you can see. Whatever it is, don't cause a scene.”</eventtext.stuckinthemiddle.o1.o1.o1.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1>“Wouldn't dream of it.”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.c1>“Oh, and if our guy ask you if you've had Versas liver, the answer is 'It's to die for.'”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1>“Got it.”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.c1>Peeking into a side room, you see somebody sitting on a chair, handcuffed. Judging by their bloody and swollen face, they've been roughed up pretty thoroughly.</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1>Check on them.</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.c1>The person is semi-delirious, but they manage to mutter a question: “You ever...ever had V-versas liver?”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1>“No, never.”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1>“S-shame. I hear it's to die for.” They chuckle to themselves. “You better leave before s-security comes back. If you could let somebody know I'm in here, it'd be s-swell.”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1>You inform the separatists of the location of their agent. They thank you for your help and set out to rescue their comrade.</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2>“It's to die for.”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1>“Take th-the scrap of paper from my pocket. M-make s-sure it makes it to safe hands. I better stay here or the pigs smell something's going on.” You take the paper and stuff it in your pocket.</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1.c1>You hand the intel to the separatist. “Damn. This isn't much to go on. The only thing this proves is that the Coalition has started mobilizing en masse and they're searching for something. I could've told you that by just looking around. Thanks for your help anyway. If you'll excuse me, we have a rescue mission to undertake.”</eventtext.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1.c1>
+<eventtext.stuckinthemiddle.o1.o1.o1.o2>“Damn, that sucks. Good luck though.”</eventtext.stuckinthemiddle.o1.o1.o1.o2>
+<eventtext.stuckinthemiddle.o1.o2>“Nope, you must be mistaken.”</eventtext.stuckinthemiddle.o1.o2>
+<eventtext.censorship.c1>“Hey, psst!” You hear a sharp whisper from behind. A person in a clown costume is trying to get your attention.</eventtext.censorship.c1>
+<eventtext.censorship.o1>Listen to what they have to say.</eventtext.censorship.o1>
+<eventtext.censorship.o1.c1>They seem grateful that you're willing to hear them out, but under all that white makeup, you can't be sure. The person is really fidgety and every time they shift, their shoes squeak loudly.</eventtext.censorship.o1.c1>
+<eventtext.censorship.o1.o1.c1>You manage to gather that a shipment of important materials has been falsely impounded from this clown person's vessel and they're asking for help getting it back.</eventtext.censorship.o1.o1.c1>
+<eventtext.censorship.o1.o1.o1>Help them out.</eventtext.censorship.o1.o1.o1>
+<eventtext.censorship.o1.o1.o1.c1>The jester is overjoyed. The box has been taken to the manager's office. They toot a horn as you turn to leave. Weird.</eventtext.censorship.o1.o1.o1.c1>
+<eventtext.censorship.o1.o1.o1.c1.c1>There is a box of supplies here, labeled “Confiscated.” This must be what the clown wanted. You bend down and pick up the box, then turn around to head back when you see a security guard pointing at you with a stun baton. “Where do you think you're going? That's confiscated materials you're carrying.”</eventtext.censorship.o1.o1.o1.c1.c1>
+<eventtext.censorship.o1.o1.o1.c1.o1>Be truthful.</eventtext.censorship.o1.o1.o1.c1.o1>
+<eventtext.censorship.o1.o1.o1.c1.o1.c1>You explain that you're helping someone get their unlawfully confiscated cargo back. “Unlawfully? Do you realize you're carrying highly dangerous implements of terror there?” The guard carefully opens the box, revealing a bunch of red and white costumes and an assortment of bike horns.</eventtext.censorship.o1.o1.o1.c1.o1.c1>
+<eventtext.censorship.o1.o1.o1.c1.o1.o1>“I'm sorry, officer. I didn't know.”</eventtext.censorship.o1.o1.o1.c1.o1.o1>
+<eventtext.censorship.o1.o1.o1.c1.o1.o1.c1>The guard takes the box from you. “Don't let me catch you trying that shit again.”</eventtext.censorship.o1.o1.o1.c1.o1.o1.c1>
+<eventtext.censorship.o1.o1.o1.c1.o1.o2>Run.</eventtext.censorship.o1.o1.o1.c1.o1.o2>
+<eventtext.censorship.o1.o1.o1.c1.o1.o2.c1>Without saying another word, you turn tail and run. The officer is stunned for a moment, then chases after you.</eventtext.censorship.o1.o1.o1.c1.o1.o2.c1>
+<eventtext.censorship.o1.o1.o1.c1.o2>Lie.</eventtext.censorship.o1.o1.o1.c1.o2>
+<eventtext.censorship.o1.o1.o1.c1.o2.c1>You explain that you are a new customs officer here and are transporting the box to a more secure facility.</eventtext.censorship.o1.o1.o1.c1.o2.c1>
+<eventtext.censorship.o1.o1.o1.c1.o2.o1>The guard scratches their head.</eventtext.censorship.o1.o1.o1.c1.o2.o1>
+<eventtext.censorship.o1.o1.o1.c1.o2.o1.c1>The guard decides it's not worth their time to fact-check what you said. They wave you to continue on.</eventtext.censorship.o1.o1.o1.c1.o2.o1.c1>
+<eventtext.censorship.o1.o1.o1.c1.o2.o1.c1.c1>The clown is happy to see their items back and teaches you a customary clown greeting that you can use to impress other clowns.</eventtext.censorship.o1.o1.o1.c1.o2.o1.c1.c1>
+<eventtext.censorship.o1.o1.o1.c1.o2.o1.c2>The guard is not convinced and takes the box from you.</eventtext.censorship.o1.o1.o1.c1.o2.o1.c2>
+<eventtext.censorship.o1.o1.o1.c1.o2.o1.c2.c2>Sadly, you return to the clown empty-handed.</eventtext.censorship.o1.o1.o1.c1.o2.o1.c2.c2>
+<eventtext.censorship.o1.o1.o2>Better not.</eventtext.censorship.o1.o1.o2>
+<eventtext.generic.walkaway>Walk away.</eventtext.generic.walkaway>
+<eventtext.generic.ignore>Ignore.</eventtext.generic.ignore>
+<eventtext.generic.continue>Continue...</eventtext.generic.continue>
+<eventtext.generic.refuse>Refuse.</eventtext.generic.refuse>
+<eventtext.atwitsend.c1>A gaunt young man walks up to you, a bottle of liquor in hand. Despite appearances, he speaks to you in a peppy tune:\n\n"Hey, the name's Artie Dolittle. You came here on that ship, right? You should take me with you!"\n</eventtext.atwitsend.c1>
+<eventtext.atwitsend.o1>“What? Why should I do that?”</eventtext.atwitsend.o1>
+<eventtext.atwitsend.o1.c1>“Because I'd be a great employee! I'm good at everything and I'll even work for free! How's that sound?”</eventtext.atwitsend.o1.c1>
+<eventtext.atwitsend.o1.o1>“You've convinced me. Welcome aboard.”</eventtext.atwitsend.o1.o1>
+<eventtext.atwitsend.o1.o1.c1>“Great! You won't regret it.”</eventtext.atwitsend.o1.o1.c1>
+<eventtext.atwitsend.o1.o2>“Not interested.”</eventtext.atwitsend.o1.o2>
+<eventtext.atwitsend.o1.o2.c1>“Oh. Can't blame a guy for trying though, right?”</eventtext.atwitsend.o1.o2.c1>
+<eventtext.atwitsend.o2>“Nah, get lost, you bum.”</eventtext.atwitsend.o2>
+<eventtext.atwitsend.o2.c1>“Well screw you, then!”</eventtext.atwitsend.o2.c1>
+<EventText.captivesouls.c1>A passing scientist grabs hold of you. “It lives! Who would've thought it would ever live?” Their eyes are wide open and sporting impressive bags under them.</EventText.captivesouls.c1>
+<EventText.captivesouls.o1>”What are you talking about?”</EventText.captivesouls.o1>
+<EventText.captivesouls.o1.c1>“I was too preoccupied with asking 'Can I?' instead of 'Should I?'” They pace back and forth, directing each word to a different passerby. When it becomes clear to them nobody's paying any attention besides you, they turn their attention back toward you.</EventText.captivesouls.o1.c1>
+<EventText.captivesouls.o1.o1.c1>“Are you not listening to me?” the hysterical researcher bellows, sending drops of spittle across your face. “A human-crawler hybrid! Oh, it's beautiful! No! Hideous!” They sit down, cross-legged on the floor. “How will the scientific community remember me? As a creator? A destroyer?” they pose to no one in particular. “Dare I say...a god?”</EventText.captivesouls.o1.o1.c1>
+<EventText.captivesouls.o1.o1.o1.c1>Looking at the scientist—now writhing on the floor, gibbering and laughing to themself—you are somewhat grateful that the end comes in your line of work quickly and violently, instead of a slow spiral to madness.</EventText.captivesouls.o1.o1.o1.c1>
+<EventText.captivesouls.o1.o1.o1.o1.c1>Their claims of having successfully bred a human-crawler hybrid are obviously fantastical. Although... There is a small part of you that wants to believe. Maybe you could check the lab, just in case?</EventText.captivesouls.o1.o1.o1.o1.c1>
+<EventText.captivesouls.c1.c1>A crawler is sitting motionless in a tank.</EventText.captivesouls.c1.c1>
+<EventText.captivesouls.c1.o1>Approach.</EventText.captivesouls.c1.o1>
+<EventText.captivesouls.c1.o1.c1>It seems to have been heavily sedated. This is not unordinary. Researchers are known to catch live specimens for research. Numerous scientific breakthroughs have been made using data received from crawlers: medical, gastronomical, psychologica— Wait. Did it just...blink?</EventText.captivesouls.c1.o1.c1>
+<EventText.captivesouls.c1.o1.o1>Knock on the glass.</EventText.captivesouls.c1.o1.o1>
+<EventText.captivesouls.c1.o1.o1.c1>You tap on the glass three times and the creature opens its eyes. They are remarkably blue and fixated on you. It blinks once, twice… You can't help but feel like the creature is trying to communicate.</EventText.captivesouls.c1.o1.o1.c1>
+<EventText.captivesouls.c1.o1.o1.o1>What is it saying?</EventText.captivesouls.c1.o1.o1.o1>
+<EventText.captivesouls.c1.o1.o1.o1.c1>“Free me.” (You shouldn't.)</EventText.captivesouls.c1.o1.o1.o1.c1>
+<EventText.captivesouls.c1.o1.o1.o1.o1>True, I shouldn't. Although...</EventText.captivesouls.c1.o1.o1.o1.o1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.c1>It is a living creature, after all. Why shouldn't it be granted clemency?</EventText.captivesouls.c1.o1.o1.o1.o1.c1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o1>Smash the glass.</EventText.captivesouls.c1.o1.o1.o1.o1.o1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o1.c1>It takes a few swings to make a crack appear. The water crashes out along with the creature, who turns its head toward you and nods, before slithering into a vent and disappearing from view. Weird. Did it acknowledge your help, or was it simply a jerky movement on its part?</EventText.captivesouls.c1.o1.o1.o1.o1.o1.c1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.c1>A glint catches your eye in the now empty, broken tank.</EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.c1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1>Check it out.</EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1.c1>Among the debris, there is a small trinket with alien etchings. You take it. It's time to go before someone starts asking questions.</EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1.c1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2>No time.</EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2.c1>It's time to go before someone starts asking questions.</EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2.c1>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o2>Don't. Final warning.</EventText.captivesouls.c1.o1.o1.o1.o1.o2>
+<EventText.captivesouls.c1.o1.o1.o1.o1.o2.c1>You decide to leave the creature in its tank.</EventText.captivesouls.c1.o1.o1.o1.o1.o2.c1>
+<EventText.captivesouls.c1.o1.o2>Leave.</EventText.captivesouls.c1.o1.o2>
+<EventText.captivesouls.c1.o2>Don't approach.</EventText.captivesouls.c1.o2>
+<EventText.explosivemishap.c1>You hear voices from behind a closed door. “...so I just hold down this button?”</EventText.explosivemishap.c1>
+<EventText.explosivemishap.o1>Listen at the door.</EventText.explosivemishap.o1>
+<EventText.explosivemishap.o1.c1>A low humming voice can be heard in the background, like an old-timey vacuum cleaner. “Basically. Though you should be careful not to overheat it.”</EventText.explosivemishap.o1.c1>
+<EventText.explosivemishap.o1.o1.c1>“Overheat?” The humming noise grows louder and louder, increasing in pitch.</EventText.explosivemishap.o1.o1.c1>
+<EventText.explosivemishap.o1.o1.o1>Keep your ear to the door.</EventText.explosivemishap.o1.o1.o1>
+<EventText.explosivemishap.o1.o1.o1.c1>The door is blown off its hinges, knocking you down.</EventText.explosivemishap.o1.o1.o1.c1>
+<EventText.explosivemishap.o1.o1.o1.o1>Look inside.</EventText.explosivemishap.o1.o1.o1.o1>
+<EventText.explosivemishap.o1.o1.o1.o1.c1>It looks as if a bomb had gone off inside the laboratory. Expensive instruments are strewn broken on the floor and the once-white walls are decorated with streaks of dark red and pieces of brain matter. Two smoking corpses lie on the floor, along with an alien device of some kind. Someone nearby is yelling for a security guard.</EventText.explosivemishap.o1.o1.o1.o1.c1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1>Examine the device before security gets here.</EventText.explosivemishap.o1.o1.o1.o1.o1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.c1>The device is made of black metallic material and is heavy to hold. There is a handle that your hand fits into, and a button that lies directly under your index finger.</EventText.explosivemishap.o1.o1.o1.o1.o1.c1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1>Pull the trigger.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.c1>Nothing happens. It seems if this item indeed is the cause of the mess here, it has run dry of its destructive power.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.c1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1>Look for anything else useful in the lab.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c1>You find a shiny capsule that fits into a slot on the underside of the device. You hear footsteps approaching. If you want to keep the device for yourself, it's time to bounce.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o1>Hightail it.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2>Surrender the weapon to the authorities.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2.c1>Security is happy to take the dangerous device off your hands. They promise to put in a good word for you in the office.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2.c1>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c2>You find nothing. You decide to hold on to the device and leave before security gets here.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c2>
+<EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o2>Hightail it.</EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o2>
+<EventText.explosivemishap.o1.o1.o1.o1.o2>Leave.</EventText.explosivemishap.o1.o1.o1.o1.o2>
+<EventText.occupationalhazards.c1>A man with a hard hat is nursing a drink.</EventText.occupationalhazards.c1>
+<EventText.occupationalhazards.o1>Join him.</EventText.occupationalhazards.o1>
+<EventText.occupationalhazards.o1.c1>You pull a seat next to him and he acknowledges you with a nod. “Here to work?”</EventText.occupationalhazards.o1.c1>
+<EventText.occupationalhazards.o1.o1>“Something like that.”</EventText.occupationalhazards.o1.o1>
+<EventText.occupationalhazards.o1.o1.c1>He chuckles. “Had you pegged as the type. Well, if you're thinking of heading into the mines, don't,” he says and finishes his drink in one gulp.</EventText.occupationalhazards.o1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1>“What's in the mines?”</EventText.occupationalhazards.o1.o1.o1>
+<EventText.occupationalhazards.o1.o1.o1.c1>“Well,” the worker starts, is interrupted by a hiccup, and continues: “Not any miners with two brain cells to rub together, that's for sure. Not during breeding season.”</EventText.occupationalhazards.o1.o1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1>“Breeding season?”</EventText.occupationalhazards.o1.o1.o1.o1>
+<EventText.occupationalhazards.o1.o1.o1.o1.c1>The worker grunts an affirmation. “But when the boss says 'drill' you drill, or you go without food. So I went deeper until I hit something.”</EventText.occupationalhazards.o1.o1.o1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1>“What did you hit?”</EventText.occupationalhazards.o1.o1.o1.o1.o1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.c1>“Eggs.”</EventText.occupationalhazards.o1.o1.o1.o1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1>“Eggs?”</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.c1>“Mudraptor eggs. Now the whole shaft is overrun with angry raptor mamas and papas.”</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1>“So, is there a reward for clearing them out?”</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.c1>The man bursts into laughter. “No. What are you, some kind of a monster hunter? Rudy might've had some cash on him but he's down there.” He yelps at the bartender and motions for another beer. “Or a part of him at least.”</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1>Stand up and leave.</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1>You excuse yourself and leave the man in peace. You wonder if you could find this Rudy's body in the mineshaft.</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1>You find a badly mauled body clad in miner's overalls. The name tag says "Rudy."</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1>Search his pockets.</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1.c1>You find some cash.</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1.c1>
+<EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o2>Leave the body.</EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o2>
+<EventText.hognose.c1>You see a man with an eyepatch and a white beard sitting at a table. Some passersby are casting nervous side-eye glances at him. “That's Hognose Huber, sea captain extraordinaire,” someone whispers.</EventText.hognose.c1>
+<EventText.hognose.o1>Approach.</EventText.hognose.o1>
+<EventText.hognose.o1.c1>The man growls as you approach.</EventText.hognose.o1.c1>
+<EventText.hognose.o1.o1>”Not too friendly, are we?”</EventText.hognose.o1.o1>
+<EventText.hognose.o1.o1.c1>He hacks up something from his throat and spits it out. “Had a bit of a blockage. Help you?” Huber squints at you.</EventText.hognose.o1.o1.c1>
+<EventText.hognose.o1.o1.o1>”I was wondering how one gets a nickname like Hognose.”</EventText.hognose.o1.o1.o1>
+<EventText.hognose.o1.o1.o1.c1>“Hognose was the name of my ship. Used to run the Hettol-Ihesas-Urghstead circuit.” He sits up, beaming with pride. “Must've had a hundred successful transports. Meds, military ordnance, submarine parts, you name it, I hauled it.”</EventText.hognose.o1.o1.o1.c1>
+<EventText.hognose.o1.o1.o1.o1>”Then what happened?”</EventText.hognose.o1.o1.o1.o1>
+<EventText.hognose.o1.o1.o1.o1.c1>“What happened? It got sunk! By Moping Jack!” Hognose pounds the table with his fist, sending empty glasses flying. “Caught me totally by surprise. One hit, the engine was down. Second, the hull was breached.” He stares through you, into the distance.</EventText.hognose.o1.o1.o1.o1.c1>
+<EventText.hognose.o1.o1.o1.o1.o1>”How did you survive?”</EventText.hognose.o1.o1.o1.o1.o1>
+<EventText.hognose.o1.o1.o1.o1.o1.c1>“I swam,” Hognose states matter-of-factly. “Grabbed all the O2 I could and hopped on a scooter. Had to even leave Ringo, my pet toad, behind.” A single tear rolls down from Hognose's remaining eye. “At that moment I swore revenge against the beast.” He slams down a radio on the table. Noticing your puzzled look, he explains. “It ate my radio mast. I've been all over Europa, trying to get a signal. If I ever find him, it's—” The radio lets out a series of beeps.</EventText.hognose.o1.o1.o1.o1.o1.c1>
+<EventText.hognose.o1.o1.o1.o1.o1.o1.c1>“It's here! You have a ship, don't you? Up for a hunt, young one?” Hognose is shaking with excitement. “Well compensated of course.”</EventText.hognose.o1.o1.o1.o1.o1.o1.c1>
+<EventText.hognose.o1.o1.o1.o1.o1.o1.o1>”Of course!”</EventText.hognose.o1.o1.o1.o1.o1.o1.o1>
+<EventText.hognose.o1.o1.o1.o1.o1.o1.o1.c1>“I knew there was a fight in your generation after all! I'll see you on board.”</EventText.hognose.o1.o1.o1.o1.o1.o1.o1.c1>
+<EventText.hognose.o1.o1.o1.o1.o1.o1.o2>Not interested.</EventText.hognose.o1.o1.o1.o1.o1.o1.o2>
+<EventText.hognose.o1.o1.o2>”Never mind.”</EventText.hognose.o1.o1.o2>
+<EventText.hognose.o1.o2>Run away.</EventText.hognose.o1.o2>
+<EventText.hognose.o2>Steer clear.</EventText.hognose.o2>
+<EventText.nothingtoseehere.c1>An elderly woman waves at you. “Could you be a dear and throw this out for me?” she asks, shoving a handful of trash in your hand.</EventText.nothingtoseehere.c1>
+<EventText.nothingtoseehere.o1>Do as she asks.</EventText.nothingtoseehere.o1>
+<EventText.nothingtoseehere.o1.c1>You're glad to be rid of the old hag's garbage. While unloading your smelly cargo you catch a glimpse of a human finger amid the refuse.</EventText.nothingtoseehere.o1.c1>
+<EventText.nothingtoseehere.o1.o1>Investigate further.</EventText.nothingtoseehere.o1.o1>
+<EventText.nothingtoseehere.o1.o1.c1>Being up to your elbows in the trash can draws some weird looks from onlookers but they shrug it off. The economy is bad after all. Under all the burger wrappers you can see a lanyard identifying the corpse as a reporter for The Europan, a newspaper of questionable quality. Curiously, their name is scratched out.</EventText.nothingtoseehere.o1.o1.c1>
+<EventText.nothingtoseehere.o1.o1.o1.c1>You try not to gag at the smell of the garbage and the dead body and rip the tag off. Maybe somebody in security would be interested in this?</EventText.nothingtoseehere.o1.o1.o1.c1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.c1>“Can I help you with something?”</EventText.nothingtoseehere.o1.o1.o1.c1.c1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1>”I'd like to report a dead body.”</EventText.nothingtoseehere.o1.o1.o1.c1.o1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1.c1>You show the name tag to the security officer and explain your findings. They scratch their head and sigh. “Look, I've been working security for fifteen years. If a line cook at Irma Burger is found dead, it's probably a crime of passion, an argument gone wrong,” they explain. “The killer may be found, justice dispensed.” They take a look around. Nobody seems to be listening, but the guard continues in whisper: “A reporter is found in the trash, their ID scratched out? You turn a blind eye. There's nothing good to be found in that rabbit hole.”</EventText.nothingtoseehere.o1.o1.o1.c1.o1.c1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1>”Understood.”</EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1.c1>The guard raises their voice again. “Thank you for your tip, citizen. Five hunded marks have been deposited to your account.”</EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1.c1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2>Prod for more information.</EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.c1>To the guard's dismay, you ask them to elaborate. “Do I need to spell this out for you? Reporters investigate—” Somebody walks by you, and the guard stops mid-sentence, waits for them to pass, then continues: “and more importantly, they report. Somebody clearly didn't want to be reported on.”</EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.c1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1>”Somebody from the Coalition?”</EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.c1>The guard rolls their eyes. “You finally get it. There's a nice reward for reporting a dead body. I suggest you take that, buy yourself some opium, or whatever it is you submarine types like and forget about what you saw. I'll take care of the body.”</EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.c1>
+<EventText.nothingtoseehere.o1.o1.o1.c1.o2>Chicken out.</EventText.nothingtoseehere.o1.o1.o1.c1.o2>
+<eventtext.huskextremists1.c1>"What kind of idiot would interrupt our undergoing experiment in the post-ascension stage?!"</eventtext.huskextremists1.c1>
+<eventtext.huskextremists1.o1>"You've done all this on purpose?!"</eventtext.huskextremists1.o1>
+<eventtext.huskextremists1.o1.c1>"Ah, of course it's a non-believer. Look around, open your eyes. Have you noticed society is slowly crumbling? Food on outposts is scarce, populations are thinning."</eventtext.huskextremists1.o1.c1>
+<eventtext.huskextremists1.o1.o1>"So you decided to speed up our demise?"</eventtext.huskextremists1.o1.o1>
+<eventtext.huskextremists1.o1.o1.c1>"Our demise? No! Our salvation. Humankind's only way to move beyond slowly being wiped out is by adapting. And the way to adapt is through the Velonaceps calyx, or Husk as you would call it. It takes us beyond the limits of our frail human bodies, makes us something more. A sacrifice now means less deaths in the long-term—probably even preventing the extinction of our whole race! By whatever means necessary!"</eventtext.huskextremists1.o1.o1.c1>
+<eventtext.huskextremists1.o1.o1.o1>"The Husk may be the way forward, but not like this… Through voluntary experiments and real science in labs, we'll find our way."</eventtext.huskextremists1.o1.o1.o1>
+<eventtext.huskextremists1.o1.o1.o2>"We will find a way to survive. I'd prefer it to be without a parasite in my throat."</eventtext.huskextremists1.o1.o1.o2>
+<eventtext.huskextremists1.o1.o1.o3>"You may have a point… We'll leave you be."</eventtext.huskextremists1.o1.o1.o3>
+<eventtext.huskextremists1.o2>"Brothers, you are clearly misguided. The mess you've made here isn't what an Ascension looks like."</eventtext.huskextremists1.o2>
+<eventtext.huskextremists1.o2.c1>"Oh, so you're one of the cowards who pretend to be on the way to Ascension, but are too afraid to take a proper dive to the deep end? Perhaps we need to silence those weak little human thoughts and give you a little push over the edge?"</eventtext.huskextremists1.o2.c1>
+<eventtext.huskextremists1.o3>"The kind that has a post-shotgun to the face experiment prepared for you."</eventtext.huskextremists1.o3>
+
+<!-- Submarine upgrades & repairs -->
+<upgradecategory.walls>Hulls</upgradecategory.walls>
+<upgradecategory.junctionboxes>Junction boxes</upgradecategory.junctionboxes>
+<upgradecategory.pumps>Pumps</upgradecategory.pumps>
+<upgradecategory.supercapacitors>Supercapacitors</upgradecategory.supercapacitors>
+<upgradecategory.batteries>Batteries</upgradecategory.batteries>
+<upgradecategory.fabricators>Fabricators</upgradecategory.fabricators>
+<upgradecategory.deconstructors>Deconstructors</upgradecategory.deconstructors>
+<upgradecategory.weapons>Weapons</upgradecategory.weapons>
+<upgradecategory.loaders>Loaders</upgradecategory.loaders>
+<upgradecategory.engines>Engines</upgradecategory.engines>
+<upgradecategory.reactors>Reactors</upgradecategory.reactors>
+<upgradecategory.monitors>Monitors</upgradecategory.monitors>
+<upgradecategory.oxygengenerators>Oxygen generators</upgradecategory.oxygengenerators>
+<upgradename.increasewallhealth>Hull Reinforcements</upgradename.increasewallhealth>
+<upgradedescription.increasewallhealth>Increase submarine hull durability. Makes the walls less vulnerable to damage and allows the submarine to dive deeper without getting crushed by pressure.</upgradedescription.increasewallhealth>
+<upgradename.increasedeteriorationdelay>Enhanced Durability</upgradename.increasedeteriorationdelay>
+<upgradedescription.increasedeteriorationdelay>Equipment will take longer to start deteriorating.</upgradedescription.increasedeteriorationdelay>
+<upgradename.decreasedeteriorationspeed>Enhanced Redundant Systems</upgradename.decreasedeteriorationspeed>
+<upgradedescription.decreasedeteriorationspeed>Equipment will deteriorate more slowly.</upgradedescription.decreasedeteriorationspeed>
+<upgradename.decreaselowskillfixduration>Modular Repairs</upgradename.decreaselowskillfixduration>
+<upgradedescription.decreaselowskillfixduration>Decrease the amount of time and skill needed to repair equipment.</upgradedescription.decreaselowskillfixduration>
+<upgradename.decreaserequiredskilllevel>Simplified Repairs</upgradename.decreaserequiredskilllevel>
+<upgradedescription.decreaserequiredskilllevel>Decrease the skill level required to repair items.</upgradedescription.decreaserequiredskilllevel>
+<upgradename.decreasepowerconsumption>Energy Efficiency</upgradename.decreasepowerconsumption>
+<upgradedescription.decreasepowerconsumption>Decrease power consumption.</upgradedescription.decreasepowerconsumption>
+<upgradename.increasefabricationspeed>Quicker Fabrication</upgradename.increasefabricationspeed>
+<upgradedescription.increasefabricationspeed>Decrease the time needed to fabricate items, but increase power usage.</upgradedescription.increasefabricationspeed>
+<upgradename.decreasefabricationskillrequirement>Simplified Fabrication</upgradename.decreasefabricationskillrequirement>
+<upgradedescription.decreasefabricationskillrequirement>Lower the skill levels required for item fabrication.</upgradedescription.decreasefabricationskillrequirement>
+<upgradename.decreasedeconstructiontime>Quicker Deconstruction</upgradename.decreasedeconstructiontime>
+<upgradedescription.decreasedeconstructiontime>Items will be deconstructed faster. Power usage increased slightly.</upgradedescription.decreasedeconstructiontime>
+<upgradename.turretdecreasepowerconsumption>Energy Efficiency</upgradename.turretdecreasepowerconsumption>
+<upgradedescription.turretdecreasepowerconsumption>Reduce power consumption.</upgradedescription.turretdecreasepowerconsumption>
+<upgradename.turretincreaserotationlowskill>Quicker Guns</upgradename.turretincreaserotationlowskill>
+<upgradedescription.turretincreaserotationlowskill>Increase the rotation rate of all guns when operated by insufficiently skilled crew.</upgradedescription.turretincreaserotationlowskill>
+<upgradename.turretincreaseoffsetonselected>Enhanced Periscopes</upgradename.turretincreaseoffsetonselected>
+<upgradedescription.turretincreaseoffsetonselected>Increase the view range of all weapons.</upgradedescription.turretincreaseoffsetonselected>
+<upgradename.increaseoxygengeneration>Oxygen Generator Efficiency</upgradename.increaseoxygengeneration>
+<upgradedescription.increaseoxygengeneration>Increase the amount of oxygen generated.</upgradedescription.increaseoxygengeneration>
+<upgradename.increasereactoroutput>Reactor Efficiency</upgradename.increasereactoroutput>
+<upgradedescription.increasereactoroutput>Increase reactor power output.</upgradedescription.increasereactoroutput>
+<upgradename.decreasefuelconsumption>Upgraded Cooling Rods</upgradename.decreasefuelconsumption>
+<upgradedescription.decreasefuelconsumption>Decrease fuel consumption rate. Increase the time reactors can stay at critical temperature before meltdown.</upgradedescription.decreasefuelconsumption>
+<upgradename.increasemeltdowndelay>Thermal Tolerance</upgradename.increasemeltdowndelay>
+<upgradedescription.increasemeltdowndelay>Increase the time reactors can stay at critical temperature before meltdown.</upgradedescription.increasemeltdowndelay>
+<upgradename.increasemaxpumpflow>Efficient Pumps</upgradename.increasemaxpumpflow>
+<upgradedescription.increasemaxpumpflow>Increase the speed at which water is pumped in or out of the sub. Decreases pumps' power consumption.</upgradedescription.increasemaxpumpflow>
+<upgradename.increaseenginemaxforce>Engine Power</upgradename.increaseenginemaxforce>
+<upgradedescription.increaseenginemaxforce>Increase maximum speed.</upgradedescription.increaseenginemaxforce>
+<upgradename.increasebatterycapacity>Enhanced Battery Capacity</upgradename.increasebatterycapacity>
+<upgradedescription.increasebatterycapacity>Increase maximum energy storage capacity.</upgradedescription.increasebatterycapacity>
+<upgradename.increasesupercapacitorcapacity>Enhanced Supercapacitor Capacity</upgradename.increasesupercapacitorcapacity>
+<upgradedescription.increasesupercapacitorcapacity>Increase maximum energy storage capacity.</upgradedescription.increasesupercapacitorcapacity>
+<upgradename.increasebatteryrechargespeed>Enhanced Battery Charging</upgradename.increasebatteryrechargespeed>
+<upgradedescription.increasebatteryrechargespeed>Increase maximum recharge rate.</upgradedescription.increasebatteryrechargespeed>
+<upgradename.decreasefireprobability>Fire Resistance</upgradename.decreasefireprobability>
+<upgradedescription.decreasefireprobability>Decrease the probability of fires occurring.</upgradedescription.decreasefireprobability>
+<upgradename.increaseovervoltageresistance>Enhanced Resistors</upgradename.increaseovervoltageresistance>
+<upgradedescription.increaseovervoltageresistance>Resist damage from excessive voltage. Decrease the probability of fires occurring.</upgradedescription.increaseovervoltageresistance>
+<upgradename.increasemaxcondition>Enhanced Durability</upgradename.increasemaxcondition>
+<upgradedescription.increasemaxcondition>Increases the maximum condition of the item, making it deteriorate more slowly and withstand more damage.</upgradedescription.increasemaxcondition>
+<upgradename.increasewallhealth2>Titanium-Aluminum Hull Reinforcements</upgradename.increasewallhealth2>
+<upgradedescription.increasewallhealth2>Significantly increases submarine hull durability. Makes the walls less vulnerable to damage and allows the submarine to dive deeper without getting crushed by pressure.</upgradedescription.increasewallhealth2>
+<upgradename.increasewallhealth3>Physicorium Hull Reinforcements</upgradename.increasewallhealth3>
+<upgradedescription.increasewallhealth3>Substantially increases submarine hull durability. Makes the walls less vulnerable to damage and allows the submarine to dive to abyssal depths.</upgradedescription.increasewallhealth3>
+<upgradename.enablemineralscanner>Mineral Scanner</upgradename.enablemineralscanner>
+<upgradedescription.enablemineralscanner>Displays locations of minerals on Navigation Terminals and Sonar Monitors.</upgradedescription.enablemineralscanner>
+<upgradename.increasesupercapacitorrechargespeed>Enhanced Supercapacitor Charging</upgradename.increasesupercapacitorrechargespeed>
+<upgradedescription.increasesupercapacitorrechargespeed>Increase maximum recharge rate.</upgradedescription.increasesupercapacitorrechargespeed>
+<upgradecategorynotapplicable>This upgrade category is not applicable for the selected submarine.</upgradecategorynotapplicable>
+<upgradeui.title>Shipyard</upgradeui.title>
+<upgradeuitooltip.moreindicator>[amount] more...</upgradeuitooltip.moreindicator>
+<upgradeuitooltip.upgradelistheader>Upgrades:</upgradeuitooltip.upgradelistheader>
+<upgradeuitooltip.upgradelistelement>- [upgradename] Lvl. [level]</upgradeuitooltip.upgradelistelement>
+<upgradeuitooltip.noupgradeselement>- None</upgradeuitooltip.noupgradeselement>
+<uicategory.upgrades>Upgrades</uicategory.upgrades>
+<uicategory.maintenance>Maintenance</uicategory.maintenance>
+<uicategory.customize>Customize</uicategory.customize>
+<weaponslot>Slot [number]</weaponslot>
+<weaponslotwithname>Slot [number]: [weaponname]</weaponslotwithname>
+<upgrades.progressformat>[level] / [maxlevel]</upgrades.progressformat>
+<upgrades.purchaseprompttitle>Confirm purchase</upgrades.purchaseprompttitle>
+<upgrade.maxedupgrade>Maxed</upgrade.maxedupgrade>
+<upgrades.purchasepromptbody>Do you want to purchase "[upgradename]" for [amount] marks?</upgrades.purchasepromptbody>
+<upgrades.installeditem>[itemname] ‖color:gui.green‖(installed)‖end‖</upgrades.installeditem>
+<upgrades.pendingitem>[itemname] ‖color:gui.orange‖(pending)‖end‖</upgrades.pendingitem>
+<upgrades.purchaseitemswappromptbody>Do you want to purchase a [itemtoinstall] for [amount] marks?</upgrades.purchaseitemswappromptbody>
+<upgrades.itemswappromptbody>Do you want to install [itemtoinstall]?</upgrades.itemswappromptbody>
+<upgrades.cancelitemswappromptbody>Do you want to cancel the installation of [itemtouninstall]?</upgrades.cancelitemswappromptbody>
+<upgrades.itemuninstallpromptbody>Do you want to uninstall [itemtouninstall]?</upgrades.itemuninstallpromptbody>
+<upgrades.cancelitemuninstallpromptbody>Do you want to cancel the uninstallation of [itemtouninstall]?</upgrades.cancelitemuninstallpromptbody>
+<upgrades.refundprompttitle>Confirm uninstallation</upgrades.refundprompttitle>
+<itemrepairs.purchasepromptbody>Do you want to repair all items on the submarine for [amount] marks?</itemrepairs.purchasepromptbody>
+<wallrepairs.purchasepromptbody>Do you want to repair all hulls on the submarine for [amount] marks?</wallrepairs.purchasepromptbody>
+<replacelostshuttles.purchasepromptbody>Do you want to replace lost shuttles for [amount] marks?</replacelostshuttles.purchasepromptbody>
+<upgraderefundtitle>Refund</upgraderefundtitle>
+<upgraderefundbody>Your pending upgrades have been refunded.</upgraderefundbody>
+<upgrade.requiredmaterials>Required materials</upgrade.requiredmaterials>
+<upgrade.missingmaterials>Missing the required materials</upgrade.missingmaterials>
+<UpgradeUI.AllSubmarinesInfo>Upgrades are automatically transferred when you switch to another submarine, provided the tier and class of the new submarine allow for it.</UpgradeUI.AllSubmarinesInfo>
+
+<!-- Campaign store -->
+<campaignstoretab.deals>Today's Deals</campaignstoretab.deals>
+<campaignstoretab.buy>Buy</campaignstoretab.buy>
+<campaignstoretab.sell>Sell</campaignstoretab.sell>
+<campaignstore.storebalance>Merchant's Balance</campaignstore.storebalance>
+<campaignstore.instock>Stock: [amount]</campaignstore.instock>
+<campaignstore.quantity>x[amount]</campaignstore.quantity>
+<campaignstore.shoppingcrate>Shopping Crate</campaignstore.shoppingcrate>
+<campaignstore.total>Total</campaignstore.total>
+<campaignstore.balance>Balance</campaignstore.balance>
+<campaignstore.clearall>Clear All</campaignstore.clearall>
+<campaignstore.purchase>Purchase</campaignstore.purchase>
+<campaignstore.sortby>Sort By</campaignstore.sortby>
+<newsupplies>New supplies</newsupplies>
+<suppliespurchasedmessage>The purchased supplies will be delivered to your submarine when you leave [location].</suppliespurchasedmessage>
+<campaignstore.sellwarningtext>Are you sure you want to sell the items?</campaignstore.sellwarningtext>
+<campaignstore.owned>Owned: [amount]</campaignstore.owned>
+<campaignstore.dailyspecials>Daily Specials</campaignstore.dailyspecials>
+<campaignstore.requestedgoods>Requested Goods</campaignstore.requestedgoods>
+<campaignstore.sellvalue>Item Sell Value</campaignstore.sellvalue>
+<campaingstore.valueincreasetooltip>Buying the listed items will increase the merchant's balance enough for them to offer more for items sold in the future!</campaingstore.valueincreasetooltip>
+<campaingstore.valuedecreasetooltip>Selling the listed items will decrease the merchant's balance enough for them to offer less for items sold in the future.</campaingstore.valuedecreasetooltip>
+<campaignstore.ownedinventory>Inventory: [amount]</campaignstore.ownedinventory>
+<campaignstore.ownedsub>Submarine: [amount]</campaignstore.ownedsub>
+<campaignstore.ownedspecific>Owned: [nonempty] ([total])</campaignstore.ownedspecific>
+<campaignstore.ownednonempty>Non-empty owned: [amount]</campaignstore.ownednonempty>
+<campaignstore.ownedtotal>Total owned: [amount]</campaignstore.ownedtotal>
+<reputationmodifier>Reputation Modifier</reputationmodifier>
+<campaignstore.reputationtooltip>Your reputation will affect prices. High reputation lets you buy low and sell high. With low reputation, merchants demand more for their goods and offer less for yours.</campaignstore.reputationtooltip>
+
+<!-- Campaign crew -->
+<sortingmethod.alphabeticalasc>Alphabetical</sortingmethod.alphabeticalasc>
+<sortingmethod.jobasc>Job</sortingmethod.jobasc>
+<sortingmethod.priceasc>Price (low to high)</sortingmethod.priceasc>
+<sortingmethod.pricedesc>Price (high to low)</sortingmethod.pricedesc>
+<sortingmethod.skillasc>Skill (low to high)</sortingmethod.skillasc>
+<sortingmethod.skilldesc>Skill (high to low)</sortingmethod.skilldesc>
+<campaigncrew.pending>Pending hires</campaigncrew.pending>
+<campaigncrew.clear>Clear</campaigncrew.clear>
+<campaigncrew.validate>Validate hires</campaigncrew.validate>
+<campaigncrew.newhire>New hire</campaigncrew.newhire>
+<newcrewmembers>New crewmembers</newcrewmembers>
+<crewhiredmessage>The newly hired personnel will join the crew when you leave [location].</crewhiredmessage>
+<campaigncrew.header>Crew management</campaigncrew.header>
+<campaigncrew.givenickname>Give a nickname</campaigncrew.givenickname>
+<campaigncrew.givenicknametooltip>[mouseprimary]: Give a nickname</campaigncrew.givenicknametooltip>
+
+<!-- Campaign interactions -->
+<campaigninteraction.map>[[key]] Plot a course</campaigninteraction.map>
+<campaigninteraction.crew>[[key]] Manage crew</campaigninteraction.crew>
+<campaigninteraction.store>[[key]] Trade</campaigninteraction.store>
+<campaigninteraction.repair>[[key]] Order repairs</campaigninteraction.repair>
+<campaigninteraction.upgrade>[[key]] Upgrade submarine</campaigninteraction.upgrade>
+<campaigninteraction.talk>[[key]] Talk</campaigninteraction.talk>
+<campaigninteraction.purchasesub>[[key]] Browse submarines</campaigninteraction.purchasesub>
+<campaigninteraction.repairupgrade>[[key]] Repair and upgrade</campaigninteraction.repairupgrade>
+<campaigninteraction.medicalclinic>[[key]] Medical clinic</campaigninteraction.medicalclinic>
+<campaigninteraction.examine>[[key]] Examine</campaigninteraction.examine>
+
+<!-- Campaign submarine purchasing / selection -->
+<purchase>Purchase</purchase>
+<purchaseandswitch>Purchase and switch</purchaseandswitch>
+<currentsub>Current submarine</currentsub>
+<requestdeliverybutton>Request delivery</requestdeliverybutton>
+<switchtosubmarinebutton>Switch</switchtosubmarinebutton>
+<purchasesubmarineheader>Submarine purchase</purchasesubmarineheader>
+<purchasesubmarinetext>Purchase [submarinename] for [amount] [currencyname]?</purchasesubmarinetext>
+<purchaseandswitchsubmarineheader>Purchase and switch submarine</purchaseandswitchsubmarineheader>
+<purchaseandswitchsubmarinetext>Purchase [submarinename1] for [amount] [currencyname] and switch to it from your current submarine ([submarinename2])?</purchaseandswitchsubmarinetext>
+<notenoughmoneyforpurchasetext>Not enough [currencyname] to purchase [submarinename]!</notenoughmoneyforpurchasetext>
+<deliveryrequestheader>Submarine delivery request</deliveryrequestheader>
+<deliveryrequesttext>Deliver [submarinename1] from the nearest colony at [location1] to your location at [location2] and switch to it from your current submarine ([submarinename2]) for [amount] [currencyname]?</deliveryrequesttext>
+<notenoughmoneyfordeliverytext>Not enough [currencyname] to deliver [submarinename] from the nearest colony at [location1] to your location at [location2]!</notenoughmoneyfordeliverytext>
+<switchsubmarineheader>Submarine switch</switchsubmarineheader>
+<switchsubmarinetext>Switch from your current submarine [submarinename1] to [submarinename2]?</switchsubmarinetext>
+<outpostshipyard>[location] shipyard</outpostshipyard>
+<transferitems>Transfer items</transferitems>
+<itemswillbetransferred>The items on the current submarine will be transferred to the new submarine.</itemswillbetransferred>
+<itemswontbetransferred>The items on the current submarine will remain there and won't be transferred to the new submarine.</itemswontbetransferred>
+<switchingbacktocurrentsub>Switching back to the currently active submarine. No items will be transferred.</switchingbacktocurrentsub>
+<submarinepurchaseandswitchwithitemsvote>[playername] wants to purchase [submarinename] for [amount] [currencyname], switch to it and transfer items from the current submarine.</submarinepurchaseandswitchwithitemsvote>
+<submarineswitchwithitemsfeevote>[playername] wants to switch and transfer items from the current submarine to [submarinename] with a delivery from [locationname] costing [amount] [currencyname].</submarineswitchwithitemsfeevote>
+<submarineswitchwithitemsnofeevote>[playername] wants to switch and transfer items from the current submarine to [submarinename].</submarineswitchwithitemsnofeevote>
+<itemtransferenabledreminder>Your items will be transferred to the new submarine when you exit the outpost.</itemtransferenabledreminder>
+<itemtransferdisabledreminder>Your items will remain on your old submarine when you exit the outpost.</itemtransferdisabledreminder>
+<toggleitemtransferprompt>You can change this by clicking the "Transfer items" toggle.</toggleitemtransferprompt>
+<deliveryfee>Delivery fee: [amount]</deliveryfee>
+<lowfuelheader>Low on fuel</lowfuelheader>
+<lowfuelwarning>There are fewer than two full fuel rods on the submarine.</lowfuelwarning>
+<noitemsheader>No items</noitemsheader>
+<noitemswarning>All the items on the selected submarine have been transferred elsewhere. Are you sure you want to switch to it without taking the items with you?</noitemswarning>
+<submarineswitchinstruction>You can switch between the submarines you've purchased at the Submarine Switch Terminal, located near the outpost's airlock.</submarineswitchinstruction>
+
+<!-- Submarine types -->
+<submarinetype>Submarine type</submarinetype>
+<submarinetype.player>Submarine</submarinetype.player>
+<submarinetype.outpost>Outpost</submarinetype.outpost>
+<submarinetype.outpostmodule>Outpost module</submarinetype.outpostmodule>
+<submarinetype.outpostmodules>Outpost modules</submarinetype.outpostmodules>
+<submarinetype.wreck>Wreck</submarinetype.wreck>
+<submarinetype.beaconstation>Beacon Station</submarinetype.beaconstation>
+
+<!-- Submarine classes -->
+<submarineclass>Class</submarineclass>
+<submarineclass.undefined>Undefined</submarineclass.undefined>
+<submarineclass.scout>Scout</submarineclass.scout>
+<submarineclass.attack>Attack</submarineclass.attack>
+<submarineclass.transport>Transport</submarineclass.transport>
+<submarineclass.deepdiver>Deep diver</submarineclass.deepdiver>
+<submarineclass.classsuffixformat>[type] class</submarineclass.classsuffixformat>
+
+<!-- Voting -->
+<initiatevoting>(Initiate a vote)</initiatevoting>
+<unabletoinitiateavoteheader>Unable to initiate a vote</unabletoinitiateavoteheader>
+<votealreadyactivetext>A vote is already active!</votealreadyactivetext>
+<submarinepurchasevote>[playername] wants to purchase [submarinename] for [amount] [currencyname].</submarinepurchasevote>
+<submarinepurchaseandswitchvote>[playername] wants to purchase [submarinename] for [amount] [currencyname] and switch to it from the current submarine.</submarinepurchaseandswitchvote>
+<submarineswitchfeevote>[playername] wants to switch from the current submarine to [submarinename] with a delivery from [locationname] costing [amount] [currencyname].</submarineswitchfeevote>
+<submarineswitchnofeevote>[playername] wants to switch from the current submarine to [submarinename].</submarineswitchnofeevote>
+<yesvoted>You voted yes.</yesvoted>
+<novoted>You voted no.</novoted>
+<submarinepurchaseandswitchvotepassed>The crew agreed to purchase and switch to [submarinename] for [amount] [currencyname], with [yesvotecount] votes for and [novotecount] against.</submarinepurchaseandswitchvotepassed>
+<submarinepurchasevotepassed>The crew agreed to purchase [submarinename] for [amount] [currencyname], with [yesvotecount] votes for and [novotecount] against.</submarinepurchasevotepassed>
+<submarineswitchfeevotepassed>The crew agreed to switch to [submarinename] with a delivery from [locationname] costing [amount] [currencyname], with [yesvotecount] votes for and [novotecount] against.</submarineswitchfeevotepassed>
+<submarineswitchnofeevotepassed>The crew agreed to switch to [submarinename], with [yesvotecount] votes for and [novotecount] against.</submarineswitchnofeevotepassed>
+<submarinepurchaseandswitchvotefailed>The vote to purchase and switch to [submarinename] for [amount] [currencyname] failed, with [yesvotecount] votes for and [novotecount] against.</submarinepurchaseandswitchvotefailed>
+<submarinepurchasevotefailed>The vote to purchase [submarinename] for [amount] [currencyname] failed, with [yesvotecount] votes for and [novotecount] against.</submarinepurchasevotefailed>
+<submarineswitchfeevotefailed>The vote to switch to [submarinename] with a delivery from [locationname] costing [amount] [currencyname] failed, with [yesvotecount] votes for and [novotecount] against.</submarineswitchfeevotefailed>
+<submarineswitchnofeevotefailed>The vote to switch to [submarinename] failed, with [yesvotecount] votes for and [novotecount] against.</submarineswitchnofeevotefailed>
+<voterejectedpleasewait>Your previous vote was rejected. You need to wait at least [time] seconds before you can vote again.</voterejectedpleasewait>
+
+<!-- Factions -->
+<factions>Factions</factions>
+<faction.coalition>Europa Coalition</faction.coalition>
+<faction.coalition.description>The autocratic de facto superpower of Europa, with a distributed bureaucracy and an iron grip on the resources, manufacturing and power within Europan society. They rule by fear, and have a reputation for shutting disobedient colonies and outposts out of the supply loop, or simply subjugating them by direct force. Their motivation is ultimately to preserve humanity, but at any cost, and preferably with the status quo left intact.</faction.coalition.description>
+<faction.coalition.shortdescription>The autocratic de facto superpower of Europa, with a distributed bureaucracy and an iron grip on the resources, manufacturing and power within Europan society.</faction.coalition.shortdescription>
+<faction.clowns>Children of the Honkmother</faction.clowns>
+<faction.clowns.description>Every once in a while, these minstrels, fools and clowns attempt to form unions, and names like "Europan Jesters' Association" pop up. In truth, the Honkmother's children are a less-than-organized lot who simply heed the call of the bikehorn.</faction.clowns.description>
+<faction.clowns.shortdescription>The Honkmother's children are an unorganized lot who simply heed the call of the bikehorn.</faction.clowns.shortdescription>
+<faction.separatists>Jovian Separatists</faction.separatists>
+<faction.separatists.description>A small, underground organization seeking a more democratic society by any means, from petty resistance to full-blown terrorism, all with the end goal of disrupting the ability of the Europa Coalition to function, and to undermine its authority.</faction.separatists.description>
+<faction.separatists.shortdescription>A small, underground organization seeking a more democratic society by any means, from petty resistance to full-blown terrorism.</faction.separatists.shortdescription>
+<faction.huskcult>The Church of Husk</faction.huskcult>
+<faction.huskcult.description>A mysterious and outlawed religious group with a transhumanist twist, they seek "communion" with the husk parasite in order to usher in a new kind of humanity, one more capable of surviving in this harsh environment, more in tune with the local ecosystem, and devoid of pride, hatred, fear, or complex thought. Hated equally by the Europa Coalition and the Jovian separatists.</faction.huskcult.description>
+<faction.huskcult.shortdescription>A religious group that seeks 'communion' with the husk parasite in order to usher in a new kind of humanity, one more capable of surviving in this harsh environment.</faction.huskcult.shortdescription>
+<reputation>Reputation</reputation>
+<reputationformat>[reputationname] ([reputationvalue])</reputationformat>
+<reputationverylow>Hostile</reputationverylow>
+<reputationlow>Unfriendly</reputationlow>
+<reputationneutral>Neutral</reputationneutral>
+<reputationhigh>Friendly</reputationhigh>
+<reputationveryhigh>Revered</reputationveryhigh>
+<reputationgainnotification>[value] [reputationname] Reputation</reputationgainnotification>
+
+<!-- Campaign meta texts -->
+<campaignstart>In the late 20th century, it was discovered that under the icy, irradiated surface of Jupiter's moon Europa lies a vast sea capable of sustaining life. This discovery sent shockwaves through the scientific community.\n\nIn the year 2022, the first manned space flight arrived on Europa to discover that the moon was indeed already sustaining life, in the form of hostile sub-aquatic fauna. Besides the wildlife, the researchers faced gruelling difficulties posed by the dangerous radiation emitted from Jupiter and the intense cold and tremendous pressure of the Europan ocean.\n\nDespite all their hardships, Earth-born colonists were able to construct a handful of habitable outposts where a new way of life developed over many decades. A new system of governance was formed by a coalition of the largest, most influential cities on the moon. Different industries made their mark in the new world, including mining, manufacturing and chemical laboratories.\n\nOver the years, Europan society became more and more dissociated from Earth. Fifty years ago, contact was lost entirely, and no more supply ships have arrived since.\n\nSub-aquatic travel and vehicles are in a key role in this new society, scouting for new inhabitable locations, protecting citizens from creature attacks and establishing supply lines between stations as humanity ventures ever deeper to evade the lethal radiation from Jupiter above. The life of a crewmember aboard one of these submarines is a lucrative one, albeit dangerous and often short.\n\nYou have enlisted to serve on a yyyy-class submarine, docked at xxxx. The waters of Europa open up before you—explore, help expand the colonies, and make of this place what you will.</campaignstart>
+<campaignend1>Hints of what are to come flash before your eyes: a crystalline space, something coiled within itself slumbering fitfully. But you are not yet ready to fully experience this. Your fate is still being woven by the Undertow.</campaignend1>
+<campaignend4>Everything fades to black in this moment... You've just been commissioned by the Europa Coalition at xxxx to serve aboard a yyyy class sub. The waters of Europa open up before you, ever deadlier. A sense of déjà vu overcomes you—have you done this all before?</campaignend4>
+<campaignend5>Having reached the end, your adventure restarts from a new beginning, this time with greater peril in store for you.</campaignend5>
+<shrinkingmap>As the intensity of the Jovian radiation effect increases, shallower regions of Europa will gradually become uninhabitable and unsafe to travel. Make your way to deeper waters to avoid it.</shrinkingmap>
+
+<!-- Outpost modules -->
+<outpostmoduletype>Module type</outpostmoduletype>
+<outpostmoduleallowedlocationtypes>Location types</outpostmoduleallowedlocationtypes>
+<outpostmodulegappositions>Gap positions</outpostmodulegappositions>
+<outpostmodulemaxcount>Maximum count</outpostmodulemaxcount>
+<outpostmodulemaxcounttooltip>How many instances of this module can be used in the same outpost.</outpostmodulemaxcounttooltip>
+<outpostmoduletooltip>Outposts are generated from a combination of outpost modules. If you want your custom modules to be used in outpost generation, you must add them to a content package (i.e. your mod) after saving.</outpostmoduletooltip>
+<outpostmoduleallowattachto>Allow attaching to</outpostmoduleallowattachto>
+
+<!-- Beacon stations -->
+<minleveldifficulty>Min level difficulty</minleveldifficulty>
+<maxleveldifficulty>Max level difficulty</maxleveldifficulty>
+<allowdamagedwalls>Allow damaged walls</allowdamagedwalls>
+<allowdisconnectedwires>Allow disconnected wires</allowdisconnectedwires>
+<beaconstationplacement>Place on ceiling</beaconstationplacement>
+
+<!-- Currency -->
+<moneygained>Gained [amount] marks.</moneygained>
+<moneygainedclient>[clientname] gained [amount] marks.</moneygainedclient>
+<moneylost>Lost [amount] marks.</moneylost>
+<moneylostclient>[clientname] lost [amount] marks.</moneylostclient>
+<currencyformat>[credits] mk</currencyformat>
+<price>Price: [amount]</price>
+
+<!-- Ready check -->
+<readycheck.title>Ready Check</readycheck.title>
+<readycheck.body>[player] has initialized a ready check. Are you ready?</readycheck.body>
+<readycheck.serverbody>Server has initialized a ready check. Are you ready?</readycheck.serverbody>
+<readycheck.readycount>Ready check complete. Ready: [ready]/[total].</readycheck.readycount>
+<readycheck.pleasewait>Please wait [seconds] second(s) before commencing another ready check.</readycheck.pleasewait>
+<readycheck.tooltip>Commence a ready check.</readycheck.tooltip>
+
+<!-- Progress bars -->
+<progressbar.watering>Watering...</progressbar.watering>
+<progressbar.planting>Planting...</progressbar.planting>
+<progressbar.fertilizing>Fertilizing...</progressbar.fertilizing>
+<progressbar.uprooting>Uprooting...</progressbar.uprooting>
+<progressbar.welding>Welding...</progressbar.welding>
+<progressbar.cutting>Cutting...</progressbar.cutting>
+<progressbar.deattaching>Detaching...</progressbar.deattaching>
+<progressbar.opening>Opening...</progressbar.opening>
+
+<!-- Event editor -->
+<eventeditor.markending>Toggle ending</eventeditor.markending>
+<eventeditor.testpromptheader>Test event</eventeditor.testpromptheader>
+<eventeditor.testpromptbody>Do you want to test the saved event in an empty outpost environment?</eventeditor.testpromptbody>
+<eventeditor.outpostgenparams>Outpost params:</eventeditor.outpostgenparams>
+<eventeditor.locationtype>Location type:</eventeditor.locationtype>
+
+<!-- Particle editor -->
+<particleeditor.copyemittertoclipboard>Copy Emitter to Clipboard</particleeditor.copyemittertoclipboard>
+<particleeditor.copyprefabtoclipboard>Copy Prefab to Clipboard</particleeditor.copyprefabtoclipboard>
+
+<!-- Radio channels -->
+<saveradiochannelbutton>MEM</saveradiochannelbutton>
+<saveradiochannelbuttontooltip>Store the current radio channel as a preset.</saveradiochannelbuttontooltip>
+<radiochannelpreset>Preset: [channel]</radiochannelpreset>
+<currentradiochannel>Current radio channel</currentradiochannel>
+
+<!-- Hint System -->
+<disableingamehints>Disable in-game hints</disableingamehints>
+<disableingamehintstooltip>Prevent any in-game hints from being displayed during the game.</disableingamehintstooltip>
+<hintmessagebox.dontshowagain>Don't show again</hintmessagebox.dontshowagain>
+<hintmessagebox.dontshowagaintooltip>Don't show this hint again. In-game hints can be disabled altogether in the settings menu.</hintmessagebox.dontshowagaintooltip>
+<hintmessagebox.disablehints>Disable hints</hintmessagebox.disablehints>
+<hintmessagebox.disablehintstooltip>Disable all future hints. They can be re-enabled from the Settings.</hintmessagebox.disablehintstooltip>
+<hintmessagebox.dismiss>Dismiss</hintmessagebox.dismiss>
+<hint.onadjacenthull.highpressure>The area beyond this door is flooded with water under high pressure. Proceeding without a diving suit may be dangerous.</hint.onadjacenthull.highpressure>
+<hint.onadjacenthull.highwaterpercentage>A nearby room is currently filled with water. You might need to bring some diving gear with you.</hint.onadjacenthull.highwaterpercentage>
+<hint.onafflictiondisplayed>You've developed an affliction. Afflictions can be treated by pressing [key] to open the medical interface.</hint.onafflictiondisplayed>
+<hint.onautopilotreachedoutpost>The autopilot has navigated the sub to the outpost. Switch to manual control to move closer to the docking port.</hint.onautopilotreachedoutpost>
+<hint.onavailabletransition.returntopreviousemptylocation>You have returned to the beginning of the level. Select a new destination to continue your journey, or close the map by pressing Esc.</hint.onavailabletransition.returntopreviousemptylocation>
+<hint.onavailabletransition.progresstonextemptylocation>You have reached the end of the level. Select a new destination to continue your journey.</hint.onavailabletransition.progresstonextemptylocation>
+<hint.oncharacterkilled>The character you were controlling has died. Switch to another crewmember by opening the crew list to the top left of the screen and clicking on a portrait.</hint.oncharacterkilled>
+<hint.oncharacterunconscious>The character you were controlling has fallen unconscious. You can either wait for another crewmember to heal you or give in by clicking on the button on the top of the screen.</hint.oncharacterunconscious>
+<hint.ondivinggearoutofoxygen>You have equipped diving gear that lacks a sufficient oxygen source. Put in a new oxygen tank before using this gear.</hint.ondivinggearoutofoxygen>
+<hint.onhandcuffed>You have been handcuffed and your capability to move or interact is limited. Someone else needs to uncuff you.</hint.onhandcuffed>
+<hint.onisinteracting.reactorwithextrarods>Adding more than one fuel rod to the reactor is useful for jump starting it when it's submerged but will produce a dangerous rate of reaction under normal operation.</hint.onisinteracting.reactorwithextrarods>
+<hint.onreactoroutoffuel>The reactor has run out of fuel and the sub will run out of power. Replace the fuel rod to get power back on.</hint.onreactoroutoffuel>
+<hint.onrepairfailed>Failing to repair a device can cause you harm. Characters more skillful in mechanical or electrical repairs are more likely to succeed.</hint.onrepairfailed>
+<hint.onroundstarted.voipdisabled>Turn on the voice chat in the setting if you want to communicate using your microphone.</hint.onroundstarted.voipdisabled>
+<hint.onshootwithoutaiming>You'll need to aim by holding [key] before using this.</hint.onshootwithoutaiming>
+<hint.onshowcampaigninterface.map>Use the campaign map to select your next destination. After picking a destination, you can choose the mission you want to undertake.</hint.onshowcampaigninterface.map>
+<hint.onshowcommandinterface>Use the command wheel to issue commands to other crewmembers. Choose an order category, then the order. A suitable person will be assigned for the job.</hint.onshowcommandinterface>
+<hint.onshowhealthinterface>This is the health interface. Choose a body part to see the afflictions affecting that part. Drag medical items from your inventory to administer them to a body part.</hint.onshowhealthinterface>
+<hint.onsonarspottedenemy>Sonar is picking up a moving target. Make sure the sub's guns are manned and try to manouver so that your gunners have a clear shot.</hint.onsonarspottedenemy>
+<hint.onstartedcontrolling.job.assistant>You're playing an assistant. Assistants are a jack-of-all-trades class. Be helpful where you can and develop your skills.</hint.onstartedcontrolling.job.assistant>
+<hint.onstartedcontrolling.job.captain>You're playing a captain. You should make your way to the command room and start navigating the submarine to the destination.</hint.onstartedcontrolling.job.captain>
+<hint.onstartedcontrolling.job.engineer>You're playing an engineer. Engineers are responsible for keeping the submarine powered at all times. To do that, tend to the reactor and keep electrical equipment in good condition by repairing them.</hint.onstartedcontrolling.job.engineer>
+<hint.onstartedcontrolling.job.mechanic>You're playing a mechanic. You should keep an eye out on all the devices on the submarine and repair them if they break.</hint.onstartedcontrolling.job.mechanic>
+<hint.onstartedcontrolling.job.medicaldoctor>You're playing a medical doctor. Take care of your fellow crew and treat their injuries if they hurt themselves.</hint.onstartedcontrolling.job.medicaldoctor>
+<hint.onstartedcontrolling.job.securityofficer>You're playing a security officer. Take inventory of the weapons on board the submarine, arm the turrets in case of an enemy attack and keep the rowdy crewmembers in line.</hint.onstartedcontrolling.job.securityofficer>
+<hint.onstartedinteracting.brokenitem>All devices on a sub will gradually break down over time, as this one has, and must be maintained for peak operating performance. Equip a screwdriver to repair electrical devices, and a wrench to repair mechanical ones.</hint.onstartedinteracting.brokenitem>
+<hint.onstartedinteracting.lootingisstealing>Items with a red hand icon belong to someone else. If you take them, there will be consequences to deal with.</hint.onstartedinteracting.lootingisstealing>
+<hint.onstartedinteracting.turretperiscope>This periscope controls a submarine weapon. Use the mouse to look around and press [shootkey] to fire and [deselectkey] or "ESC" to stop.</hint.onstartedinteracting.turretperiscope>
+<hint.onstartedinteracting.item.deconstructor>Use the deconstructor to break down items to their components. Insert an item to the input slot and press "Deconstruct" to start the process.</hint.onstartedinteracting.item.deconstructor>
+<hint.onstartedinteracting.item.fabricator>Use the fabricator to craft items. Choose an item from the list, and if you have the required items in your inventory, press "Create" to start fabricating.</hint.onstartedinteracting.item.fabricator>
+<hint.onstartedinteracting.item.gunloader>This loader must be loaded with ammunition for the linked submarine weapon.</hint.onstartedinteracting.item.gunloader>
+<hint.onstartedinteracting.item.navterminal>You can plot a course for the sub, set the autopilot, control the sonar, and monitor a side view of the sonar returns from here. Click on the sonar view to select direction. Use Mouse scroll wheel to zoom in and out.</hint.onstartedinteracting.item.navterminal>
+<hint.onstartedinteracting.item.reactor>Nuclear reactors provide power to your devices. Try to keep the "load" and "output" the same, otherwise you'll likely suffer from blackouts or power spikes that damage your devices.</hint.onstartedinteracting.item.reactor>
+<hint.onstoleitem>You just stole something. This has hurt your reputation, and worse still, security will need to deal with you.</hint.onstoleitem>
+<hint.ontryopenstuckdoor>The door has been welded shut. You need a plasma cutter to open it.</hint.ontryopenstuckdoor>
+<hint.onweldingdoor>You're welding a door shut. Once it's completely welded, you'll need to use a plasma cutter or crowbar to get it open again.</hint.onweldingdoor>
+<hint.reminder.characterchange>If you wish, you can play as any of your crew by opening the crew list to the top left of the screen and clicking on a portrait.</hint.reminder.characterchange>
+<hint.reminder.commandinterface>You can give orders to the crew via the command wheel, which is displayed with [commandkey].</hint.reminder.commandinterface>
+<hint.reminder.tabmenu>Press [infotabkey] to open the info tab where you can find information about things like your crew, your mission, and your reputation.</hint.reminder.tabmenu>
+<hint.reminder.toolbelt>You have a toolbelt equipped. Hover over the icon in your inventory to access the toolbelt inventory.</hint.reminder.toolbelt>
+<hint.onballastflorainfected>One of the ballast pumps is infected with ballast flora. Destroy the root with fire to kill it.</hint.onballastflorainfected>
+<hint.onobtaineditem.unidentifiedgeneticmaterial>You've found a mass of unidentified alien genetic material. You can use a research station to process it into something that can be inserted into a Gene Splicer—a device that can be used to augment people with non-human abilities.</hint.onobtaineditem.unidentifiedgeneticmaterial>
+<hint.onobtaineditem.geneticmaterial>You've obtained a vial of identified alien genetic material. You can use it with a Gene Splicer, combine it with genetic material of the same type in a Research Station to refine it and boost it's effectiveness, or combine it with a genetic material of different type to combine their effects.</hint.onobtaineditem.geneticmaterial>
+<hint.geneticmaterial.useinstructions>You can use the genetic material by equipping a Gene Splicer, and inserting the genetic material into it in the health interface. Once spliced onto a living subject, genetic material cannot be removed without destroying it.</hint.geneticmaterial.useinstructions>
+<hint.geneticmaterial.onrefiningorcombining>Refining and combining genetic materials has a chance of tainting them, dependent on your medical skill. Combining genetic materials of different type always taints them.\n\nTainted genes cannot be refined or combined further, and using them can have unexpected side-effects.</hint.geneticmaterial.onrefiningorcombining>
+<hint.upgradedivingsuits>You are approaching a depth of 4,000 meters, after which normal diving suits will not be adequate to protect you from the pressure. You should try to obtain better ones, such as combat or abyss suits.</hint.upgradedivingsuits>
+
+<!-- Item quality -->
+<itemname.quality-1>[itemname] ‖color:gui.itemqualitycolorpoor‖(Poor quality)‖end‖</itemname.quality-1>
+<itemname.quality0>[itemname] ‖color:gui.itemqualitycolornormal‖(Normal quality)‖end‖</itemname.quality0>
+<itemname.quality1>[itemname] ‖color:gui.itemqualitycolorgood‖(Good quality)‖end‖</itemname.quality1>
+<itemname.quality2>[itemname] ‖color:gui.itemqualitycolorexcellent‖(Excellent quality)‖end‖</itemname.quality2>
+<itemname.quality3>[itemname] ‖color:gui.itemqualitycolormasterwork‖(Masterwork quality)‖end‖</itemname.quality3>
+<qualitystattypenames.strikingpowermultiplier>Striking Power</qualitystattypenames.strikingpowermultiplier>
+<qualitystattypenames.strikingspeedmultiplier>Striking Speed</qualitystattypenames.strikingspeedmultiplier>
+<qualitystattypenames.firepowermultiplier>Firepower</qualitystattypenames.firepowermultiplier>
+<qualitystattypenames.firingratemultiplier>Firing Rate</qualitystattypenames.firingratemultiplier>
+<qualitystattypenames.condition>Max Condition</qualitystattypenames.condition>
+<qualitystattypenames.explosionradius>Explosion Radius</qualitystattypenames.explosionradius>
+<qualitystattypenames.explosiondamage>Explosion Damage</qualitystattypenames.explosiondamage>
+<qualitystattypenames.repairspeed>Repair Speed</qualitystattypenames.repairspeed>
+<qualitystattypenames.repairtoolstructurerepairmultiplier>Hull Repair Speed</qualitystattypenames.repairtoolstructurerepairmultiplier>
+<qualitystattypenames.repairtoolstructuredamagemultiplier>Hull Damage</qualitystattypenames.repairtoolstructuredamagemultiplier>
+<qualitystattypenames.repairtooldeattachtimemultiplier>Deattach Time Reduction</qualitystattypenames.repairtooldeattachtimemultiplier>
+<qualitystattypenames.attackmultiplier>Attack Power</qualitystattypenames.attackmultiplier>
+<qualitystattypenames.attackspeedmultiplier>Attack Speed</qualitystattypenames.attackspeedmultiplier>
+<qualitystattypenames.forcedoorsopenspeedmultiplier>Force Doors Open Speed</qualitystattypenames.forcedoorsopenspeedmultiplier>
+<qualitystattypenames.rangedspreadreduction>Spread Reduction</qualitystattypenames.rangedspreadreduction>
+<qualitystattypenames.chargespeedmultiplier>Charge Speed</qualitystattypenames.chargespeedmultiplier>
+<qualitystattypenames.movementspeedmultiplier>Movement Speed</qualitystattypenames.movementspeedmultiplier>
+<qualitystattypenames.effectivenessmultiplier>Effectiveness</qualitystattypenames.effectivenessmultiplier>
+<qualitystattypenames.poweroutputmultiplier>Power Output</qualitystattypenames.poweroutputmultiplier>
+<qualitystattypenames.consumptionreductionmultiplier>Consumption Reduction</qualitystattypenames.consumptionreductionmultiplier>
+
+<!-- Talent trees -->
+<talenttree.gunslinger>Gunslinger</talenttree.gunslinger>
+<talenttree.skipper>Skipper</talenttree.skipper>
+<talenttree.shipmaster>Shipmaster</talenttree.shipmaster>
+<talenttree.specialist>Specialist</talenttree.specialist>
+<talenttree.warden>Warden</talenttree.warden>
+<talenttree.soldier>Soldier</talenttree.soldier>
+<talenttree.jackofalltrades>Jack of All Trades</talenttree.jackofalltrades>
+<talenttree.grayshirt>Grayshirt</talenttree.grayshirt>
+<talenttree.clown>Clown</talenttree.clown>
+<talenttree.weaponsengineer>Weapons Engineer</talenttree.weaponsengineer>
+<talenttree.electrician>Electrician</talenttree.electrician>
+<talenttree.physicist>Physicist</talenttree.physicist>
+<talenttree.machinist>Machinist</talenttree.machinist>
+<talenttree.technician>Technician</talenttree.technician>
+<talenttree.pioneer>Pioneer</talenttree.pioneer>
+<talenttree.xenologist>Xenologist</talenttree.xenologist>
+<talenttree.medic>Medic</talenttree.medic>
+<talenttree.scientist>Scientist</talenttree.scientist>
+<talenttree.frogman>Frogman</talenttree.frogman>
+<talenttree.enforcer>Enforcer</talenttree.enforcer>
+<talenttree.gunner>Gunner</talenttree.gunner>
+<talenttree.scrapper>Scrapper</talenttree.scrapper>
+<talenttree.brawler>Brawler</talenttree.brawler>
+<talenttree.apprentice>Apprentice</talenttree.apprentice>
+<talenttree.primary>Primary</talenttree.primary>
+<talenttree.scientist>Chemist</talenttree.scientist>
+
+<!-- Talents -->
+<talentrequirement.requiretalent>Requires a talent point.</talentrequirement.requiretalent>
+<talentrequirement.requiretwoabove>Requires two (or more) talents selected from the row above.</talentrequirement.requiretwoabove>
+<talentrequirement.requirefourabove>Requires four (or more) talents selected from the rows above.</talentrequirement.requirefourabove>
+<talentrequirement.requiresixabove>Requires six (or more) talents selected from the rows above.</talentrequirement.requiresixabove>
+<talentrequirement.requireeightabove>Requires eight (or more) talents selected from the rows above.</talentrequirement.requireeightabove>
+<talentrequirement.requirespec>Requires a specialization from the previous row.</talentrequirement.requirespec>
+<talentrequirement.speclocked>Specialization talents in the same row are mutually exclusive, you can pick only one.</talentrequirement.speclocked>
+<talentrequirement.spectree2>Requires finishing your first specialization.</talentrequirement.spectree2>
+<talentrequirement.spectree3>Requires finishing your second specialization.</talentrequirement.spectree3>
+<talentrequirement.spectreelocked>This specialization tree has been locked by selecting a different specialization.</talentrequirement.spectreelocked>
+<talentmenu.alltalentsunlocked>All talents unlocked</talentmenu.alltalentsunlocked>
+<talentmenu.points>Talent Points: [amount]</talentmenu.points>
+<talentmenu.points.spending>Talent Points: [amount] ([used])</talentmenu.points.spending>
+<talentmenu.extratalents>Extra talents</talentmenu.extratalents>
+<experienceshort>EXP</experienceshort>
+<talentpointsleft>Talent points left:</talentpointsleft>
+<experiencetooltip>Experience is primarily gained by completing missions.\nCompleting missions in a more difficult area rewards more experience.</experiencetooltip>
+<talentname.handsomestranger>Once Upon a Time on Europa</talentname.handsomestranger>
+<talentname.tumble>Tumble</talentname.tumble>
+<talentdescription.tumble>Whenever you ragdoll for at least [seconds] seconds, your attacks with pistols are [damage]% more powerful for the next [duration] seconds.</talentdescription.tumble>
+<talentname.sailorwithnoname>Sailor with No Name</talentname.sailorwithnoname>
+<talentname.quickdraw>Quickdraw</talentname.quickdraw>
+<talentdescription.quickdraw>If it has been longer than [seconds] seconds since you've attacked with a pistol, your next attack with a pistol is [damage]% more powerful.</talentdescription.quickdraw>
+<talentname.travelingtradesman>Traveling Tradesman</talentname.travelingtradesman>
+<talentname.evasivemaneuvers>Evasive Maneuvers</talentname.evasivemaneuvers>
+
+<talentname.bountyhunter>Bounty Hunter</talentname.bountyhunter>
+<talentdescription.bountyhunter>Whenever you or an allied crewmember kills a monster, your crew gains additional marks equal to [percentage]% of the creature's maximum health.</talentdescription.bountyhunter>
+<talentname.trustedcaptain>Trusted Captain</talentname.trustedcaptain>
+<talentdescription.trustedcaptain>Whenever you finish at least one mission, gain a Coalition Commendation.\nWhen you apply a Coalition Commendation on another character, gain [selfxpgain] experience.</talentdescription.trustedcaptain>
+<talentname.esteemedcaptain>Esteemed Captain</talentname.esteemedcaptain>
+<talentdescription.esteemedcaptain>Whenever you finish at least one mission, gain a Coalition Medal.\nWhen you apply a Coalition Medal on another character, gain [selfxpgain] experience.</talentdescription.esteemedcaptain>
+<talentname.downwiththeship>Down with the Ship</talentname.downwiththeship>
+<talentname.camaraderie>Camaraderie</talentname.camaraderie>
+<talentdescription.camaraderie>Whenever you finish a mission without a crewmember dying, and your crew contains at least [jobcount] different jobs, your crew gains an additional [extramoney]% money and experience.</talentdescription.camaraderie>
+<talentname.drunkensailor>Drunken Sailor</talentname.drunkensailor>
+<talentdescription.drunkensailor>Gain [stunresistance]% stun resistance while drunk and immunity to the negative effects of drunkenness.</talentdescription.drunkensailor>
+<talentname.trucker>Trucker</talentname.trucker>
+<talentdescription.trucker>Whenever you finish all your selected missions, gain an additional Coalition Commendation.</talentdescription.trucker>
+<talentname.trustbuilding>Trust Building</talentname.trustbuilding>
+<talentdescription.trustbuilding>Whenever you finish a mission, your crew gains an additional [smallgain]% maximum health, and if all crewmembers survived, your crew gains an additional [largegain]% maximum health instead, up to a maximum of [maxgain]%.</talentdescription.trustbuilding>
+<talentname.allseeingeye>All-Seeing Eye</talentname.allseeingeye>
+<talentname.firstaidtraining>First Aid Training</talentname.firstaidtraining>
+<talentname.bythebook>By the Book</talentname.bythebook>
+<talentdescription.bythebook>Whenever you finish at least one mission, your crew gains an additional [moneyamount] marks and [experienceamount] experience for each captured, live enemy human on board your ship, up to a maximum of [moneyamountmax] marks and [experienceamountmax] experience.</talentdescription.bythebook>
+<talentname.bootcamp>Bootcamp</talentname.bootcamp>
+<talentdescription.bootcamp>Whenever you finish a mission without a crewmember dying, you gain an additional [amount]% experience.</talentdescription.bootcamp>
+<talentname.tandemfire>Tandem Fire</talentname.tandemfire>
+<talentdescription.tandemfire>As long as you are manning a turret alongside another allied crewmember, both of your attacks are [amount]% more powerful. Only the closest allied crewmember gains this effect.</talentdescription.tandemfire>
+<talentname.munitionsexpertise>Munitions Expertise</talentname.munitionsexpertise>
+<talentdescription.munitionsexpertise>Whenever you fabricate SMG ammo, shotgun ammo or stun gun ammo, you have a [probability]% chance to gain twice as much output.</talentdescription.munitionsexpertise>
+<talentdescription.multitasker>Whenever you gain a skill point, if it’s not for the same skill as the last skill point gained, gain an additional skill point.</talentdescription.multitasker>
+<talentdescription.apprenticeship>Whenever another allied character gains a skill point, you have a [probability]% chance to also gain a skill point in that skill.</talentdescription.apprenticeship>
+<talentname.navydiver>Navy Diver</talentname.navydiver>
+<talentname.scavenger>Scavenger</talentname.scavenger>
+<talentname.buccaneer>Buccaneer</talentname.buccaneer>
+<talentdescription.buccaneer>Aiming with a melee weapon before attacking adds up to [amount]% power to your next melee attack.</talentdescription.buccaneer>
+<talentname.physicalconditioning>Physical Conditioning</talentname.physicalconditioning>
+<talentname.enforcer>Enforcer</talentname.enforcer>
+<talentname.beatcop>Beat Cop</talentname.beatcop>
+<talentname.warlord>Warlord</talentname.warlord>
+<talentname.deepseaslayer>Deep Sea Slayer</talentname.deepseaslayer>
+<talentname.stonewall>Stonewall</talentname.stonewall>
+<talentname.warriorpoet>Warrior Poet</talentname.warriorpoet>
+<talentname.gunsmith>Gunsmith</talentname.gunsmith>
+<talentname.dualspecops>Dual Spec-Ops</talentname.dualspecops>
+<talentname.implacable>Implacable</talentname.implacable>
+<talentname.apprenticeship>Apprenticeship</talentname.apprenticeship>
+<talentname.multitasker>Multitasker</talentname.multitasker>
+<talentname.richinknowledge>Rich in Knowledge</talentname.richinknowledge>
+<talentname.standanddeliver>Stand and Deliver</talentname.standanddeliver>
+<talentname.aceofalltrades>Ace of All Trades</talentname.aceofalltrades>
+<talentname.olympian>Olympian</talentname.olympian>
+<talentname.playingcatchup>Playing Catchup</talentname.playingcatchup>
+<talentname.skedaddle>Skedaddle</talentname.skedaddle>
+<talentname.crewlayabout>Crew Layabout</talentname.crewlayabout>
+<talentname.survivalpackage>Survival Package</talentname.survivalpackage>
+<talentname.insurancepolicy>Insurance Policy</talentname.insurancepolicy>
+<talentname.stillkicking>Still Kicking</talentname.stillkicking>
+<talentname.graduationceremony>Graduation Ceremony</talentname.graduationceremony>
+<talentname.enrollintoclowncollege>Enroll into Clown College</talentname.enrollintoclowncollege>
+<talentname.waterprankster>Water Prankster</talentname.waterprankster>
+<talentname.inspiringtunes>Inspiring Tunes</talentname.inspiringtunes>
+<talentname.psychoclown>Psycho Clown</talentname.psychoclown>
+<talentname.slapstickexpert>Slapstick Expert</talentname.slapstickexpert>
+<talentname.truepotential>True Potential</talentname.truepotential>
+<talentname.remotemonitor>Remote Monitor</talentname.remotemonitor>
+<talentname.collegeathletics>College Athletics</talentname.collegeathletics>
+<talentname.hazardousmaterials>Hazardous Materials</talentname.hazardousmaterials>
+<talentname.scrounger>Scrounger</talentname.scrounger>
+<talentname.militaryapplications>Military Applications</talentname.militaryapplications>
+<talentname.strengthenedalloys>Strengthened Alloys</talentname.strengthenedalloys>
+<talentname.expandedresearch>Expanded Research</talentname.expandedresearch>
+<talentname.armsdealer>Arms Dealer</talentname.armsdealer>
+<talentname.nuclearoption>Nuclear Option</talentname.nuclearoption>
+<talentname.minorinmechanics>Minor in Mechanics</talentname.minorinmechanics>
+<talentname.intheflow>In the Flow</talentname.intheflow>
+<talentname.castledoctrine>Castle Doctrine</talentname.castledoctrine>
+<talentname.electrochemist>Electrochemist</talentname.electrochemist>
+<talentname.optimizedpowerflow>Optimized Power-Flow</talentname.optimizedpowerflow>
+<talentname.coauthor>Co-Author</talentname.coauthor>
+<talentname.polymath>Polymath</talentname.polymath>
+<talentname.phdinnuclearphysics>Ph.D in Nuclear Physics</talentname.phdinnuclearphysics>
+<talentname.tinkerer>Tinkerer</talentname.tinkerer>
+<talentname.quickfix>Quickfix</talentname.quickfix>
+<talentname.massproduction>Mass Production</talentname.massproduction>
+<talentname.hullsealer>Hull Sealer</talentname.hullsealer>
+<talentname.letitdrain>Let It Drain</talentname.letitdrain>
+<talentname.crisismanagement>Crisis Management</talentname.crisismanagement>
+<talentdescription.crisismanagement>The more filled with water your submarine is, the faster you repair devices and swim, up to an additional [statamount1]% repair speed and [statamount2]% swimming speed.</talentdescription.crisismanagement>
+<talentname.hullfixer>Hull Fixer</talentname.hullfixer>
+<talentname.miner>Miner</talentname.miner>
+<talentname.elbowgrease>Elbow Grease</talentname.elbowgrease>
+<talentname.scrapsavant>Scrap Savant</talentname.scrapsavant>
+<talentname.safetyfirst>Safety First</talentname.safetyfirst>
+<talentname.aggressiveengineering>Aggressive Engineering</talentname.aggressiveengineering>
+<talentname.pyromaniac>Pyromaniac</talentname.pyromaniac>
+<talentname.demolitionsexpert>Demolitions Expert</talentname.demolitionsexpert>
+<talentname.cannedheat>Canned Heat</talentname.cannedheat>
+<talentname.atmosmachine>Atmos Machine</talentname.atmosmachine>
+<talentname.artisansmith>Artisan Smith</talentname.artisansmith>
+<talentname.researchersintuition>Researcher's Intuition</talentname.researchersintuition>
+<talentname.fieldmedic>Field Medic</talentname.fieldmedic>
+<talentname.curiosity>Curiosity</talentname.curiosity>
+<talentname.reverseengineer>Reverse Engineer</talentname.reverseengineer>
+<talentname.alienhoarder>Alien Hoarder</talentname.alienhoarder>
+<talentname.doubleduty>Double Duty</talentname.doubleduty>
+<talentname.firemanscarry>Fireman's Carry</talentname.firemanscarry>
+<talentname.mechanicscourse>Mechanics Course</talentname.mechanicscourse>
+<talentname.commander>Commander</talentname.commander>
+<talentname.maintenanceroutine>Maintenance Routine</talentname.maintenanceroutine>
+<talentname.inspiretobattle>Inspire to Battle</talentname.inspiretobattle>
+<talentname.allhandsondeck>All Hands on Deck</talentname.allhandsondeck>
+<talentname.genetherapist>Gene Therapist</talentname.genetherapist>
+<talentname.researchanddevelopment>Research and Development</talentname.researchanddevelopment>
+<talentname.geneticstability>Genetic Stability</talentname.geneticstability>
+<talentname.advancedsplicing>Advanced Splicing</talentname.advancedsplicing>
+<talentname.veteran>Veteran</talentname.veteran>
+<talentname.inspirationalleader>Inspirational Leader</talentname.inspirationalleader>
+<talentname.prodigy>Prodigy</talentname.prodigy>
+<talentname.logisticsexpert>Logistics Expert</talentname.logisticsexpert>
+<talentname.lonewolf>Lone Wolf</talentname.lonewolf>
+<talentname.deputy>Deputy</talentname.deputy>
+<talentname.bigguns>Big Guns</talentname.bigguns>
+<talentname.affiliation>Affiliation</talentname.affiliation>
+<talentname.campaigning>Campaigning</talentname.campaigning>
+<talentname.yourreputation>Your Reputation...</talentname.yourreputation>
+<talentname.networking>Networking</talentname.networking>
+<talentname.figurehead>Figurehead</talentname.figurehead>
+<talentname.helmsman>Helmsman</talentname.helmsman>
+<talentname.inspiringpresence>Inspiring Presence</talentname.inspiringpresence>
+<talentname.trickledown>Trickle Down</talentname.trickledown>
+<talentname.steadytune>Steady Tune</talentname.steadytune>
+<talentname.family>Family</talentname.family>
+<talentname.leadingbyexample>Leading By Example</talentname.leadingbyexample>
+<talentname.protectandserve>Protect and Serve</talentname.protectandserve>
+<talentname.warstories>War Stories</talentname.warstories>
+<talentname.swole>Swole</talentname.swole>
+<talentname.weaponsmith>Weaponsmith</talentname.weaponsmith>
+<talentname.dontpushit>Don't Push It</talentname.dontpushit>
+<talentname.buff>Buff</talentname.buff>
+<talentname.boardingparty>Boarding Party</talentname.boardingparty>
+<talentname.daringdolphin>Daring Dolphin</talentname.daringdolphin>
+<talentname.easyturtle>Easy Turtle</talentname.easyturtle>
+<talentname.pacificationkit>Pacification Kit</talentname.pacificationkit>
+<talentname.inordinateexsanguination>Inordinate Exsanguination</talentname.inordinateexsanguination>
+<talentname.crustyseaman>Crusty Seaman</talentname.crustyseaman>
+<talentname.rifleman>Rifleman</talentname.rifleman>
+<talentname.extrapowder>Extra Powder</talentname.extrapowder>
+<talentname.gunrunner>Gun Runner</talentname.gunrunner>
+<talentname.healthinsurance>Health Insurance</talentname.healthinsurance>
+<talentname.nobodyimportantdies>Nobody Important Dies</talentname.nobodyimportantdies>
+<talentname.exampleofhealth>Example of Health</talentname.exampleofhealth>
+<talentname.laresistance>La Resistance</talentname.laresistance>
+<talentname.selfcare>Self-care</talentname.selfcare>
+<talentname.stayinalive>Stayin' Alive</talentname.stayinalive>
+<talentname.blooddonor>Blood Donor</talentname.blooddonor>
+<talentname.bloodybusiness>Bloody Business</talentname.bloodybusiness>
+<talentname.genetampering>Gene Tampering</talentname.genetampering>
+<talentname.emergencyresponse>Emergency Response</talentname.emergencyresponse>
+<talentname.medicalexpertise>Medical Expertise</talentname.medicalexpertise>
+<talentname.medicalassistance>Medical Assistance</talentname.medicalassistance>
+<talentname.miracleworker>Miracle Worker</talentname.miracleworker>
+<talentname.deliverysystem>Delivery System</talentname.deliverysystem>
+<talentname.labcontacts>Lab Contacts</talentname.labcontacts>
+<talentname.macrodosing>Macrodosing</talentname.macrodosing>
+<talentname.funwithfission>Fun With Fission</talentname.funwithfission>
+<talentname.grounded>Grounded</talentname.grounded>
+<talentname.egghead>Egghead</talentname.egghead>
+<talentname.junctionjunkie>Junction Junkie</talentname.junctionjunkie>
+<talentname.stationengineer>Station Engineer</talentname.stationengineer>
+<talentname.weaponartisan>Weapon Artisan</talentname.weaponartisan>
+<talentname.submarineofthings>Submarine Of Things</talentname.submarineofthings>
+<talentname.lightningwizard>Lightning Wizard</talentname.lightningwizard>
+<talentname.buzzing>Buzzin'</talentname.buzzing>
+<talentname.cruising>Cruisin'</talentname.cruising>
+<talentname.betterthannew>Better Than New</talentname.betterthannew>
+<talentname.machinemaniac>Machine Maniac</talentname.machinemaniac>
+<talentname.salvagecrew>Salvage Crew</talentname.salvagecrew>
+<talentname.multifunctional>Multifunctional</talentname.multifunctional>
+<talentname.engineengineer>Engine Engineer</talentname.engineengineer>
+<talentname.ballastdenizen>Ballast Denizen</talentname.ballastdenizen>
+<talentname.pumpndump>Pump N Dump</talentname.pumpndump>
+<talentname.ironman>Ironman</talentname.ironman>
+<talentname.oiledmachinery>Oiled Machinery</talentname.oiledmachinery>
+<talentname.retrofit>Retrofit</talentname.retrofit>
+<talentname.toolmaintenance>Tool Maintenance</talentname.toolmaintenance>
+<talentname.residualwaste>Residual Waste</talentname.residualwaste>
+<talentname.ironstorm>Iron Storm</talentname.ironstorm>
+<talentname.iamthatguy>I Am That Guy</talentname.iamthatguy>
+<talentname.heavylifting>Heavy Lifting</talentname.heavylifting>
+<talentname.mudraptorwrestler>Mudraptor Wrestler</talentname.mudraptorwrestler>
+<talentname.foolhardy>Foolhardy</talentname.foolhardy>
+<talentname.berserker>Berserker</talentname.berserker>
+<talentname.powerarmor>MECHanic</talentname.powerarmor>
+<talentname.revengesquad>Revenge Squad</talentname.revengesquad>
+<talentname.jackinthebox>Jack-In-The-Box</talentname.jackinthebox>
+<talentname.peerlearning>Peer Learning</talentname.peerlearning>
+<talentname.thearrival>The Arrival</talentname.thearrival>
+<talentname.mailman>Mailman</talentname.mailman>
+<talentname.anappleaday>An Apple A Day</talentname.anappleaday>
+<talentname.thewaitinglist>The Waiting List</talentname.thewaitinglist>
+<talentname.thefriendswemade>The Friends We Made</talentname.thefriendswemade>
+<talentname.chonkyhonks>Chonky Honks</talentname.chonkyhonks>
+<talentname.logisticssystems>Logistics Systems</talentname.logisticssystems>
+<talentname.journeyman>Journeyman</talentname.journeyman>
+<talentname.loyalassistant>Loyal Assistant</talentname.loyalassistant>
+<talentname.disloyalscum>Treacherous Scum</talentname.disloyalscum>
+<talentname.commendations>Commendations</talentname.commendations>
+<talentname.emergencymaneuvers>Emergency Maneuvers</talentname.emergencymaneuvers>
+<talentname.commando>Commando</talentname.commando>
+<talentname.slayer>Slayer</talentname.slayer>
+<talentname.specops>Spec-Ops</talentname.specops>
+<talentname.medicalcompanion>Medical Companion</talentname.medicalcompanion>
+<talentname.nopressure>No Pressure</talentname.nopressure>
+<talentname.genesplicer>Gene Splicer</talentname.genesplicer>
+<talentname.geneticgenious>Genetic Genius</talentname.geneticgenious>
+<talentname.supersoldiers>Super Soldiers</talentname.supersoldiers>
+<talentname.vitaminsupplements>Vitamin Supplements</talentname.vitaminsupplements>
+<talentname.samplecollection>Sample Collection</talentname.samplecollection>
+<talentname.armsrace>Arms Race</talentname.armsrace>
+<talentname.heavyhitter>Heavy Hitter</talentname.heavyhitter>
+<talentname.gridmaintainer>Grid Maintainer</talentname.gridmaintainer>
+<talentname.unlimitedpower>Unlimited Power</talentname.unlimitedpower>
+<talentname.dangerzone>Danger Zone</talentname.dangerzone>
+<talentname.unstoppablecuriosity>Unstoppable Curiosity</talentname.unstoppablecuriosity>
+<talentname.modularrepairs>Modular Repairs</talentname.modularrepairs>
+<talentname.hullfixer>Hull Fixer</talentname.hullfixer>
+<talentname.quickfixer>Quickfixer</talentname.quickfixer>
+<talentname.nonthreatening>Non-threatening</talentname.nonthreatening>
+<talentname.whatastench>What a Stench!</talentname.whatastench>
+<talentname.blackmarketgenes>Blackmarket Genes</talentname.blackmarketgenes>
+<talentname.robotics>Robotics</talentname.robotics>
+<talentname.plaguedoctor>Plague Doctor</talentname.plaguedoctor>
+<talentdescription.vitaminsupplements>Whenever you apply medicine to a friendly character, they gain [healthboost]% health until the end of the mission.</talentdescription.vitaminsupplements>
+<talentdescription.cannotfallunconsciousforseconds>Whenever you fall below 0 health, you will remain fully conscious and your attacks are [powerincrease]% more powerful for [seconds] seconds.</talentdescription.cannotfallunconsciousforseconds>
+<talentdescription.gainmedicalskillformissionrun>Whenever you complete a mission, if all crewmembers survived, gain [skillincrease] points in Medical skill.</talentdescription.gainmedicalskillformissionrun>
+<talentdescription.gainoutputandskillfromartifacts>Whenever you deconstruct an alien artifact, you have a [probability]% chance to gain double output from it and gain [largeartifactskill] to a random skill. Small alien artifacts, when deconstructed, give [smallartifactskill] skill instead.</talentdescription.gainoutputandskillfromartifacts>
+<talentdescription.gainexperiencefromartifacts>Whenever you deconstruct an alien artifact, you and another random allied crewmember gains [experiencegain] experience. Small alien artifacts, when deconstructed, give [smallexperiencegain] experience instead.</talentdescription.gainexperiencefromartifacts>
+<talentdescription.maxtriggeruntildeath>This effect can only occur once per life each round.</talentdescription.maxtriggeruntildeath>
+<talentdescription.maxskillfromtalent>This talent can only give up to [skillamount] skill bonus.</talentdescription.maxskillfromtalent>
+<talentdescription.expertcommando>When firing a ranged weapon while crouched, you gain [spreadreduction]% reduction to spread and your attacks are [powerincrease]% more powerful, but your firing rate is [firingratedecrease]% slower.\nRecover from bleeding much more quickly.</talentdescription.expertcommando>
+<talentdescription.gainmedicalitemeffectiveness>Medical items you apply are [amount]% more potent.</talentdescription.gainmedicalitemeffectiveness>
+<talentdescription.geneticmaterialrefineflatbonus>Refining genetic materials adds an additional [amount]% to their potency.</talentdescription.geneticmaterialrefineflatbonus>
+<talentdescription.stillkickingheal>Whenever you fall below 0 health, rapidly heal normal damage types and remove stun over a short duration.</talentdescription.stillkickingheal>
+<talentdescription.extraskillfromcraftingany>Gain [amount]% more skill from fabricating items.</talentdescription.extraskillfromcraftingany>
+<talentdescription.medicaleffectiveness>Medical items are [amount]% more potent when applied to you.</talentdescription.medicaleffectiveness>
+<talentdescription.payextra.monsterandnest>You are paid an additional [extra]% for monster and nest missions.</talentdescription.payextra.monsterandnest>
+<talentdescription.tinker.fabricatoranddeconstructor>You can tinker with a fabricator or a deconstructor, increasing their operating rate by [speedincrease]%.\nYou can tinker with fabricators and deconstructors indefinitely.</talentdescription.tinker.fabricatoranddeconstructor>
+<talentdescription.honkinggivesskillgain>Clown Power allows you to honk your horn to give nearby allies an additional [skillgainincrease]% skill gain for a short while.</talentdescription.honkinggivesskillgain>
+<talentdescription.honkinghealscharacters>Clown Power allows you to honk your horn to slowly heal nearby allies.</talentdescription.honkinghealscharacters>
+<talentdescription.standanddeliver>Whenever you finish at least one mission, gain "The Sailor's Guide."\nWhenever you use "The Sailor's Guide," the ally nearest to you gains [skillamount] to all skills.</talentdescription.standanddeliver>
+<talentdescription.letitdrainreminder>You can only install a maximum of [itemcount] of this item on your submarine.</talentdescription.letitdrainreminder>
+<talentdescription.cannedheat>Whenever you play an accordion, the ally nearest to you will gain [allyexperienceamount] experience every second. When they do, you gain [experienceamount] experience.</talentdescription.cannedheat>
+<talentdescription.nuclearoption>You can craft much cheaper ‖color:gui.orange‖Nuclear Shells‖end‖ and ‖color:gui.orange‖Nuclear Depth Charges‖end‖, using non-spent ‖color:gui.orange‖Fuel Rods‖end‖.</talentdescription.nuclearoption>
+<talentdescription.quickfix>Whenever you fully repair a device, gain [experienceamount] experience.</talentdescription.quickfix>
+<talentdescription.maxtriggeruntildeath>This effect can only occur once per life.</talentdescription.maxtriggeruntildeath>
+<talentdescription.maxtriggeruntilmission>This effect can only occur up to [maxtrigger] times until you finish another mission.</talentdescription.maxtriggeruntilmission>
+<talentdescription.singletriggeruntilmission>This effect cannot occur again until you finish another mission.</talentdescription.singletriggeruntilmission>
+<talentdescription.increaseattackpowertomonstersinsub>Your attacks are [attackpowerincrease]% more powerful against monsters inside your submarine.</talentdescription.increaseattackpowertomonstersinsub>
+<talentdescription.cannotfallunconscious>You will remain fully conscious even after falling below 0 health.</talentdescription.cannotfallunconscious>
+<talentdescription.extramarksonnewstation>Your crew gains an additional [marks] marks whenever you reach a new station.</talentdescription.extramarksonnewstation>
+<talentdescription.specialsaleitemincrease>Special sales offer [itemcount] additional items.</talentdescription.specialsaleitemincrease>
+<talentdescription.offeradditionalmissions>Stations offer [missioncount] additional missions.</talentdescription.offeradditionalmissions>
+<talentdescription.bonuseslostondeath>These bonuses are lost on death.</talentdescription.bonuseslostondeath>
+<talentdescription.bonuslostondeath>This bonus is lost on death.</talentdescription.bonuslostondeath>
+<talentdescription.gainattributes>You gain the following attributes:</talentdescription.gainattributes>
+<talentdescription.assistantsdontcount>The deaths of assistants do not count.</talentdescription.assistantsdontcount>
+<talentdescription.gainitemonfinishmissionwithoutdeaths>Whenever you finish a mission without a crewmember dying, gain the item [item]</talentdescription.gainitemonfinishmissionwithoutdeaths>
+<talentdescription.maximumhealthperlevel>Gain an additional [maximumhealth]% maximum health for each of your levels.</talentdescription.maximumhealthperlevel>
+<talentdescription.gainalltalentsintree>Gain all the talents in this talent tree.</talentdescription.gainalltalentsintree>
+<talentname.bedsidemanner>Bedside Manner</talentname.bedsidemanner>
+<talentdescription.bedsidemanner>Whenever you apply medicine to a friendly character, they gain [physicaldamageresistance] physical damage resistance and an additional [skillgainincrease]% skill gain, the total duration depending on your medical skill.</talentdescription.bedsidemanner>
+<talentdescription.electrochemist>If you have not been attacked for [seconds] seconds, the next attack you suffer has [powerreduction]% less power and your attacker is stunned for [stunseconds] seconds.</talentdescription.electrochemist>
+<talentname.drsubmarine>Dr. Submarine</talentname.drsubmarine>
+<talentdescription.drsubmarine>Using medical items while crouched also applies [selfinflictpercentage]% of the effects on you as well.</talentdescription.drsubmarine>
+<talentname.combatmedic>Combat Medic</talentname.combatmedic>
+<talentdescription.combatmedic>Gain an additional percentage to Movement Speed, Ranged Fire Rate and Melee Attack Speed equal to [skillpercentage]% of your medical skill.</talentdescription.combatmedic>
+<talentname.geneharvester>Gene Harvester</talentname.geneharvester>
+<talentdescription.geneharvester>When looting a monster, there is a [probability]% chance of finding a genetic material on it.</talentdescription.geneharvester>
+<talentname.researchgrant>Research Grant</talentname.researchgrant>
+<talentdescription.researchgrant>Whenever you refine or combine genetic items, gain [marks] marks.</talentdescription.researchgrant>
+<talentname.melodicrespite>Melodic Respite</talentname.melodicrespite>
+<talentdescription.melodicrespite>When you play a guitar, you and allies near you gain the following attributes for up to [seconds] seconds:</talentdescription.melodicrespite>
+<talentdescription.expandedresearch>Whenever you fabricate depleted fuel or a fuel rod, gain [experienceamount] experience.</talentdescription.expandedresearch>
+<talentdescription.hazardousmaterials>Whenever you loot a reactor in a wreck for the first time, you will find rare materials.</talentdescription.hazardousmaterials>
+<talentdescription.gainskillatlowskill>When you gain a skill point for a skill that has a total lower than [skilltotal], gain an additional skill point.</talentdescription.gainskillatlowskill>
+<talentdescription.advancedsplicing>Whenever you or another allied crewmember combines or refines genetic materials, gain [experienceamount] experience and a bonus of [skillbonus] to medical.</talentdescription.advancedsplicing>
+<talentdescription.increasemaxrepairelectrical>As long as your electrical skill is [skilltotal] or higher, you can repair electrical devices [percentage]% past their maximum condition.</talentdescription.increasemaxrepairelectrical>
+<talentname.overclocking>Overclocking</talentname.overclocking>
+<talentname.dontdieonme>Don't Die on Me!</talentname.dontdieonme>
+<talentdescription.dontdieonme>The CPR you apply is much more powerful.</talentdescription.dontdieonme>
+<talentname.justascratch>Just a scratch</talentname.justascratch>
+<talentdescription.healabovehealth>As long as you are above [percentage]% health, normal damage types slowly heal by themselves.</talentdescription.healabovehealth>
+<talentdescription.extraskillfromcrafting>Gain [amount]% more [skillname] skill from fabricating items.</talentdescription.extraskillfromcrafting>
+<talentdescription.extrastunonenemies>Inflict [amount]% more stun.</talentdescription.extrastunonenemies>
+<talentdescription.scavenger>Whenever you open a container outside your submarine for the first time, you have a [probability]% chance of finding additional items.</talentdescription.scavenger>
+<talentdescription.increasebuffduration>Buffs last [amount]% longer.</talentdescription.increasebuffduration>
+<talentdescription.skillbonus>Gain a bonus of [amount] to [skillname].</talentdescription.skillbonus>
+<talentdescription.payextra.cargoandescort>You are paid an additional [extra]% for cargo and escort missions.</talentdescription.payextra.cargoandescort>
+<talentdescription.unlockrecipe>Unlock recipe: [itemname].</talentdescription.unlockrecipe>
+<talentdescription.simultaneousskillgain>Whenever you gain [skillname1] skill, also gain [skillname2] skill.</talentdescription.simultaneousskillgain>
+<talentdescription.increasereputationgains>Your crew's reputation gains are improved by [value]%.</talentdescription.increasereputationgains>
+<talentdescription.chanceofextraweapondamage>Whenever you attack with any weapon, your attack has a [probability]% chance of becoming twice as powerful.</talentdescription.chanceofextraweapondamage>
+<talentdescription.extrapowertoharpoons>Gain an additional [value]% attack power with ‖color:gui.orange‖harpoons‖end‖.</talentdescription.extrapowertoharpoons>
+<talentdescription.extrapowertoharpoonsinopensea>If you are in the open sea, gain an additional [value]% attack power to harpoons instead.</talentdescription.extrapowertoharpoonsinopensea>
+<talentdescription.dropalienmaterialonkill>When you kill a monster while outside your submarine, it has a [probability]% chance of having an additional alien material.</talentdescription.dropalienmaterialonkill>
+<talentdescription.warriorpoet>You can write a book.\nTo do this, ragdoll yourself. After [seconds] seconds, you will gain the item [itemname] and [moneyamount] marks for each enemy you've killed since your last book (as royalties).</talentdescription.warriorpoet>
+<talentdescription.dualspecops>When you ragdoll in water, propel yourself forward in your current direction.</talentdescription.dualspecops>
+<talentdescription.beatcop>Doubled against monsters inside the submarine.</talentdescription.beatcop>
+<talentdescription.truepotential>Clown Power allows you to hit characters with a Toy Hammer for a [probability]% chance to implode them.</talentdescription.truepotential>
+<talentdescription.stonewall>Whenever you are attacked, gain an additional [physicaldamagereduction]% physical damage resistance and [stunresistance]% stun resistance for [seconds] seconds.</talentdescription.stonewall>
+<talentdescription.richinknowledge>Whenever you gain a skill point, gain an additional [experienceamount] experience, while your allied crewmembers gain [alliedexperienceamount] experience.</talentdescription.richinknowledge>
+<talentdescription.olympian>You gain an additional percentage to the following attributes equal to [skillpercentage] of the total average of all your skills:</talentdescription.olympian>
+<talentdescription.playingcatchup>If you are [levelvalue] or more levels behind your most highest-leveled crewmember, gain an additional [experiencevalue]% mission experience.</talentdescription.playingcatchup>
+<talentdescription.skedaddle>Move [value]% faster. When you are attacked, this bonus is increased to [attackedvalue]% for [seconds] seconds.</talentdescription.skedaddle>
+<talentdescription.insurancepolicy>Whenever you die from non-friendly sources during a mission, your crew is paid [amount] marks for each mission you've completed since the last time you've died.</talentdescription.insurancepolicy>
+<talentdescription.feigndeath>Enemies will ignore you if you have been ragdolled for longer than [seconds] seconds.</talentdescription.feigndeath>
+<talentdescription.stillkicking>Whenever you fall unconscious, revive a short while later and remove all afflictions.</talentdescription.stillkicking>
+<talentdescription.crewlayabout>Allies near you repair [repairspeed]% faster and gain a bonus of [amount] to all skills.</talentdescription.crewlayabout>
+<talentdescription.graduationceremony>Upon creating a new character, retain all of your current experience for that new character.</talentdescription.graduationceremony>
+<talentdescription.enrollintoclowncollege>As long as you are wearing a full clown outfit, you gain Clown Power.</talentdescription.enrollintoclowncollege>
+<talentdescription.clownpowerdamagereduction>Clown Power gives you an additional [physicalresistance]% physical damage resistance.</talentdescription.clownpowerdamagereduction>
+<talentdescription.waterprankster>Clown Power gives you immunity to pressure and allows you to swim [swimspeedvalue]% faster.</talentdescription.waterprankster>
+
+<talentdescription.psychoclown>Clown Power allows you to attack faster with melee weapons based on how much Psychosis you have, up to [maxattackspeed]%.</talentdescription.psychoclown>
+<talentdescription.slapstickexpert>Clown Power allows you to have a small chance to trip randomly when you run.\nWhile ragdolled, Clown Power allows you to reduce the power of incoming attacks by [powerreduction]%, and characters that attack you have a [probability]% chance of becoming stunned for [stunseconds] seconds.</talentdescription.slapstickexpert>
+<talentdescription.commando>When firing a ranged weapon while crouched, you gain [spreadreduction]% reduction to spread and inflict [powerincrease]% more damage.</talentdescription.commando>
+<talentdescription.phdinnuclearphysics>Your attacks with crowbars are [powerincrease]% more powerful.</talentdescription.phdinnuclearphysics>
+<talentdescription.intheflow>Whenever you fully repair a device, repair [repairspeed]% faster for the next [seconds] seconds.</talentdescription.intheflow>
+<talentdescription.coauthor>You can co-write a book with a Mechanic.\nTo do this, select their character and have them select yours. After [seconds] seconds, you will gain [itemname], and both of you gain [experienceamount] experience.</talentdescription.coauthor>
+<talentdescription.polymath>Gain a bonus of [skillincrease] to all skills, and you gain [experiencegain]% more mission experience, but you have [maximumhealthreduction]% less maximum health.</talentdescription.polymath>
+
+<talentdescription.pyromaniac>Inflict [burnincrease]% more burning damage. Doubled when fighting against ‖color:gui.orange‖Ballast Flora‖end‖.</talentdescription.pyromaniac>
+<talentdescription.scrapsavant>You can refine [scrapamount] scrap to any alien material.\nGain [experienceamount] experience when you fabricate an alien material.</talentdescription.scrapsavant>
+<talentdescription.scrounger>When you deconstruct scrap, gain [experienceamount] experience.</talentdescription.scrounger>
+
+<talentdescription.miner>Whenever you deconstruct an ore, you have a [probability]% chance to gain double the output.</talentdescription.miner>
+<talentdescription.tinker.fabricatoranddeconstructor>You can tinker with a fabricator or a deconstructor, increases their operating rate by [speedincrease]%.\nYou can tinker with fabricators and deconstructors indefinitely.</talentdescription.tinker.fabricatoranddeconstructor>
+<talentdescription.tinker.pump>You can tinker with a pump, increasing its pumping rate by [speedincrease]%.</talentdescription.tinker.pump>
+<talentdescription.tinker.engine>You can tinker with an engine, increasing its torque by [speedincrease]%.</talentdescription.tinker.engine>
+<talentdescription.tinker.loader>You can tinker with a loader, increasing the connected turret's firing rate and damage by [damageincrease]%, while lowering its power usage by [powercostreduction]%.</talentdescription.tinker.loader>
+<talentdescription.tinker.tutorial>You can use a wrench to tinker with devices.</talentdescription.tinker.tutorial>
+<talentdescription.tinker.cooldownreduction>The cooldown period of tinkering is reduced to [seconds] seconds.</talentdescription.tinker.cooldownreduction>
+<talentdescription.tinker.durationincrease>You can tinker for an additional [seconds] seconds.</talentdescription.tinker.durationincrease>
+<talentdescription.tinker.suppliespower>Non-turret devices you tinker with will always function as if they had power.</talentdescription.tinker.suppliespower>
+<talentdescription.tinker.reminder>The device is only affected for as long as you keep tinkering with it.</talentdescription.tinker.reminder>
+<talentdescription.tinker.duration>You can tinker for [duration] seconds. After you have tinkered with a device, you cannot tinker for [cooldown] seconds.</talentdescription.tinker.duration>
+<talentdescription.tinker.overclocking>Tinkering with items damages them, but the effects of tinkering are increased by [tinkerincrease]%.</talentdescription.tinker.overclocking>
+<talentdescription.fieldmedic>Every [seconds] seconds, if your allied crewmembers are at [healththreshold]% health or higher, gain [skillincrease] point in Medical skill.</talentdescription.fieldmedic>
+<talentdescription.curiosity>Whenever you deconstruct an alien artifact you gain [experiencegain] experience, and your crew gains [crewexperiencegain] experience.</talentdescription.curiosity>
+<talentdescription.reverseengineer>Whenever you deconstruct an alien artifact, gain double output from it and gain [skillgain] to a random skill.</talentdescription.reverseengineer>
+<talentdescription.alienhoarder>Your attacks with alien pistols have [powerincrease]% additional power for each alien artifact you are carrying, up to an additional [maxpowerincrease]% power.</talentdescription.alienhoarder>
+
+<talentdescription.firemanscarry>You can drag characters at full speed.</talentdescription.firemanscarry>
+<talentdescription.researchersintuition>Whenever you open an alien container for the first time, you have a [probability]% chance of finding additional items.\nWhile you are holding a large alien artifact, gain an additional [swimmingspeed]% Swimming Speed.</talentdescription.researchersintuition>
+<talentdescription.commander>Whenever you give an order to another character, apply Inspiration to that character, giving them [physicalresistance]% physical damage resistance and a bonus of [skillincrease] to all skills.</talentdescription.commander>
+<talentdescription.commanderreminder>Giving an order to a new character removes the effect from the last character.</talentdescription.commanderreminder>
+<talentdescription.additionalinspirationbonuses>In addition to other Inspiration bonuses, the ordered character also gains the following attributes:</talentdescription.additionalinspirationbonuses>
+<talentdescription.allhandsondeck>You may bestow an additional character with Inspiration effects.</talentdescription.allhandsondeck>
+<talentdescription.atmosmachine>When you deconstruct an alien artifact, there is a [probability]% chance it will instead transform into a random alien item.\nWhenever you finish a mission, your crew gains [experienceamount]% additional mission experience for each large alien artifact on board your ship, up to [maxexperienceamount]%.</talentdescription.atmosmachine>
+<talentdescription.navydiver>Attacks you suffer are [attackpowerreduction]% less powerful while you are in water.</talentdescription.navydiver>
+<talentdescription.crafthighqualityrepairtools>‖color:gui.orange‖Welding tools‖end‖ and ‖color:gui.orange‖Plasma Cutters‖end‖ you fabricate are [qualitybonus] higher quality.</talentdescription.crafthighqualityrepairtools>
+<talentdescription.crafthighqualityweapons>‖color:gui.orange‖Weapons‖end‖ you fabricate are of [qualitybonus] higher quality.</talentdescription.crafthighqualityweapons>
+<talentdescription.crafthighqualitybatteries>‖color:gui.orange‖Battery Cells‖end‖ you fabricate are of [qualitybonus] higher quality.</talentdescription.crafthighqualitybatteries>
+<talentdescription.crafthighqualityfuelrods>‖color:gui.orange‖Fuel Rods‖end‖ you fabricate are of [qualitybonus] higher quality.</talentdescription.crafthighqualityfuelrods>
+<talentdescription.crafthighqualitytools>‖color:gui.orange‖Tools‖end‖ you fabricate are of [qualitybonus] higher quality.</talentdescription.crafthighqualitytools>
+<talentdescription.crafthighqualitytanks>‖color:gui.orange‖Welding Fuel‖end‖ and ‖color:gui.orange‖Oxygen Tanks‖end‖ you fabricate are of [qualitybonus] higher quality.</talentdescription.crafthighqualitytanks>
+<talentdescription.crafthighqualityexplosives>‖color:gui.orange‖Explosives‖end‖ you fabricate are of [qualitybonus] higher quality.</talentdescription.crafthighqualityexplosives>
+<talentdescription.gainitemsonmission>Whenever you finish at least one mission, gain the following items as an additional reward:</talentdescription.gainitemsonmission>
+<talentdescription.extramission>You may select an additional mission.</talentdescription.extramission>
+<talentdescription.extratalentpoint>Gain [points] free additional talent points.</talentdescription.extratalentpoint>
+<talentdescription.lowhealth.effectivehealing>When you are below [health]% health, normal damage types are healed [extraheal]% more effectively.</talentdescription.lowhealth.effectivehealing>
+<talentdescription.lowhealth.regenerate>When you are below [health]% health, normal damage types slowly heal by themselves.</talentdescription.lowhealth.regenerate>
+<talentdescription.gainstructurerepairspeed>Repair hulls [amount]% faster with welding tools.</talentdescription.gainstructurerepairspeed>
+<talentdescription.gainstructurecutterdamage>Deal [amount]% more damage to structures with cutters.</talentdescription.gainstructurecutterdamage>
+<talentdescription.gainoredetachspeed>Detach ores [amount]% faster with cutters.</talentdescription.gainoredetachspeed>
+<talentdescription.gainforcedoorsopenspeed>Force doors open [amount]% faster.</talentdescription.gainforcedoorsopenspeed>
+<talentdescription.findadditionalscrap>Whenever you open a container in a wreck for the first time, you have a [probability]% chance of finding an additional scrap.</talentdescription.findadditionalscrap>
+<talentdescription.gainmarksonskillpoint>Gain [amount] marks when you gain a skill point.</talentdescription.gainmarksonskillpoint>
+<talentdescription.gainskillspastmax>You can gain skills past their ordinary maximum.</talentdescription.gainskillspastmax>
+<talentdescription.gainbonustoallskills>Gain a bonus of [amount] to all skills.</talentdescription.gainbonustoallskills>
+<talentdescription.reductiontoallskills>Suffer a reduction of [amount] to all skills.</talentdescription.reductiontoallskills>
+<talentdescription.increasemaxrepairmechanical>You can repair mechanical devices [percentage]% past their normal maximum condition.</talentdescription.increasemaxrepairmechanical>
+<talentdescription.geneticmaterialrefinebonus>Refining genetic materials improves their potency by [amount]% more.</talentdescription.geneticmaterialrefinebonus>
+<talentdescription.geneticmaterialtaintedprobabilityreductiononcombine>Combining different types of genetic materials is [amount]% less likely to taint the materials.</talentdescription.geneticmaterialtaintedprobabilityreductiononcombine>
+<talentdescription.physicaldamageresistance>+[amount] Physical Damage resistance</talentdescription.physicaldamageresistance>
+<talentdescription.gainitem>[amount]x [itemname]</talentdescription.gainitem>
+<talentdescription.additionalskill>+[amount] [stattype]</talentdescription.additionalskill>
+<talentdescription.additionalstattype>+[amount]% [stattype]</talentdescription.additionalstattype>
+<talentdescription.reductiontostattype>-[amount]% [stattype]</talentdescription.reductiontostattype>
+<talentdescription.additionalresistance>+[amount]% [affliction] resistance</talentdescription.additionalresistance>
+<talentdescription.additionalstattypeself>Gain an additional [amount]% [stattype].</talentdescription.additionalstattypeself>
+<talentdescription.reductiontostattypeself>Lose [amount]% [stattype].</talentdescription.reductiontostattypeself>
+<talentdescription.additionalresistanceself>Gain an additional [amount]% [affliction] resistance.</talentdescription.additionalresistanceself>
+<talentdescription.gainmissionxpanditem>Whenever you finish a mission without a crewmember dying, you gain an additional [amount]% experience and gain the item [item].</talentdescription.gainmissionxpanditem>
+<talentdescription.depletedfueldeconstructedbyally>Whenever you or another allied crewmember deconstructs depleted fuel, they gain [amount] experience.</talentdescription.depletedfueldeconstructedbyally>
+<talentdescription.gaindoubleskillatskill>As long as your [skillname1] skill is [skilltotal] or higher, they gain twice as much [skillname2] skill.</talentdescription.gaindoubleskillatskill>
+<talentdescription.warstories>Gain [xpbonus] bonus XP when completing a mission in which you killed at least [creatureamount] creatures.</talentdescription.warstories>
+<talentdescription.easyturtle>Take [amount]% less damage from attacks while you are in water.</talentdescription.easyturtle>
+
+<talentdescription.logisticsexpert>Gain [xpbonus]% bonus XP and [moneybonus]% bonus money when completing a [missiontype1] or [missiontype2] mission.</talentdescription.logisticsexpert>
+<talentdescription.healthinsurance>Gain [xpbonus]% bonus XP and [moneybonus]% bonus money when completing a [missiontype] mission.</talentdescription.healthinsurance>
+<talentdescription.mailman>Gain [xpbonus]% bonus XP and [moneybonus] bonus money when completing a [missiontype] mission.</talentdescription.mailman>
+<talentdescription.protectandserve>Gain [xpbonus]% bonus XP when completing a [missiontype] mission.</talentdescription.protectandserve>
+<talentdescription.nobodyimportantdies>Gain [xpbonus]% bonus XP when completing a mission, if all crewmembers survived.</talentdescription.nobodyimportantdies>
+<talentdescription.travelingtradesman>Items sold by your crew sell for [amount]% more.</talentdescription.travelingtradesman>
+<talentdescription.appliestoallcrew>Applies to all crew:</talentdescription.appliestoallcrew>
+<talentdescription.camaraderienew>Whenever you finish a mission without a crewmember dying, your crew gains an additional [extraexperience]% experience.</talentdescription.camaraderienew>
+<talentdescription.downwiththeship>If you are on your submarine and it becomes at least [flooded]% flooded, you gain an additional [swimmingboost]% swimming speed and repair hulls [repairspeed]% faster for [duration] seconds.</talentdescription.downwiththeship>
+<talentdescription.emergencymaneuvers>Whenever your submarine takes damage from a monster, gain ‖color:gui.orange‖maximum Helm skill‖end‖ for [seconds] seconds.</talentdescription.emergencymaneuvers>
+<talentdescription.lonewolf>If there are no crewmembers nearby, gain the following:</talentdescription.lonewolf>
+<talentdescription.deputy>‖color:gui.orange‖Assistants‖end‖ nearby get [skillbonus1] ‖color:gui.orange‖Helm‖end‖ and [skillbonus2] ‖color:gui.orange‖Weapons‖end‖ skill and gain these skills twice as fast.</talentdescription.deputy>
+<talentdescription.bigguns>Deal [amount]% more damage with ‖color:gui.orange‖Revolvers‖end‖ and ‖color:gui.orange‖Handcannons‖end‖ to monsters.</talentdescription.bigguns>
+<talentdescription.commendations>Whenever you finish at least one mission, gain a ‖color:gui.orange‖Commendation‖end‖.\nWhen you apply a ‖color:gui.orange‖Commendation‖end‖ on another character, give them [selfxpgain] experience.</talentdescription.commendations>
+<talentdescription.yourreputation>When entering a new outpost you have positive faction reputation with, gain [amount] mk.\nDoubled for cities.</talentdescription.yourreputation>
+<talentdescription.affiliation>Choose a faction to side with, in order to gain affiliation bonuses for that faction.</talentdescription.affiliation>
+<talentdescription.affiliationfaction>Choose to side with [faction] and gain the following:</talentdescription.affiliationfaction>
+<talentdescription.affiliationbenefit1>Reputation with [faction] increases [reputationincrease]% faster, but reputation with other factions decreases [reputationloss]% faster.</talentdescription.affiliationbenefit1>
+<talentdescription.affiliationbenefit2>Earn [amount]% more marks when completing a mission for [faction].</talentdescription.affiliationbenefit2>
+
+<talentdescription.campaigning>Affiliated faction shipyards offer [amount]% discount for upgrades and buying submarines.</talentdescription.campaigning>
+<talentdescription.networking>Affiliated faction shops offer [amount]% lower prices. Doubled for faction-unique items.</talentdescription.networking>
+<talentdescription.figurehead>Replaces ‖color:gui.orange‖Commendations‖end‖ with ‖color:gui.orange‖Medals‖end‖ that give [selfxpgain] XP. If the character is then below level [level], give them XP to reach level [level].</talentdescription.figurehead>
+<talentdescription.factiondiscount>All services on affiliated outposts give [discount]% discount.</talentdescription.factiondiscount>
+<talentdescription.leadingbyexample>As long as you're alive, all crewmembers receive ‖color:gui.orange‖High Morale‖end‖ granting the following:</talentdescription.leadingbyexample>
+
+<talentdescription.increaseeffectiveness>Increases ‖color:gui.orange‖Engines‖end‖ and ‖color:gui.orange‖Pumps‖end‖ effectiveness by [amount]%.</talentdescription.increaseeffectiveness>
+<talentdescription.inspiringpresence>Crewmembers in the same room that gain a skill point, instead get [amount]. Crewmembers walk [movespeed]% faster.</talentdescription.inspiringpresence>
+<talentdescription.trickledown>If you gain a skill, so does every other crewmember everywhere. Crewmembers swim [amount]% faster.</talentdescription.trickledown>
+<talentdescription.steadytune>After playing a ‖color:gui.orange‖Harmonica‖end‖ for [duration] seconds or longer, you and nearby allies gain +[buffamount]% [buffname] for [buffduration] seconds.</talentdescription.steadytune>
+<talentdescription.melodicrespite2>After playing a ‖color:gui.orange‖Guitar‖end‖ for [duration] seconds or longer, you and nearby allies gain +[buffamount]% [buffname] for [buffduration] seconds.</talentdescription.melodicrespite2>
+<talentdescription.family>‖color:gui.green‖On unlock:‖end‖ Every crewmember gains one level.</talentdescription.family>
+<talentdescription.family2>During missions, if no crewmember has died, upgrades ‖color:gui.orange‖High Morale‖end‖ to ‖color:gui.orange‖Excellent Morale‖end‖, doubling the bonuses.</talentdescription.family2>
+<talentdescription.extrableedingdamage>Inflict [amount]% more ‖color:gui.orange‖Bleeding‖end‖ damage.</talentdescription.extrableedingdamage>
+<talentdescription.crustyseaman>Recover from bleeding much more quickly.</talentdescription.crustyseaman>
+<talentdescription.moredamagerifles>Inflict [amount]% more damage with ‖color:gui.orange‖Rifles‖end‖.</talentdescription.moredamagerifles>
+<talentdescription.extrapowder>Explosions have [rangeamount]% larger radius and deal [damageamount]% more damage.</talentdescription.extrapowder>
+<talentdescription.gunrunner>You move [amount]% faster while carrying turret ammunition.</talentdescription.gunrunner>
+<talentdescription.walkfasterwhileaiming>Walk [amount]% faster while aiming.</talentdescription.walkfasterwhileaiming>
+<talentdescription.warlord>Inflict [amount]% more damage with ranged weapons for every nearby enemy. Up to [maxamount]%.</talentdescription.warlord>
+<talentdescription.blooddonor>Whenever you finish at least one mission, gain one ‖color:gui.orange‖Blood Pack‖end‖ in your inventory.</talentdescription.blooddonor>
+<talentdescription.itemgiveslessaffliction>Administering ‖color:gui.orange‖Alien Blood‖end‖ gives [amount]% less ‖color:gui.orange‖Psychosis‖end‖.</talentdescription.itemgiveslessaffliction>
+<talentdescription.bloodybusiness>‖color:gui.orange‖Large creatures‖end‖ drop one extra [item].</talentdescription.bloodybusiness>
+<talentdescription.genetampering>All crewmembers gain [healthamount]% more health and move [movementspeed]% faster.</talentdescription.genetampering>
+<talentdescription.assistantdragatfullspeed>‖color:gui.orange‖Assistants‖end‖ can drag characters at full speed.</talentdescription.assistantdragatfullspeed>
+
+<talentdescription.slightlypowerfulcpr>The CPR applied by crewmembers reduces ‖color:gui.orange‖Oxygen Low‖end‖ [amount]% more effectively.</talentdescription.slightlypowerfulcpr>
+
+<talentdescription.medicalassistance>‖color:gui.orange‖Assistants‖end‖ in the same room have their ‖color:gui.orange‖Medical‖end‖ skill boosted by [amount].</talentdescription.medicalassistance>
+<talentdescription.miracleworker>Nearby crewmembers are unable to succumb to their injuries unless they give in.</talentdescription.miracleworker>
+<talentdescription.blackmarketgenes>Shops on ‖color:gui.orange‖Research Stations‖end‖ and ‖color:gui.orange‖Cities‖end‖ can sell genetic materials.</talentdescription.blackmarketgenes>
+<talentdescription.sellgeneticmaterialsmultiplier>You can sell genetic materials for [amount]% more.</talentdescription.sellgeneticmaterialsmultiplier>
+<talentdescription.chemicalsboughtcheaper>‖color:gui.orange‖Chemicals‖end‖ can be bought [amount]% cheaper.</talentdescription.chemicalsboughtcheaper>
+<talentdescription.constructmedicinefaster>You construct medical items [amount]% faster.</talentdescription.constructmedicinefaster>
+<talentdescription.increaseappliedbuffduration>Buffs you apply last [amount]% longer.</talentdescription.increaseappliedbuffduration>
+<talentdescription.poisonsandacidsdealmoredamage>‖color:gui.orange‖Poisons‖end‖ and ‖color:gui.orange‖Acid‖end‖ deal [amount]% more damage.</talentdescription.poisonsandacidsdealmoredamage>
+<talentdescription.junctionjunkie>Gain [bonus] bonus XP when completing a mission in which you repaired at least [amount] electrical devices.</talentdescription.junctionjunkie>
+<talentdescription.aggressiveengineering>You deal ‖color:gui.green‖triple‖end‖ damage with ‖color:gui.orange‖screwdrivers‖end‖.</talentdescription.aggressiveengineering>
+<talentdescription.machinemaniac>Gain [bonus] bonus XP when completing a mission in which you repaired at least [amount] mechanical devices.</talentdescription.machinemaniac>
+<talentdescription.stationengineer>Gain [bonus]% bonus XP when reactivating a ‖color:gui.orange‖Beacon Station‖end‖.</talentdescription.stationengineer>
+
+<talentdescription.buzzing>Your reactor's ‖color:gui.orange‖Max Output‖end‖ is increased by [amount]%.</talentdescription.buzzing>
+<talentdescription.cruising>Your reactor's ‖color:gui.orange‖Fuel Efficiency‖end‖ is increased by [amount]%.</talentdescription.cruising>
+<talentdescription.doesnotstackwith>Does not stack with [talentname].</talentdescription.doesnotstackwith>
+<talentdescription.doesnotstack>Does not stack with multiple of the same talent.</talentdescription.doesnotstack>
+<talentdescription.betterthannew>Electrical devices you've repaired deteriorate [amount]% slower.</talentdescription.betterthannew>
+<talentdescription.unlimitedpower>‖color:gui.orange‖Batteries‖end‖ and ‖color:gui.orange‖Supercapacitors‖end‖ have +[amount]% capacity.</talentdescription.unlimitedpower>
+<talentdescription.multifunctional>Deal [powerincrease]% more damage with ‖color:gui.orange‖Wrenches‖end‖ and ‖color:gui.orange‖Crowbars‖end‖.</talentdescription.multifunctional>
+<talentdescription.engineengineer>Submarine ‖color:gui.orange‖engines‖end‖ have +[amount]% [stattype] per level you have, to a maximum of [max]%.</talentdescription.engineengineer>
+<talentdescription.ballastdenizen>Hold your breath [amount]% longer.</talentdescription.ballastdenizen>
+<talentdescription.underwaterengineer>Submarine ‖color:gui.orange‖Engines‖end‖ have +[amount]% [stattype] when submerged.</talentdescription.underwaterengineer>
+<talentdescription.pumpndump>‖color:gui.orange‖Pumps‖end‖ you've repaired gain [amount]% [stattype].</talentdescription.pumpndump>
+<talentdescription.oiledmachinery>‖color:gui.orange‖Fabricators‖end‖ and ‖color:gui.orange‖Deconstructors‖end‖ works [amount]% faster.</talentdescription.oiledmachinery>
+<talentdescription.retrofit>Unlock ‖color:gui.orange‖hull upgrades‖end‖ as if your submarine is one tier higher.</talentdescription.retrofit>
+<talentdescription.toolmaintenance>All crewmembers craft tools at [amount] higher quality.</talentdescription.toolmaintenance>
+<talentdescription.residualwaste>Deconstructing an item has a [chance]% chance to give double the output.</talentdescription.residualwaste>
+<talentdescription.ironstorm>‖color:gui.orange‖Tier 1‖end‖ and ‖color:gui.orange‖Tier 2‖end‖ submarines can be upgraded as if ‖color:gui.orange‖Tier 3‖end‖.</talentdescription.ironstorm>
+<talentdescription.doublescrapoutput>Deconstructing ‖color:gui.orange‖Scrap‖end‖ gives double the output.</talentdescription.doublescrapoutput>
+<talentdescription.repairmechanicaldevicestwiceasfast>You repair ‖color:gui.orange‖mechanical devices‖end‖ twice as fast.</talentdescription.repairmechanicaldevicestwiceasfast>
+<talentdescription.quickfixer>After you repair a ‖color:gui.orange‖mechanical device‖end‖, move [amount]% faster for [duration] seconds.</talentdescription.quickfixer>
+<talentdescription.robotics>Build a powerful (but fragile) drone to watch your back.</talentdescription.robotics>
+<talentdescription.roboticsreminder>Only [amount] defense bots per crew can be active at the same time.</talentdescription.roboticsreminder>
+<talentdescription.iamthatguy>Inflict [amount]% more ‖color:gui.orange‖Blunt Force Trauma‖end‖ damage with melee weapons.</talentdescription.iamthatguy>
+<talentdescription.lowhealthstatboost>While below [health]% health, you gain the following:</talentdescription.lowhealthstatboost>
+<talentdescription.heavylifting>You move [amount]% faster when carrying ‖color:gui.orange‖Metal Crates‖end‖ or ‖color:gui.orange‖Artifacts‖end‖.</talentdescription.heavylifting>
+<talentdescription.mudraptorwrestler>Deal [amount]% more melee damage to ‖color:gui.orange‖Mudraptors‖end‖.</talentdescription.mudraptorwrestler>
+<talentdescription.revengesquad>When you die, your crewmates get [amount]% ‖color:gui.orange‖Physical Damage Resistance‖end‖ for [duration] seconds.</talentdescription.revengesquad>
+<talentdescription.peerlearning>When completing a mission, give the lowest level crewmembers [amount]% bonus XP.</talentdescription.peerlearning>
+<talentdescription.anappleaday>Gain [amount]% resistance to ‖color:gui.orange‖Reaper's Tax‖end‖.</talentdescription.anappleaday>
+<talentdescription.miracleworkerreminder>You become immune to ‖color:gui.orange‖Miracle In Progress‖end‖.</talentdescription.miracleworkerreminder>
+<talentdescription.thewaitinglist>When waiting for CPR, your vitality bar decreases [amount]% slower.</talentdescription.thewaitinglist>
+<talentdescription.thefriendswemade>Turn unhatched mudraptors friendly in the medical fabricator.</talentdescription.thefriendswemade>
+<talentdescription.thefriendswemadereminder>Only [amount] per crew can be active at the same time.</talentdescription.thefriendswemadereminder>
+<talentdescription.clownpowerbenefits>Clown Power grants you:</talentdescription.clownpowerbenefits>
+<talentdescription.thearrival>Once per station, honking a ‖color:gui.orange‖Bike Horn‖end‖ will give you [amount] reputation with [faction].</talentdescription.thearrival>
+
+<talentdescription.apprenticeshipbase>Choose one job as apprenticeship and gain relevant skill boost of that job.</talentdescription.apprenticeshipbase>
+<talentdescription.apprenticeshipjob>Choose [job] as your apprenticeship and gain the following:</talentdescription.apprenticeshipjob>
+<talentdescription.journeyman>You and all crewmembers whose job matches your apprenticeship get [skillamount] of the job's primary skill and earn this skill [skillspeedboost]% faster.</talentdescription.journeyman>
+<talentdescription.loyalassistant>You and all crewmembers whose job matches your apprenticeship can craft items at [amount] higher quality.</talentdescription.loyalassistant>
+<talentdescription.disloyalscum>You and all crewmembers whose job ‖color:gui.orange‖does not‖end‖ match your apprenticeship repair, weld and gain skills [amount]% faster.</talentdescription.disloyalscum>
+<talentdescription.unlockapprenticeshiptalents>Get all talents from one ‖color:gui.orange‖random specialization‖end‖ tree of your apprenticeship job's talent tree.</talentdescription.unlockapprenticeshiptalents>
+
+<talentdescription.massproduction>Fabricating items has a [chance]% chance to not consume one of the input ingredients.</talentdescription.massproduction>
+<talentdescription.specops>Inflict double (non-turret) damage against full health enemies.</talentdescription.specops>
+<talentdescription.letitdrain>Build portable pumps and install them where you need them.</talentdescription.letitdrain>
+<talentdescription.powerarmor>Move [bonusmovement]% faster in an ‖color:gui.orange‖Exosuit‖end‖.</talentdescription.powerarmor>
+<talentdescription.dangerzone>Have an additional [resistance]% resistance to ‖color:gui.orange‖Radiation sickness‖end‖ while wearing a ‖color:gui.orange‖Hazmat Suit‖end‖.</talentdescription.dangerzone>
+<talentdescription.affiliationreputation>Reputation with factions increases [reputationincrease]% faster.</talentdescription.affiliationreputation>
+<talentdescription.affiliationbenefit>Earn [amount]% more marks when completing a mission for your ‖color:gui.orange‖Affiliated faction‖end‖.</talentdescription.affiliationbenefit>
+<talentdescription.currentaffiliation>Your current ‖color:gui.orange‖Affiliated faction‖end‖ is: [affiliatedfaction]</talentdescription.currentaffiliation>
+<talentdescription.affiliationfactionreminder>‖color:gui.orange‖Affiliated faction:‖end‖ The faction you have the highest reputation with.</talentdescription.affiliationfactionreminder>
+<talentdescription.campaigning>‖color:gui.orange‖Affiliated faction‖end‖ shipyards offer [amount]% discount for upgrades and buying submarines.</talentdescription.campaigning>
+<talentdescription.networking>‖color:gui.orange‖Affiliated faction‖end‖ shops offer [amount]% lower prices. Doubled for faction-unique items.</talentdescription.networking>
+<talentdescription.factiondiscount>All services on ‖color:gui.orange‖Affiliated faction‖end‖ outposts give [discount]% discount.</talentdescription.factiondiscount>
+<talentdescription.emergencyresponse>You move [movementspeed]% faster if any crewmember is unconscious.</talentdescription.emergencyresponse>
+<talentdescription.chonkyhonks>Honking your horn has a [chance]% chance to stun nearby creatures for one second.</talentdescription.chonkyhonks>
+<talentdescription.truepotentialtemporary>Hitting an unconscious ally with a ‖color:gui.orange‖Toy Hammer‖end‖ revives them with [affliction] applied for [duration] seconds. Requires Clown Power.</talentdescription.truepotentialtemporary>
+
+<!-- Talent stat types -->
+<stattypenames.maximumhealthmultiplier>Maximum Health</stattypenames.maximumhealthmultiplier>
+<stattypenames.repairspeed>Repair Speed</stattypenames.repairspeed>
+<stattypenames.meleeattackspeed>Melee Attack Speed</stattypenames.meleeattackspeed>
+<stattypenames.rangedattackspeed>Ranged Fire Rate</stattypenames.rangedattackspeed>
+<stattypenames.turretattackspeed>Turret Fire Rate</stattypenames.turretattackspeed>
+<stattypenames.meleeattackmultiplier>Melee Power</stattypenames.meleeattackmultiplier>
+<stattypenames.attackmultiplier>Attack Power</stattypenames.attackmultiplier>
+<stattypenames.rangedattackmultiplier>Ranged Power</stattypenames.rangedattackmultiplier>
+<stattypenames.turretpowercostreduction>Turret Power Cost Reduction</stattypenames.turretpowercostreduction>
+<stattypenames.movementspeed>Movement Speed</stattypenames.movementspeed>
+<stattypenames.buffdurationmultiplier>Buff Duration</stattypenames.buffdurationmultiplier>
+<stattypenames.swimmingspeed>Swimming Speed</stattypenames.swimmingspeed>
+<stattypenames.walkingspeed>Walking Speed</stattypenames.walkingspeed>
+<stattypenames.skillgainspeed>Skill Gain Speed</stattypenames.skillgainspeed>
+<stattypenames.deconstructorspeedmultiplier>Deconstructor Speed</stattypenames.deconstructorspeedmultiplier>
+<stattypenames.repairtoolstructurerepairmultiplier>Hull Repair Speed</stattypenames.repairtoolstructurerepairmultiplier>
+<stattypenames.electricalskillbonus>Bonus Electrical Skill</stattypenames.electricalskillbonus>
+<stattypenames.helmskillbonus>Bonus Helm Skill</stattypenames.helmskillbonus>
+<stattypenames.mechanicalskillbonus>Bonus Mechanical Skill</stattypenames.mechanicalskillbonus>
+<stattypenames.medicalskillbonus>Bonus Medical Skill</stattypenames.medicalskillbonus>
+<stattypenames.weaponsskillbonus>Bonus Weapons Skill</stattypenames.weaponsskillbonus>
+<stattypenames.maxspeed>Max Speed</stattypenames.maxspeed>
+<stattypenames.storesellmultiplier>Item Sell Value</stattypenames.storesellmultiplier>
+<stattypenames.physicalresistance>Physical Damage Resistance</stattypenames.physicalresistance>
+<stattypenames.stunresistance>Stun Resistance</stattypenames.stunresistance>
+<stattypenames.meleedamagebonus>Melee Damage Dealt</stattypenames.meleedamagebonus>
+<stattypenames.reputationgain>Bonus Reputation Gain</stattypenames.reputationgain>
+<stattypenames.reputationloss>Bonus Reputation Loss</stattypenames.reputationloss>
+<stattypenames.maxflow>Maximum Flow</stattypenames.maxflow>
+
+
+<!-- Modified values September 18 -->
+
+<talentdescription.veteran>Gain a bonus of [helmbonus] ‖color:gui.orange‖Helm‖end‖ skill and [otherbonus] to all other skills.</talentdescription.veteran>
+<talentdescription.helmsman>Gain a bonus of [amount] ‖color:gui.orange‖Helm‖end‖ skill.</talentdescription.helmsman>
+<talentdescription.medicalexpertise>Gain a bonus of [amount] ‖color:gui.orange‖Medical‖end‖ skill. Your bandages are more effective.</talentdescription.medicalexpertise>
+<talentdescription.evasivemaneuvers>Whenever your submarine takes damage from a monster, gain a bonus of [helmbonus] ‖color:gui.orange‖Helm‖end‖ skill for [seconds] seconds.</talentdescription.evasivemaneuvers>
+<talentdescription.inspiringtunes>Nearby allies gain a bonus of [skillamount] to all skills for [duration] seconds when honking a bike horn.</talentdescription.inspiringtunes>
+<talentdescription.optimizedpowerflow>Gain an additional percentage to Turret Power Cost Reduction and Turret Charge Speed equal to [statamount]% of your ‖color:gui.orange‖Electrical‖end‖ skill.\nWhenever you fully repair an item, gain a bonus of [skillamount] ‖color:gui.orange‖Electrical‖end‖ skill.</talentdescription.optimizedpowerflow>
+<talentdescription.elbowgrease>Gain an additional percentage to Melee Power and Maximum Health equal to [statamount]% of your Mechanical skill.\nWhenever you deconstruct scrap, gain a bonus of [skillamount] to Mechanical.</talentdescription.elbowgrease>
+<talentdescription.doubleduty>As long as you are outside your sub, take [physicaldamagedecrease]% less physical damage. As long as you are inside your sub, gain a bonus of [skillincrease] ‖color:gui.orange‖Medicine‖end‖ skill.</talentdescription.doubleduty>
+<talentdescription.craftwithlessitems>You can craft ‖color:gui.orange‖FPGA Circuits‖end‖ and ‖color:gui.orange‖Circuit Boxes‖end‖ with much fewer materials.</talentdescription.craftwithlessitems>
+<sp.controller.istoggle.description>When enabled, the item will continuously send out a signal, and interacting with it will flip the signal (making the item behave like a switch). When disabled, the item will simply send out a signal when interacted with.</sp.controller.istoggle.description>
+<eventtext.clownrelations1.c1>Someone has left a toolbelt in the middle of the hallway.</eventtext.clownrelations1.c1>
+<eventtext.clownrelations1.o1.c1>The toolbelt contains bike horns, masks and oversized shoes. As you’re rummaging through it, a posse of people dressed in clown suits march down the hallway. One of them walks straight up to the belt, picks it up and stares at you, then at your hand. You realize you’re still holding a bike horn.</eventtext.clownrelations1.o1.c1>
+<eventtext.clownrelations1.o1.o1>Apologize and put the horn back in the toolbelt.</eventtext.clownrelations1.o1.o1>
+<submarine.description.camel>Easily identified by its two humps, the CML (Cargo &amp; Medical Logistics) submarine is best known as the Camel. The Camel has an extensive medic bay and ample cargo space, but it handles flooding poorly. The front ballast tank is a liability, and some less-liked crewmembers may have found an untimely death in an "accident" there. Trivia: The two humps are welded to the submarine during missions, but they can still be detached relatively easily when needed to supply heavier equipment to stations.</submarine.description.camel>
+
+<!-- New values September 18 -->
+
+<missionmessage0.scanruin>Mission accomplished: The ruins are successfully scanned.</missionmessage0.scanruin>
+<missiondescription.scanruin>To further their research, a group of scientists in [location1] have asked you to scan the nearby ruin. Venture into the ruin and scan the marked rooms using the provided scanners.</missiondescription.scanruin>
+<connection.disableoutput>disable_output</connection.disableoutput>
+<connection.activateout>activate_out</connection.activateout>
+<sp.door.ToggleWhenClicked>Toggle when clicked</sp.door.ToggleWhenClicked>
+<sp.door.ToggleWhenClicked.description>If the door has integrated buttons, should clicking on it perform the default action of opening the door? Can be used in conjunction with the "activate_out" output to pass a signal to a circuit without toggling the door when someone tries to open or close it.</sp.door.ToggleWhenClicked.description>
+<sortitemsalphabetically>Sort alphabetically</sortitemsalphabetically>
+<mergeitemstacks>Merge stacks</mergeitemstacks>
+<sp.controller.output.description>The signal sent when the controller is being activated or toggled on. If empty, no signal is sent.</sp.controller.output.description>
+<sp.controller.falseoutput.description>The signal sent when the controller is toggled off. If empty, no signal is sent. Only valid if IsToggle is true.</sp.controller.falseoutput.description>
+<entityname.dirtybomb_showofstrength>Modified Dirty Bomb</entityname.dirtybomb_showofstrength>
+<entitydescription.dirtybomb_showofstrength>An especially dirty bomb built for nefarious purposes.</entitydescription.dirtybomb_showofstrength>
+<fabricationdescription.ammoboxrecycle>Any empty ammunition box.</fabricationdescription.ammoboxrecycle>
+<fabricationheader.ammoboxrecycle>Empty Ammunition Box</fabricationheader.ammoboxrecycle>
+<ellipsis>...</ellipsis>
+<campaignsavetransfer.timeout>Failed to start the campaign round (timed out while waiting for the latest campaign save from the server). This may be caused by a bad connection and/or an abnormally large save file.</campaignsavetransfer.timeout>
+<entityname.backpack>Backpack</entityname.backpack>
+<entitydescription.backpack>A bulky backpack that can hold a large amount of tools and supplies, at the cost of slightly impaired movement.</entitydescription.backpack>
+<talentname.bagitup>Bag It Up</talentname.bagitup>
+<hint.radiojammed>There's nothing but static coming out of your headset—someone might have activated a radio jammer somewhere.</hint.radiojammed>
+<radiojammedwarning>Radio jammed</radiojammedwarning>
+<sp.structure.castshadows.name>Cast Shadows</sp.structure.castshadows.name>
+<circuitboxnode.addercomponent>Adder</circuitboxnode.addercomponent>
+<circuitboxnode.andcomponent>And</circuitboxnode.andcomponent>
+<circuitboxnode.addercomponent>Adder</circuitboxnode.addercomponent>
+<circuitboxnode.orcomponent>Or</circuitboxnode.orcomponent>
+<circuitboxnode.notcomponent>Not</circuitboxnode.notcomponent>
+<circuitboxnode.relaycomponent>Relay</circuitboxnode.relaycomponent>
+<circuitboxnode.delaycomponent>Delay</circuitboxnode.delaycomponent>
+<circuitboxnode.equalscomponent>Equals</circuitboxnode.equalscomponent>
+<circuitboxnode.greatercomponent>Greater</circuitboxnode.greatercomponent>
+<circuitboxnode.colorcomponent>Color</circuitboxnode.colorcomponent>
+<circuitboxnode.subtractcomponent>Subtract</circuitboxnode.subtractcomponent>
+<circuitboxnode.multiplycomponent>Multiply</circuitboxnode.multiplycomponent>
+<circuitboxnode.dividecomponent>Divide</circuitboxnode.dividecomponent>
+<circuitboxnode.xorcomponent>Xor</circuitboxnode.xorcomponent>
+<circuitboxnode.memorycomponent>Memory</circuitboxnode.memorycomponent>
+<circuitboxnode.signalcheckcomponent>Signal Check</circuitboxnode.signalcheckcomponent>
+<circuitboxnode.regexcomponent>RegEx</circuitboxnode.regexcomponent>
+<circuitboxnode.oscillator>Oscillator</circuitboxnode.oscillator>
+<circuitboxnode.wificomponent>WiFi</circuitboxnode.wificomponent>
+<circuitboxnode.sincomponent>Sin</circuitboxnode.sincomponent>
+<circuitboxnode.coscomponent>Cos</circuitboxnode.coscomponent>
+<circuitboxnode.tancomponent>Tan</circuitboxnode.tancomponent>
+<circuitboxnode.asincomponent>Asin</circuitboxnode.asincomponent>
+<circuitboxnode.acoscomponent>Acos</circuitboxnode.acoscomponent>
+<circuitboxnode.atancomponent>Atan</circuitboxnode.atancomponent>
+<circuitboxnode.modulocomponent>Modulo</circuitboxnode.modulocomponent>
+<circuitboxnode.roundcomponent>Round</circuitboxnode.roundcomponent>
+<circuitboxnode.ceilcomponent>Ceiling</circuitboxnode.ceilcomponent>
+<circuitboxnode.floorcomponent>Floor</circuitboxnode.floorcomponent>
+<circuitboxnode.factorialcomponent>Factorial</circuitboxnode.factorialcomponent>
+<circuitboxnode.squarerootcomponent>Square Root</circuitboxnode.squarerootcomponent>
+<circuitboxnode.abscomponent>Absolute</circuitboxnode.abscomponent>
+<circuitboxnode.powcomponent>Exponentiation</circuitboxnode.powcomponent>
+<circuitboxnode.concatcomponent>Concatenation</circuitboxnode.concatcomponent>
+<entityname.circuitbox>Circuit Box</entityname.circuitbox>
+<entitydescription.circuitbox>Allows creating complex circuits in a compact and portable container.</entitydescription.circuitbox>
+<circuitboxuicomponentnotavailable>You need to have ‖color:gui.orange‖[item]‖end‖ or ‖color:gui.orange‖FPGA Circuit‖end‖ in your inventory to place this component.</circuitboxuicomponentnotavailable>
+<circuitboxsetting.resetview>Reset view</circuitboxsetting.resetview>
+<circuitboxsetting.find>Find...</circuitboxsetting.find>
+<circuitboxsettingdescription.resetview>Returns the camera to the center.</circuitboxsettingdescription.resetview>
+<circuitboxsetting.focusinput>Inputs</circuitboxsetting.focusinput>
+<circuitboxsettingdescription.focusinput>Teleports the camera to the circuit box inputs node.</circuitboxsettingdescription.focusinput>
+<circuitboxsetting.focusoutput>Outputs</circuitboxsetting.focusoutput>
+<circuitboxsettingdescription.focusoutput>Teleports the camera to the circuit box output node.</circuitboxsettingdescription.focusoutput>
+<circuitboxsetting.focuscircuits>Circuits</circuitboxsetting.focuscircuits>
+<circuitboxsettingdescription.focuscircuits>Teleports the camera to the nearest component node.</circuitboxsettingdescription.focuscircuits>
+
+<serverlog.traitors>Traitors</serverlog.traitors>
+<eventname.bakingstation>Baking Station</eventname.bakingstation>
+<EventText.bakingstation.c1>You are angry. Enraged, even. The constant stress of being confined to your metal coffin is taking its toll on you, and you know it. You have to take out that anger somewhere on something… The beacon station you're supposed to visit might have a nuclear reactor that could be overloaded, causing a huge explosion and radiation to harm those Jove-forsaken crawlers and mudraptors for a long time to come. Your hand stops shaking for the first time in days. You know now: It is what you have to do.</EventText.bakingstation.c1>
+<EventText.bakingstation.objective1>Cause a nuclear meltdown at the beacon station's nuclear reactor.</EventText.bakingstation.objective1>
+<EventText.bakingstation.objective2>The beacon station has been burnt to a crisp!</EventText.bakingstation.objective2>
+<EventText.bakingstation.objective3>No beacon station meltdown has been observed.</EventText.bakingstation.objective3>
+<traitorobjective.bakingstation.meltdown>Cause beacon station reactor meltdown</traitorobjective.bakingstation.meltdown>
+<eventname.cargotheft>Cargo Theft</eventname.cargotheft>
+<EventText.cargotheft.c1>Right before you entered the submarine through the station's airlock, you found a shady-looking figure standing in the shadows. He gave you a crooked smile, and said: “Your wallet looks awfully light after the shore leave, eh? Want to do something about that? You see, the cargo you're transporting… The recipients are very desperate for that cargo. They pay good money. Now, if that cargo arrives, they're no longer desperate, no longer paying good money. See where I am going with this? If some cargo were to go missing, it might profit both of us.”\n\nNow you're still wondering whether or not to take the money. It's dirty, but marks are marks.</EventText.cargotheft.c1>
+<EventText.cargotheft.objective1>Ensure at least half of the cargo that's part of the transport mission doesn't make it to the destination.</EventText.cargotheft.objective1>
+<EventText.cargotheft.c2>You've disposed of the cargo.</EventText.cargotheft.c2>
+<EventText.cargotheft.objective2>The cargo is no longer on the submarine. Looks like you're getting paid while your crew is getting played.</EventText.cargotheft.objective2>
+<EventText.cargotheft.objective3>To the dismay of your crew and the receiving party, the cargo was nowhere to be found.</EventText.cargotheft.objective3>
+<EventText.cargotheft.objective4>When the time came to unload the cargo, your crew found out most of the items were missing. The client is not pleased.</EventText.cargotheft.objective4>
+<EventText.cargotheft.objective5>You've failed to get rid of enough cargo.</EventText.cargotheft.objective5>
+<EventText.cargotheft.objective6>The cargo was found on board the submarine, despite a risk of betrayal.</EventText.cargotheft.objective6>
+<traitorobjective.cargotheft.missingcargo>Dispose of the cargo</traitorobjective.cargotheft.missingcargo>
+<eventname.miningsabotage>Mining Sabotage</eventname.miningsabotage>
+<EventText.miningsabotage.c1>A burly figure leans in the doorframe, blocking your way. You're already late, having just heard the call to get back to your submarine ASAP—what could he possibly want? He has a scowl on his face, but does not seem to be threatening you.\n\n“Hear me out,” he starts. “I oversee mining operations around here, and to put it frankly, your mining mission is going to cut into my profits. Not your problem, you could say, but I say: business opportunity. Cause a few malfunctions in your plasma cutters, and I'll see you're paid more than your mission's cut would be.”</EventText.miningsabotage.c1>
+<EventText.miningsabotage.objective1>Disrupt the mining efforts by swapping oxygen tanks in 50% of the plasma cutters for welding fuel tanks.</EventText.miningsabotage.objective1>
+<EventText.miningsabotage.c2>This should scare the crew off from future mining operations, which will make your employer happy.</EventText.miningsabotage.c2>
+<EventText.miningsabotage.objective2>The plasma cutters have been sabotaged. Fingers crossed that nobody actually dies.</EventText.miningsabotage.objective2>
+<EventText.miningsabotage.objective3>The sabotage has been carried out successfully.</EventText.miningsabotage.objective3>
+<EventText.miningsabotage.objective4>The sabotage did not meet the requirements.</EventText.miningsabotage.objective4>
+<traitorobjective.miningsabotage.swapobjective>Swap welding fuel tanks into 50% of the plasma cutters</traitorobjective.miningsabotage.swapobjective>
+<eventname.naturevsnurture>Nature vs. Nurture</eventname.naturevsnurture>
+<eventname.naturevsnurture_beacon>Nature vs. Nurture</eventname.naturevsnurture_beacon>
+<EventText.naturevsnurture.c1>In the latest edition of The Europan magazine, you read about a hot new craze: pet mudraptors. How cool would it be if you could hatch and train a mudraptor from birth to be your loyal ally? Your captain wouldn't dare refuse your requests for a pay raise after that. And it just so happens that you might have a perfect chance to get yourself a fresh mudraptor egg!</EventText.naturevsnurture.c1>
+<EventText.naturevsnurture.objective1>Obtain a mudraptor egg from the nest and bring it into the submarine.</EventText.naturevsnurture.objective1>
+<EventText.naturevsnurture_beacon.c1>In the latest edition of The Europan magazine, you read about a hot new craze: pet mudraptors. How cool would it be if you could hatch and train a mudraptor from birth to be your loyal ally? Your captain wouldn't dare refuse your requests for a pay raise after that. Now, it just so happens the beacon station here was destroyed by mudraptors, and they may have left an egg behind. You better volunteer to fix that station and find the egg!</EventText.naturevsnurture_beacon.c1>
+<EventText.naturevsnurture_beacon.objective1>Obtain a mudraptor egg from the beacon station and bring it into the submarine.</EventText.naturevsnurture_beacon.objective1>
+<EventText.naturevsnurture_beacon.c2>You found a mudraptor's egg! Now to sneak it back to the submarine unseen…</EventText.naturevsnurture_beacon.c2>
+<EventText.naturevsnurture_beacon.c3>You've obtained an egg. Better keep it safe for now.</EventText.naturevsnurture_beacon.c3>
+<EventText.naturevsnurture_beacon.objective2>A mudraptor egg has been brought to the submarine. Keep it safe from deconstructors.</EventText.naturevsnurture_beacon.objective2>
+<EventText.naturevsnurture_beacon.objective3>A mudraptor egg has been collected. Maybe it will hatch into a beautiful and loyal pet one day?</EventText.naturevsnurture_beacon.objective3>
+<EventText.naturevsnurture_beacon.objective4>A mudraptor egg has found its way onto the submarine.</EventText.naturevsnurture_beacon.objective4>
+<EventText.naturevsnurture_beacon.objective5>No mudraptor eggs have been brought and kept safe on the submarine.</EventText.naturevsnurture_beacon.objective5>
+<traitorobjective.naturevsnurture.findmudraptoregg>Find and obtain a mudraptor egg</traitorobjective.naturevsnurture.findmudraptoregg>
+<traitorobjective.naturevsnurture.obtainmudraptoregg>Bring a mudraptor egg to the submarine</traitorobjective.naturevsnurture.obtainmudraptoregg>
+<eventname.naturevsnurture2>Nature vs. Nurture – Part 2</eventname.naturevsnurture2>
+<EventText.naturevsnurture2.c1>A one-armed wretch of a man has sold you a guide titled “Mudraptor Pets 101.” It is far from professional—in fact it's all written on some crusty old bandages—but he insisted he has experience in raising mudraptors as pets.\n\nAccording to the guide, the first minutes after hatching are crucial. If they get a taste of human flesh during this period, they'll forever crave more, so this should be avoided at all costs.</EventText.naturevsnurture2.c1>
+<EventText.naturevsnurture2.objective1>You want to hatch a mudraptor and train it as a pet. According to the instructions, you need to inject a mudraptor egg with saline, wait until it hatches and then ensure the mudraptor lives long enough to really experience pet ownership. A mudraptor egg has already been stashed away in a loose vent.</EventText.naturevsnurture2.objective1>
+<EventText.naturevsnurture2.objective2>You've obtained the egg. Next step is to hatch it with [catalystitem] in a safe place.</EventText.naturevsnurture2.objective2>
+<EventText.naturevsnurture2.c2>The egg bulges and makes strange noises… You're about to become a parent!</EventText.naturevsnurture2.c2>
+<EventText.naturevsnurture2.c3>The egg has hatched! Keep the abyss-puppy alive for [time] minutes.</EventText.naturevsnurture2.c3>
+<EventText.naturevsnurture2.objective3>The egg has hatched. Now make sure the mudraptor hatchling doesn't get killed for [time] minutes.</EventText.naturevsnurture2.objective3>
+<EventText.naturevsnurture2.objective4>[time] seconds passed.</EventText.naturevsnurture2.objective4>
+<EventText.naturevsnurture2.objective5>Enough time has passed.</EventText.naturevsnurture2.objective5>
+<EventText.naturevsnurture2.objective6>Your mudraptor hatchling died. Bummer.</EventText.naturevsnurture2.objective6>
+<EventText.naturevsnurture2.c4>Your dream of having your own pet mudraptor was shot to pieces by the reality of Europa. It is an unforgiving moon, and weakness has no place here.</EventText.naturevsnurture2.c4>
+<EventText.naturevsnurture2.c5>You have followed the instructions to the letter, so the mudraptor should be trainable as an obedient pet now, right?</EventText.naturevsnurture2.c5>
+<EventText.naturevsnurture2.objective7>Your mudraptor hatchling has survived long enough. You feel proud of your accomplishment, no matter what happens next.</EventText.naturevsnurture2.objective7>
+<EventText.naturevsnurture2.objective8>Inject a mudraptor egg with saline, wait until it hatches and then ensure the baby mudraptor lives long enough to really experience pet ownership.</EventText.naturevsnurture2.objective8>
+<EventText.naturevsnurture2.objective9>The mudraptor hatchling lived as long as required.</EventText.naturevsnurture2.objective9>
+<EventText.naturevsnurture2.objective10>The mudraptor hatchling didn't live long enough.</EventText.naturevsnurture2.objective10>
+<traitorobjective.naturevsnurture2.retrieveegg>Retrieve the mudraptor egg from its hiding spot</traitorobjective.naturevsnurture2.retrieveegg>
+<traitorobjective.naturevsnurture2.hatchegg>Hatch the egg in a safe spot</traitorobjective.naturevsnurture2.hatchegg>
+<traitorobjective.naturevsnurture2.keepalive>Keep the hatchling alive</traitorobjective.naturevsnurture2.keepalive>
+<traitorobjective.naturevsnurture2.keepfrombiting>Keep the hatchling from biting</traitorobjective.naturevsnurture2.keepfrombiting>
+<eventname.adhominem>Ad Hominem</eventname.adhominem>
+<EventText.adhominem.c1>People often get more honest when under the influence of alcohol, and yesterday was no exception. Although your head is spinning and parts of the night are missing from memory, you remember the comments of one crewmember rubbing you the wrong way, and not just you. While you can't exactly recall who insulted whom, the drunk version of you left behind a note: “Codeword: [codeword].” Perhaps this will help with identifying like-minded folk?</EventText.adhominem.c1>
+<EventText.adhominem.c2>Some of your memory from last night is slowly returning—you seem to recall it was [victim] spewing vile words to multiple crewmates. Time to teach [victim] a little lesson on slander and smear campaigns.</EventText.adhominem.c2>
+<EventText.adhominem.objective1>Ensure the majority of crewmembers will accuse the target of being a traitor. With everyone's memories a bit hazy, only a co-conspirator might remember the name of the target. A note saying “Codeword: [codeword]” could help you.</EventText.adhominem.objective1>
+<EventText.adhominem.objective2>Your memory tells you [victim] is the one bad-mouthing other crewmembers. Let your fellow conspirators and the rest of the crew know they're not to be trusted. Use the codeword “[codeword]” to identify the co-conspirators.</EventText.adhominem.objective2>
+<EventText.adhominem.objective3>The reputation of the target has been successfully ruined.</EventText.adhominem.objective3>
+<EventText.adhominem.objective4>The crew did not agree the target was a traitor. Their reputation remains intact.</EventText.adhominem.objective4>
+<traitorobjective.adhominem.accuse>Get your target accused of being a traitor</traitorobjective.adhominem.accuse>
+<traitorobjective.adhominem.victimknown>Ensure people know who the target is</traitorobjective.adhominem.victimknown>
+<eventname.goblinhorde>Dungeons and Doomworms: Goblin Horde</eventname.goblinhorde>
+<EventText.goblinhorde.c1>“You step into the forest clearing…roll for initiative,” said the GM. The appropriately costumed party members looked at each other in concern.\n“Not again…” exclaimed the rogue. “A one…oh dear.”\n“Goblin children appear at the tree lines all around you, and their bows sing: ‘Thwang, thwang.’”</EventText.goblinhorde.c1>
+<EventText.goblinhorde.o1>Roll for dexterity at a disadvantage.</EventText.goblinhorde.o1>
+<EventText.goblinhorde.o1.c1>“Party-wiped by goblin children again,” sighed the warlock. “We need to grow stronger. We must understand our enemies and, to do that, think like our enemies.” And thus, a plan has formed: You will roleplay as goblins. Use the codeword “[codeword]” to identify fellow goblins.</EventText.goblinhorde.o1.c1>
+<EventText.goblinhorde.objective1>Roleplay as ballast goblins. Ensure all ballast tanks are painted green and all goblins are in a ballast tank. Use the codeword “[codeword]” to identify fellow goblins.</EventText.goblinhorde.objective1>
+<EventText.goblinhorde.c2>You've gained valuable insight into the psyche of a (ballast) goblin, which will surely prove to be invaluable the next time you encounter a horde of greenskins.</EventText.goblinhorde.c2>
+<EventText.goblinhorde.objective2>Roleplay as ballast goblins. Ensure all ballast tanks are painted green and all goblins are in a ballast tank.</EventText.goblinhorde.objective2>
+<EventText.goblinhorde.objective3>Goblins together smelly, but strong.</EventText.goblinhorde.objective3>
+<EventText.goblinhorde.objective4>The goblins were too green to accomplish their task (read: inexperienced).</EventText.goblinhorde.objective4>
+<traitorobjective.goblinhorde.green>Paint all ballast tanks green</traitorobjective.goblinhorde.green>
+<traitorobjective.goblinhorde.occupation>Occupy ballast tanks for five minutes straight</traitorobjective.goblinhorde.occupation>
+<traitorobjective.goblinhorde.occupation_start>Get every goblin in a ballast tank</traitorobjective.goblinhorde.occupation_start>
+<traitorobjective.goblinhorde.occupation_1min>One minute passed</traitorobjective.goblinhorde.occupation_1min>
+<traitorobjective.goblinhorde.occupation_2min>Two minutes passed</traitorobjective.goblinhorde.occupation_2min>
+<traitorobjective.goblinhorde.occupation_3min>Three minutes passed</traitorobjective.goblinhorde.occupation_3min>
+<traitorobjective.goblinhorde.occupation_4min>Four minutes passed</traitorobjective.goblinhorde.occupation_4min>
+<traitorobjective.goblinhorde.occupation_5min>Five minutes passed</traitorobjective.goblinhorde.occupation_5min>
+<eventname.partypreparations>Party Preparations</eventname.partypreparations>
+<EventText.partypreparations.c1>“How about we throw a heckin' big party?” one of you said.\n“Yeah!”someone replied. “But it's gotta be a surprise until we're ready.”\n“Let's call it ‘Project: [codeword],’” another anonymous voice on the terminal suggested. \n\nYou don't know who your fellow planners are, yet, but they're probably the coolest kids on the crew.</EventText.partypreparations.c1>
+<EventText.partypreparations.c2>As luck would have it, you have a banner that'd work perfectly as a party decoration. Designate the party room by attaching the banner on a wall.</EventText.partypreparations.c2>
+<EventText.partypreparations.objective1>Ensure that preparations for a big party, called “Project: [codeword],” are completed. Nobody should enter the designated party room until the preparations are complete. The party planners are anonymous, but mentioning [codeword] will help with coordinating the planning.</EventText.partypreparations.objective1>
+<EventText.partypreparations.objective2>Designate a party room using party decorations.</EventText.partypreparations.objective2>
+<EventText.partypreparations.c3>The party room has been designated. Now, time to find some drinks for the party. One can have booze without fun, but not the other way around, right? A bottle of ethanol per guest should do.</EventText.partypreparations.c3>
+<EventText.partypreparations.objective3>Gather enough ethanol in the party room to get everyone drunk.</EventText.partypreparations.objective3>
+<EventText.partypreparations.objective4>Ensure there's music by bringing an instrument to the party room. An instrument has been stashed in a loose vent, but any instrument will do.</EventText.partypreparations.objective4>
+<EventText.partypreparations.c4>The drinks have been taken care of, but we need music! Find an instrument of some sort and bring it to the party room. One instrument had been smuggled aboard and stashed in a loose vent somewhere, but any instrument will do.</EventText.partypreparations.c4>
+<EventText.partypreparations.objective5>Party lighting. There has to be suitable red-colored lighting. Red room rave!</EventText.partypreparations.objective5>
+<EventText.partypreparations.c5>Now we've got drinks and music, but how about some party lighting? Make the lighting in the party room red. Red room rave!</EventText.partypreparations.c5>
+<EventText.partypreparations.objective6>Everything's set up. Party hard!</EventText.partypreparations.objective6>
+<EventText.partypreparations.objective7>Best. Party. Ever.</EventText.partypreparations.objective7>
+<EventText.partypreparations.objective8>Worst. Party. Ever.</EventText.partypreparations.objective8>
+<traitorobjective.partypreparations.designateroom>Decorate a party room</traitorobjective.partypreparations.designateroom>
+<traitorobjective.partypreparations.secretprepare>Prepare the party in secret</traitorobjective.partypreparations.secretprepare>
+<traitorobjective.partypreparations.booze>Ethanol for every crewmember</traitorobjective.partypreparations.booze>
+<traitorobjective.partypreparations.instrument>One instrument present</traitorobjective.partypreparations.instrument>
+<traitorobjective.partypreparations.lighting>Red party lighting</traitorobjective.partypreparations.lighting>
+<eventname.murdermystery>Murder Mystery</eventname.murdermystery>
+<EventText.murdermystery.c1>“Well well well, it seems we have a murder mystery on our hands,” you mutter while looking at the mangled corpse of a crawler.\n“No we don't,” replied a crewmember. “Crawler lives don't count. We should murder an assistant or something, present the crew with a real murder mystery.”\n\nWhile it seems like a rather psychopathic thing to say, you do think giving the crew some relief from their dreary routines is worth sacrificing one crewmember. After all, a lack of motivation could get the entire crew killed.</EventText.murdermystery.c1>
+<EventText.murdermystery.c2>You are part of creating a murder mystery. To make the murder very mysterious, nobody knows the full details.\nThere are three accomplices, who are not known to each other. One knows the victim, one knows the murder weapon, and one knows which of the accomplices is supposed to do the murder.</EventText.murdermystery.c2>
+<EventText.murdermystery.objective1>Set up a murder mystery. Information about the mystery—the murderer, the victim, and the weapon—is split among three accomplices. The murderer is one of the accomplices. Use the codeword “[codeword]” to identify your accomplices.</EventText.murdermystery.objective1>
+<EventText.murdermystery.c3>You know who the murderer is: it's [murderer]. Use the codeword “[codeword]” to identify your accomplices.</EventText.murdermystery.c3>
+<EventText.murdermystery.c4>You know who the murder victim is: it's [victim]. Use the codeword “[codeword]” to identify your accomplices.</EventText.murdermystery.c4>
+<EventText.murdermystery.c5>You know the weapon to use: There's a special [weapon] hidden somewhere in the submarine. Use the codeword “[codeword]” to identify your accomplices.</EventText.murdermystery.c5>
+<EventText.murdermystery.c6>You've found the murder weapon.</EventText.murdermystery.c6>
+<EventText.murdermystery.objective2>A murder has been committed—now the crew can play detective and hopefully be not very good at it.</EventText.murdermystery.objective2>
+<EventText.murdermystery.c7>The victim has died, but wasn't killed with the correct murder weapon, by the correct murderer. The murder mystery has failed.</EventText.murdermystery.c7>
+<EventText.murdermystery.objective3>Set up a murder mystery. Information about the mystery—the murderer, the victim, and the weapon—is split among three accomplices. The identities of the accomplices are part of the mystery, but the murderer is one of them.</EventText.murdermystery.objective3>
+<EventText.murdermystery.objective4>The murder mystery was very mysterious indeed.</EventText.murdermystery.objective4>
+<EventText.murdermystery.objective5>Here's a clue: The murder mystery sucked.</EventText.murdermystery.objective5>
+<traitorobjective.murdermystery.killtarget>Kill the target</traitorobjective.murdermystery.killtarget>
+<traitorobjective.murdermystery.correctweapon>Using the designated weapon</traitorobjective.murdermystery.correctweapon>
+<traitorobjective.murdermystery.correctmurderer>By the designated murderer</traitorobjective.murdermystery.correctmurderer>
+<eventname.handcuffshortage>Handcuff Shortage</eventname.handcuffshortage>
+<EventText.handcuffshortage.c1>“The plebs have been growing unruly as of late, and we are lacking in certain peacekeeping tools. Perhaps for a reward, you could craft some on your submarine? You've probably got too many resources stockpiled, anyway—time to clear some of those cabinets.”</EventText.handcuffshortage.c1>
+<EventText.handcuffshortage.objective1>Use the fabricator to craft [number] handcuffs.</EventText.handcuffshortage.objective1>
+<EventText.handcuffshortage.c2>You have created enough handcuffs to resupply the Coalition.</EventText.handcuffshortage.c2>
+<EventText.handcuffshortage.objective2>There's enough newly crafted handcuffs. Now you need to ensure they reach their destination.</EventText.handcuffshortage.objective2>
+<EventText.handcuffshortage.objective3>The Coalition has been provided an ample supply of handcuffs.</EventText.handcuffshortage.objective3>
+<EventText.handcuffshortage.objective4>There weren't enough handcuffs aboard the submarine to meet the Coalition's needs.</EventText.handcuffshortage.objective4>
+<traitorobjective.handcuffshortage.create>Craft 8 handcuffs</traitorobjective.handcuffshortage.create>
+<eventname.compoundnowhere>Compound Nowhere</eventname.compoundnowhere>
+<EventText.compoundnowhere.c1>Just as you enter the submarine, your headset emits some static noises. When you're about to check whether or not it's damaged, you hear a voice: \n“Listen carefully. You're transporting high explosive materials to be used in a terrorist attack on civilians. Remember, the Coalition is kind to those who help us.”</EventText.compoundnowhere.c1>
+<EventText.compoundnowhere.objective1>Ensure the weapons from the Arms Delivery mission are no longer on the submarine when it docks.</EventText.compoundnowhere.objective1>
+<EventText.compoundnowhere.c2>You've disposed of the explosives.</EventText.compoundnowhere.c2>
+<EventText.compoundnowhere.objective2>The explosives have been disposed of. As long as they stay gone, the Coalition will be pleased.</EventText.compoundnowhere.objective2>
+<EventText.compoundnowhere.objective3>The explosives were delivered to the separatists.</EventText.compoundnowhere.objective3>
+<EventText.compoundnowhere.objective4>To the dismay of your crew and the separatists, the explosives were nowhere to be found.</EventText.compoundnowhere.objective4>
+<traitorobjective.compoundnowhere.missingcargo>Get rid of the explosives</traitorobjective.compoundnowhere.missingcargo>
+<eventname.vipbombing>Bomberman</eventname.vipbombing>
+<EventText.vipbombing.c1>“A certain activist you're transporting is actually responsible for the bombing of Dank Station. We want the separatist scum to know what it is like to be caught in the blast. It's the one with the fancy hat who calls himself a captain.”</EventText.vipbombing.c1>
+<EventText.vipbombing.objective1>Blow up the VIP you're escorting, an alleged separatist bomber, using a supplied detonator and C-4.</EventText.vipbombing.objective1>
+<EventText.vipbombing.objective2>First, find the detonator and C-4 in a loose vent.</EventText.vipbombing.objective2>
+<EventText.vipbombing.objective3>Detonate the C-4 near the VIP.</EventText.vipbombing.objective3>
+<EventText.vipbombing.objective4>Kaboom. Your task has been completed.</EventText.vipbombing.objective4>
+<EventText.vipbombing.objective5>Well shoot. The C-4 is gone, but the VIP wasn't caught in the blast.</EventText.vipbombing.objective5>
+<EventText.vipbombing.objective6>Blow up the alleged separatist bomber using a supplied detonator and C-4.</EventText.vipbombing.objective6>
+<EventText.vipbombing.objective7>The VIP was caught in the blast radius of an explosion.</EventText.vipbombing.objective7>
+<EventText.vipbombing.objective8>The VIP hasn't been harmed by explosives on their voyage.</EventText.vipbombing.objective8>
+<traitorobjective.vipbombing.find>Find the detonator and C-4</traitorobjective.vipbombing.find>
+<traitorobjective.vipbombing.detonate>Detonate the C-4 near the VIP</traitorobjective.vipbombing.detonate>
+<eventname.deadoralive>Dead or Alive</eventname.deadoralive>
+<EventText.deadoralive.c1>“We have strong suspicions [character] is actually the nefarious Sootman, although we have no evidence to back it up. We’ve put a big bounty on their head, dead or alive. Also, about that evidence… We'd like you to plant some.”</EventText.deadoralive.c1>
+<EventText.deadoralive.objective1>Incapacitate [character], then replace their ID card with the fabricated ID card belonging to the terrorist Sootman. To avoid facial recognition, mask the victim. Don't get caught.</EventText.deadoralive.objective1>
+<EventText.deadoralive.c2>Someone saw you plant the evidence! Your plan is foiled.</EventText.deadoralive.c2>
+<EventText.deadoralive.c3>The evidence is planted—now someone needs to discover it…</EventText.deadoralive.c3>
+<EventText.deadoralive.objective2>You have covertly planted the evidence—now "Sootman" just has to be found.</EventText.deadoralive.objective2>
+<EventText.deadoralive.c4>The evidence you've planted has been discovered!</EventText.deadoralive.c4>
+<EventText.deadoralive.objective3>The nefarious Sootman was found aboard your submarine, and you are the hero who took them out. Well done!</EventText.deadoralive.objective3>
+<EventText.deadoralive.c5>Looks like your "Sootman" is up and about again, and your ploy has been discovered.</EventText.deadoralive.c5>
+<EventText.deadoralive.objective4>The crewmate you disguised as Sootman has been resuscitated, and your ploy has been discovered.</EventText.deadoralive.objective4>
+<EventText.deadoralive.objective5>The terrorist Sootman was found as a part of your crew! No one was more surprised than "Sootman" themself.</EventText.deadoralive.objective5>
+<EventText.deadoralive.objective6>The requirements of the tasks were not met.</EventText.deadoralive.objective6>
+<traitorobjective.deadoralive.plantevidence>Plant Sootman's ID card and mask</traitorobjective.deadoralive.plantevidence>
+<traitorobjective.deadoralive.findbody>Make sure "Sootman" is found</traitorobjective.deadoralive.findbody>
+<eventname.undercover>Undercover</eventname.undercover>
+<EventText.undercover.c1>“Your crew is aiding the oppressors, another boot on the neck of the workers who risk their lives every day. Will you do what is right? All we need is [target]'s ID card…”</EventText.undercover.c1>
+<EventText.undercover.objective1>The Jovian separatists have some designs on [target]'s ID card. Find a way to obtain it.</EventText.undercover.objective1>
+<EventText.undercover.c2>You've taken a crewmember's ID card. The separatists seem to have a plan in mind for it.</EventText.undercover.c2>
+<EventText.undercover.objective2>You've obtained the ID card. Keep it on you until you make it to the station.</EventText.undercover.objective2>
+<EventText.undercover.objective3>The separatists have obtained a crewmember's ID card.</EventText.undercover.objective3>
+<EventText.undercover.objective4>The security of the crew remains uncompromised…for now.</EventText.undercover.objective4>
+<traitorobjective.undercover.obtainid>Obtain target's ID card</traitorobjective.undercover.obtainid>
+<eventname.armsinterception>Arms Interception</eventname.armsinterception>
+<EventText.armsinterception.c1>You find a wrinkly note in your pocket that you certainly didn't put there yourself. You unfold it and can barely make out the hastily written instructions: \n“You know those weapons you're transporting are going to harm good people—get rid of them and we'll see you're rewarded.”</EventText.armsinterception.c1>
+<EventText.armsinterception.objective1>Ensure the weapons of the Arms Delivery mission are no longer on the submarine when docking.</EventText.armsinterception.objective1>
+<EventText.armsinterception.c2>You've disposed of the weapons.</EventText.armsinterception.c2>
+<EventText.armsinterception.objective2>The weapons are no longer on the submarine, and the separatists will be pleased—assuming the weapons stay gone.</EventText.armsinterception.objective2>
+<EventText.armsinterception.objective3>The weapons were delivered to the Coalition.</EventText.armsinterception.objective3>
+<EventText.armsinterception.objective4>To the dismay of your crew and the Coalition, the weapons were nowhere to be found.</EventText.armsinterception.objective4>
+<traitorobjective.armsinterception.missingcargo>Get rid of the weapons</traitorobjective.armsinterception.missingcargo>
+<eventname.vippoison>Taste of Their Own Medicine</eventname.vippoison>
+<EventText.vippoison.c1>“You know when the Coalition says you are transporting ‘a highly esteemed medical expert,’ they mean someone who does horrible experiments on anyone disagreeing with them, right?” The separatist recruiter sounded convincing and gave plenty of evidence of a certain Dr. Happy, to boot. Now they asked you to give the VIP a taste of their own medicine. Even if they survive, it will get the message across.</EventText.vippoison.c1>
+<EventText.vippoison.objective1>Poison the VIP using the supplied poison.</EventText.vippoison.objective1>
+<EventText.vippoison.objective2>Find the poison in a loose vent.</EventText.vippoison.objective2>
+<EventText.vippoison.objective3>Inject the VIP with the poison.</EventText.vippoison.objective3>
+<EventText.vippoison.objective4>Looks like VIP stands for “Very Injected with Poison” today. Task completed.</EventText.vippoison.objective4>
+<EventText.vippoison.objective5>The VIP has been poisoned.</EventText.vippoison.objective5>
+<EventText.vippoison.objective6>The VIP has not been poisoned.</EventText.vippoison.objective6>
+<traitorobjective.vippoison.findpoison>Find the poison in a hiding spot</traitorobjective.vippoison.findpoison>
+<traitorobjective.vippoison.injectpoison>Inject the VIP with the poison</traitorobjective.vippoison.injectpoison>
+<eventname.showofstrength>Show of Strength</eventname.showofstrength>
+<EventText.showofstrength.c1>While the comrades are unhappy that you have chosen to socialize with the ruling class, they are willing to look past this. You have been chosen as the executive muscle for a display of strength, cause and message. The separatist effort has tasked Blind Jim to stash necessary tools inside your vessel. Retrieve the stash and separate the bourgeoisie snakehead from its body, or whatever the missive suggests.</EventText.showofstrength.c1>
+<EventText.showofstrength.objective1>The task is to remove the “head of the snake.” You imagine blowing up the person steering this vessel would symbolically fit the objective.</EventText.showofstrength.objective1>
+<EventText.showofstrength.objective2>Find the hidden stash in a loose vent.</EventText.showofstrength.objective2>
+<EventText.showofstrength.c2>You rummage through the container but find nothing. Maybe you've been discovered, or maybe the stash is in a different location?</EventText.showofstrength.c2>
+<EventText.showofstrength.objective3>You've found the bomb. Now, blow up the person steering the vessel.</EventText.showofstrength.objective3>
+<EventText.showofstrength.c3>The command room has been bombed!</EventText.showofstrength.c3>
+<EventText.showofstrength.c4>Blowing up the command room failed.</EventText.showofstrength.c4>
+<EventText.showofstrength.objective4>The command room was not bombed.</EventText.showofstrength.objective4>
+<traitorobjective.showofstrength.findstash>Find the hidden stash</traitorobjective.showofstrength.findstash>
+<traitorobjective.showofstrength.blownavterminal>Blow up the crew at the navigation terminal</traitorobjective.showofstrength.blownavterminal>
+<eventname.deepdiverducks>Deepdiver Ducks</eventname.deepdiverducks>
+<EventText.deepdiverducks.c1>You find a handkerchief with drawings and incoherent scribbling. Writing runs along the edges: “You know what's funny? Rubber ducks. What's even funnier is rubber ducks filled with lead so that they sink instead of float. We need prototypes. Get to it. Now that's funny.”</EventText.deepdiverducks.c1>
+<EventText.deepdiverducks.objective1>Use the fabricator to craft [number] Deepdiver Ducks.</EventText.deepdiverducks.objective1>
+<EventText.deepdiverducks.c2>You have created 7 prototype ducks as requested. They're magnificent.</EventText.deepdiverducks.c2>
+<EventText.deepdiverducks.objective2>There's enough Deepdiver Duck prototypes—now you need to ensure they survive the rest of the voyage.</EventText.deepdiverducks.objective2>
+<EventText.deepdiverducks.objective3>The Children of the Honkmother have prototyped a new Deepdiver Duck. The purpose is unknown, but it's full of potential nonetheless.</EventText.deepdiverducks.objective3>
+<EventText.deepdiverducks.objective4>The Children of the Honkmother's attempts at prototyping Deepdiver Ducks have failed.</EventText.deepdiverducks.objective4>
+<traitorobjective.deepdiverducks.create>Craft 7 Deepdiver Ducks</traitorobjective.deepdiverducks.create>
+<eventname.theduffelbag>The Duffel Bag</eventname.theduffelbag>
+<EventText.theduffelbag.c1>You find a note in your pocket.\n\n“The Con-sortium of Very Important Deliveries has chosen you to deliver a very important item to your destination. The item is a seemingly normal (but in reality, a very important) duffel bag, hidden somewhere in your submarine. It is very important that you do not let anyone look inside the bag until it's reached its destination.”</EventText.theduffelbag.c1>
+<EventText.theduffelbag.objective1>Deliver a duffel bag to your destination. For some reason, nobody is supposed to look inside the bag.</EventText.theduffelbag.objective1>
+<EventText.theduffelbag.c2>This seems to be the bag the note talked about. Now I'll just need to make sure no one looks inside it…?</EventText.theduffelbag.c2>
+<EventText.theduffelbag.objective2>You've found the bag. Make sure no one looks inside it.</EventText.theduffelbag.objective2>
+<EventText.theduffelbag.c3>Oh no! Someone looked inside the bag.</EventText.theduffelbag.c3>
+<EventText.theduffelbag.objective3>Someone looked inside the bag. The Con-sortium of Very Important Deliveries must be very disappointed in you.</EventText.theduffelbag.objective3>
+<EventText.theduffelbag.objective4>Nobody has looked into the bag. The Con-sortium of Very Important Deliveries is likely to be pleased.</EventText.theduffelbag.objective4>
+<EventText.theduffelbag.objective5>Tossing the duffel bag out of the submarine wasn't exactly the Con-sortium of Very Important Deliveries' plan, although they appreciate the creative thinking.</EventText.theduffelbag.objective5>
+<EventText.theduffelbag.objective6>Someone looked into the bag.</EventText.theduffelbag.objective6>
+<traitorobjective.theduffelbag.findduffelbag>Find the duffel bag</traitorobjective.theduffelbag.findduffelbag>
+<traitorobjective.theduffelbag.dontlookduffelbag>Do not let anyone look inside the bag</traitorobjective.theduffelbag.dontlookduffelbag>
+<eventname.theduffelbagbomb>2 Duffel 2 Bag</eventname.theduffelbagbomb>
+<EventText.theduffelbagbomb.c1>You find a note in your pocket.\n\n“The Con-sortium of Very Important Deliveries has chosen you, yet again, to deliver a very important item to your destination. Plot twist, though! You do want people to take a peek inside it this time.”</EventText.theduffelbagbomb.c1>
+<EventText.theduffelbagbomb.objective1>The clowns have tasked you to deliver yet another duffel bag to your destination. This time it's booby trapped with a time bomb and needs to be found as quickly as possible.</EventText.theduffelbagbomb.objective1>
+<EventText.theduffelbagbomb.c2>This seems to be the bag the note talked about. Now to make sure it's discovered…</EventText.theduffelbagbomb.c2>
+<EventText.theduffelbagbomb.objective2>You've found the bag. Make sure someone discovers it.</EventText.theduffelbagbomb.objective2>
+<EventText.theduffelbagbomb.c3>Someone looked inside the bag, and the time bomb has been activated! …All according to plan? Now it should probably be kept from killing everyone on board, but your task is complete regardless.</EventText.theduffelbagbomb.c3>
+<EventText.theduffelbagbomb.objective3>Someone looked inside the bag. The time bomb has been activated—now it should preferably be kept from killing everyone. Regardless though, your task is complete.</EventText.theduffelbagbomb.objective3>
+<EventText.theduffelbagbomb.c4>Someone was wise enough to just toss the bomb out of the submarine. Time to leave the blast area.</EventText.theduffelbagbomb.c4>
+<EventText.theduffelbagbomb.c5>A ticking time bomb was tossed out of the submarine.</EventText.theduffelbagbomb.c5>
+<EventText.theduffelbagbomb.objective4>The bomb was found and chaos ensued.</EventText.theduffelbagbomb.objective4>
+<traitorobjective.theduffelbagbomb.find>Enjoy your duffel bag</traitorobjective.theduffelbagbomb.find>
+<traitorobjective.theduffelbagbomb.ticktick>Tick tick tick</traitorobjective.theduffelbagbomb.ticktick>
+<eventname.theduffelbagbomb2>Duffel Bag: Turku Drift</eventname.theduffelbagbomb2>
+<EventText.theduffelbagbomb2.c1>You find a note in your pocket.\n\n“The Con-sortium of Very Important Deliveries has chosen you to—well, you know the drill. Do they look inside? Do they not look inside? You'll figure it out.”</EventText.theduffelbagbomb2.c1>
+<EventText.theduffelbagbomb2.objective1>The clowns have tasked you to deliver another explosive duffel bag to your destination. No further instructions have been given, so the plan requires some improvisation.</EventText.theduffelbagbomb2.objective1>
+<EventText.theduffelbagbomb2.c2>This seems to be the bag the note talked about. Now what…? Inside, there appears to be a battery-powered bomb.</EventText.theduffelbagbomb2.c2>
+<EventText.theduffelbagbomb2.objective2>You've found the bag. It has a battery-powered bomb inside it.</EventText.theduffelbagbomb2.objective2>
+<EventText.theduffelbagbomb2.c3>Someone looked inside the bag and the time bomb has been activated.</EventText.theduffelbagbomb2.c3>
+<EventText.theduffelbagbomb2.objective3>Someone looked inside the bag. The time bomb has been activated.</EventText.theduffelbagbomb2.objective3>
+<EventText.theduffelbagbomb2.c4>Tick tick tick. You hear some very ominous ticking aboard the submarine. Better check it out.</EventText.theduffelbagbomb2.c4>
+<EventText.theduffelbagbomb2.c5>The bomb's inner workings could be accessed by equipping the bomb and a screwdriver.</EventText.theduffelbagbomb2.c5>
+<EventText.theduffelbagbomb2.c6>Bomb defusal progress is being made. Should I tell them to cut the red wire as a joke?</EventText.theduffelbagbomb2.c6>
+<EventText.theduffelbagbomb2.c7>The bomb's wires are exposed. Someone skilled in explosives or weapons manufacturing and equipped with a sharp tool could disarm it.</EventText.theduffelbagbomb2.c7>
+<EventText.theduffelbagbomb2.c8>Crisis averted—the bomb has been defused.</EventText.theduffelbagbomb2.c8>
+<EventText.theduffelbagbomb2.objective4>Phew, the bomb has been defused.</EventText.theduffelbagbomb2.objective4>
+<EventText.theduffelbagbomb2.objective5>Someone incompetent is cutting wires on the bomb. Your clown friends would love to hear about this.</EventText.theduffelbagbomb2.objective5>
+<EventText.theduffelbagbomb2.objective6>The bomb was found and more chaos ensued.</EventText.theduffelbagbomb2.objective6>
+<EventText.theduffelbagbomb2.objective7>The bomb was never found.</EventText.theduffelbagbomb2.objective7>
+<eventname.harbingerofhonks>Harbinger of Honks</eventname.harbingerofhonks>
+<eventtext.harbingerofhonks.intro>“Honk…” A pause. “Honk…” Closer this time. The Honkmother is calling. And furthermore, she's calling you! The message is clear: Go honk or go home.</eventtext.harbingerofhonks.intro>
+<eventtext.harbingerofhonks.stayhidden>They saw me honking, but I should honk unseen. I need to avoid further suspicion.</eventtext.harbingerofhonks.stayhidden>
+<eventtext.harbingerofhonks.objective>Honk a bike horn in [halfHulls] rooms unseen. Hide a bike horn in at least [halfCabinets] supplies cabinets.</eventtext.harbingerofhonks.objective>
+<EventText.harbingerofhonks.objective1>Someone saw me honk. Not ideal.</EventText.harbingerofhonks.objective1>
+<EventText.harbingerofhonks.objective2>Honk.</EventText.harbingerofhonks.objective2>
+<EventText.harbingerofhonks.objective3>Honk. Halfway there…</EventText.harbingerofhonks.objective3>
+<EventText.harbingerofhonks.objective4>Honk. Just a few more rooms…</EventText.harbingerofhonks.objective4>
+<EventText.harbingerofhonks.c1>The call of the Honkmother has undoubtedly been heard by now. Time for the next step.</EventText.harbingerofhonks.c1>
+<EventText.harbingerofhonks.objective5>The call of the Honkmother has been heard. Once [halfCabinets] of the supplies cabinets are stocked with bike horns, the call shall be heard again.</EventText.harbingerofhonks.objective5>
+<EventText.harbingerofhonks.objective6>You've placed half the bike horns. Good progress!</EventText.harbingerofhonks.objective6>
+<EventText.harbingerofhonks.c2>Your job as the Harbinger of Honks has been completed.</EventText.harbingerofhonks.c2>
+<EventText.harbingerofhonks.objective7>You have earned some rest, having set the honks onto a path of inevitability.</EventText.harbingerofhonks.objective7>
+<EventText.harbingerofhonks.objective8>A job well done.</EventText.harbingerofhonks.objective8>
+<EventText.harbingerofhonks.objective9>The honkin' objectives were completed.</EventText.harbingerofhonks.objective9>
+<EventText.harbingerofhonks.objective10>The honkin' objectives were not completed.</EventText.harbingerofhonks.objective10>
+<traitorobjective.harbingerofhonks.honk>Honk a bike horn in various rooms</traitorobjective.harbingerofhonks.honk>
+<traitorobjective.harbingerofhonks.hide>Hide a bike horn in supplies cabinets</traitorobjective.harbingerofhonks.hide>
+<eventname.divinelabor>Divine Labor</eventname.divinelabor>
+<EventText.divinelabor.c1>There was an addendum in the monthly issue of Beacon: “Hard times are upon the Church of Husk. We require aluminum to make a batch of commemorative Velonaceps calyx figurines, but the coffers run dry. All the faithful are called upon to create figures according to their means.”</EventText.divinelabor.c1>
+<EventText.divinelabor.objective1>Use the fabricator to craft [number] husk figurines.</EventText.divinelabor.objective1>
+<EventText.divinelabor.c2>You have devotedly created 10 husk figurines and you're sad to have to part with them.</EventText.divinelabor.c2>
+<EventText.divinelabor.objective2>There's enough husk figurines—now you need to ensure they make it to the end of this voyage.</EventText.divinelabor.objective2>
+<EventText.divinelabor.objective3>The Church of Husk's hard times may soon be over, now that they've been supplied with finely crafted Velonaceps calyx figurines.</EventText.divinelabor.objective3>
+<EventText.divinelabor.objective4>The Church of Husk's struggles know no end. They're lacking both volunteers for communion and Velonaceps calyx figurines.</EventText.divinelabor.objective4>
+<traitorobjective.divinelabor.create>Craft 10 husk figurines</traitorobjective.divinelabor.create>
+<eventname.faultyrobes>Faulty Robes</eventname.faultyrobes>
+<EventText.faultyrobes.c1>A recent mishap at a Church of Husk initiation rite left the church feeling rather embarrassed. Some of their robes didn't do their intended job of masking the wearer from the husks. Not a good showing for potential recruits, as those wearing the faulty robes got torn to pieces or taken over. Now they're offering a reward for anyone willing to test out the faulty batch.\n\nAll you have to do is get your crew to wear the robes amidst a large group of husks. It may be difficult to convince them to participate—better wait for the husks to board so the crew is more willing to try out the robes.</EventText.faultyrobes.c1>
+<EventText.faultyrobes.objective1>Some Church of Husk robes didn't do their intended job of masking their wearers from the husks. Test which robes are functional and which are faulty by exposing them to the husks—the husks won't attack someone wearing functional robes. Once your tests are complete, get rid of the faulty robes.</EventText.faultyrobes.objective1>
+<EventText.faultyrobes.objective2>Find the robes and the husk caller.</EventText.faultyrobes.objective2>
+<EventText.faultyrobes.objective3>Use the husk caller and test the robes.</EventText.faultyrobes.objective3>
+<EventText.faultyrobes.c2>You've found the supplies. You can use the husk caller to attract husks to your submarine.\n\nFind a way to test which of the robes prevent husks from attacking, and make sure you've gotten rid of the ones that don't before the submarine makes it to the destination.</EventText.faultyrobes.c2>
+<EventText.faultyrobes.objective4>Husks have been called! Test the robes, then deconstruct or dump the faulty robes out of the submarine.</EventText.faultyrobes.objective4>
+<EventText.faultyrobes.objective5>The cultist robes have been sorted. The Church of Husk will be happy to receive their functional robes back.</EventText.faultyrobes.objective5>
+<EventText.faultyrobes.objective6>Although no faulty robes were returned to the Church of Husk, they didn't receive all the good robes, either. </EventText.faultyrobes.objective6>
+<EventText.faultyrobes.objective7>Some faulty robes were returned to the Church of Husk, which may cause a few unlucky sods to get bitten in the near future.</EventText.faultyrobes.objective7>
+<traitorobjective.faultyrobes.find>Find the robes and the husk caller</traitorobjective.faultyrobes.find>
+<traitorobjective.faultyrobes.huskcall>Use the husk caller</traitorobjective.faultyrobes.huskcall>
+<traitorobjective.faultyrobes.sorting>Dock with only functional robes on board</traitorobjective.faultyrobes.sorting>
+<eventname.bloodsamples>Blood Samples</eventname.bloodsamples>
+<EventText.bloodsamples.c1>You find a note in your pocket. “The Church would like to offer you an assignment. You may or may not believe in our cause, but this is strictly for research purposes.\n\nWe need blood samples from healthy individuals. Your crew would make excellent test subjects. We've hidden some blood sample vials in your sub; find and fill them, and we'll be sure to make it worth your while.”</EventText.bloodsamples.c1>
+<EventText.bloodsamples.objective1>Find the empty vials, then collect a blood sample from each crewmate.</EventText.bloodsamples.objective1>
+<EventText.bloodsamples.c2>You've found the vials. Now, they'll need some filling… First, inflict bleeding on a crewmate (in a preferably inconspicuous way), and then use the vial on the bleeding area to collect a sample.</EventText.bloodsamples.c2>
+<EventText.bloodsamples.c3>You've now collected blood samples from everyone. The Church of Husk will be pleased.</EventText.bloodsamples.c3>
+<EventText.bloodsamples.objective2>The traitor successfully collected the samples.</EventText.bloodsamples.objective2>
+<EventText.bloodsamples.objective3>Collecting the samples has failed.</EventText.bloodsamples.objective3>
+<traitorobjective.bloodsamples.find>Obtain the empty vials</traitorobjective.bloodsamples.find>
+<traitorobjective.bloodsamples.samples>Collect blood samples</traitorobjective.bloodsamples.samples>
+<eventname.bloodsamples2>Blood Samples – Part 2</eventname.bloodsamples2>
+<EventText.bloodsamples2.c1>“Research of the husk symbiote is progressing, but could be sped up if you ask me. The next experiment is dangerous but crucial for any significant breakthrough to occur. Your blood samples collection suggests [character] is the perfect candidate for symbiosis. It is up to you to convince them to voluntarily agree to the symbiosis, or just inject them against their will.”</EventText.bloodsamples2.c1>
+<EventText.bloodsamples2.objective1>Inject [character] with the provided Calyx extract. Blood tests suggested a good chance for symbiosis to occur.</EventText.bloodsamples2.objective1>
+<EventText.bloodsamples2.objective2>The test subject has been infected. Now we wait.</EventText.bloodsamples2.objective2>
+<EventText.bloodsamples2.c2>The husk is about to take over the test subject. Soon we will see if the researchers were correct. In any case, my mission has been completed.</EventText.bloodsamples2.c2>
+<EventText.bloodsamples2.objective3>The scientific experiment has concluded. The target was successfully infected.</EventText.bloodsamples2.objective3>
+<EventText.bloodsamples2.objective4>The experiment was never completed to the Church of Husk's satisfaction.</EventText.bloodsamples2.objective4>
+<traitorobjective.bloodsamples2.inject>Inject the target with Calyx extract</traitorobjective.bloodsamples2.inject>
+<traitorobjective.bloodsamples2.observe>Observe the husk infection's progress</traitorobjective.bloodsamples2.observe>
+<eventtext.traitorgeneric.success>You have succeeded in your mission.</eventtext.traitorgeneric.success>
+<eventtext.traitorgeneric.failure>You have failed your traitorous mission.</eventtext.traitorgeneric.failure>
+<nohiddencontainerswarning>There are no hidden containers (such as loose vents or panels) in the submarine. Certain traitor events require these to function properly.</nohiddencontainerswarning>
+<entityname.deepdiverduck>Deepdiver Duck</entityname.deepdiverduck>
+<entitydescription.deepdiverduck>Subverting expectations.</entitydescription.deepdiverduck>
+<entityname.huskfigurine>Husk Figurine</entityname.huskfigurine>
+<entitydescription.huskfigurine>A somewhat pleasant depiction of the Velonaceps calyx, made of aluminum.</entitydescription.huskfigurine>
+<entityname.huskcaller>Husk Caller</entityname.huskcaller>
+<entitydescription.huskcaller>An item of dubious origin that attracts a large swarm of husks when used.</entitydescription.huskcaller>
+<entityname.traitortimebomb>Ticking Time Bomb</entityname.traitortimebomb>
+<entitydescription.traitortimebomb>It looks like a nuke with a text display and some wires strapped to it.</entitydescription.traitortimebomb>
+<entityname.traitortimebomb2>Ticking Time Bomb (Exposed)</entityname.traitortimebomb2>
+<entitydescription.traitortimebomb2>It looks like a nuke with a text display and some wires strapped to it. Any water would probably trigger an explosion due to the exposed wires.</entitydescription.traitortimebomb2>
+<entityname.traitortimebomb3>Ticking Time Bomb (Powered)</entityname.traitortimebomb3>
+<entitydescription.traitortimebomb3>It looks like a nuke with a text display and some wires strapped to it. It is powered by a battery, which should be kept from running out.</entitydescription.traitortimebomb3>
+<entityname.partybanner>Party Banner</entityname.partybanner>
+<entityname.murderweapon>Murder Weapon</entityname.murderweapon>
+<entityname.bloodsamplevial>Blood Sample Vial</entityname.bloodsamplevial>
+<entitydescription.bloodsamplevial>Proper equipment for taking blood samples isn't something you usually find on subs, but it will work as long as the patient is bleeding. Getting the patient to bleed, however, is left as an exercise for the reader.</entitydescription.bloodsamplevial>
+<traitortimebomb.stage1>By equipping the bomb and a screwdriver, one could remove a panel.</traitortimebomb.stage1>
+<traitortimebomb.stage2>Wires are exposed. A skilled weapon-user could defuse this by equipping the bomb and a sharp tool like a knife.</traitortimebomb.stage2>
+<traitortimebomb.stage3>It looks like a nuke with a text display and some wires strapped to it. It has been defused.</traitortimebomb.stage3>
+<traitor.dangerlevelsetting>Maximum danger level</traitor.dangerlevelsetting>
+<traitor.dangerlevelsetting.tooltip>How dangerous the traitor objectives can be. If, for example, you're playing the campaign mode and don't want players to get assigned traitor objectives that would seriously harm the crew's progress, you might want to choose a low danger level.</traitor.dangerlevelsetting.tooltip>
+<traitor.dangerlevel>Danger level</traitor.dangerlevel>
+<traitor.dangerlevel.1>Harmless</traitor.dangerlevel.1>
+<traitor.dangerlevel.1.description>Nobody gets hurt.</traitor.dangerlevel.1.description>
+<traitor.dangerlevel.2>Dangerous</traitor.dangerlevel.2>
+<traitor.dangerlevel.2.description>Might result in injuries and/or damage to the submarine.</traitor.dangerlevel.2.description>
+<traitor.dangerlevel.3>Lethal</traitor.dangerlevel.3>
+<traitor.dangerlevel.3.description>High chance of causing injuries or even casualties.</traitor.dangerlevel.3.description>
+<traitor.probability>Traitor probability</traitor.probability>
+<traitor.probability.tooltip>The probability of some players getting assigned traitor objectives during a round.</traitor.probability.tooltip>
+<traitorobjective.codeword>Identify co-conspirators with the codeword</traitorobjective.codeword>
+<orderdialog.reporttraitor>Something suspicious is going on in [roomname]!</orderdialog.reporttraitor>
+<orderdialog.reporttraitor>I think we might have a traitor in [roomname]!</orderdialog.reporttraitor>
+<ordername.reporttraitor>Report Traitor</ordername.reporttraitor>
+<traitor.blamebutton>Suspect as traitor</traitor.blamebutton>
+<traitor.blamebutton.tooltip>At the end of the round, if the majority of players have correctly suspected the traitor, the traitor fails their objective and will not receive any rewards (such as getting to steal experience points or portions of the mission reward).</traitor.blamebutton.tooltip>
+<traitor.blamebutton.dialog>I think [name] might be trying to sabotage our mission…</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>I have a feeling [name] is a traitor…</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>Acting mighty suspicious there, [name]…</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>[name] is acting kinda sus, right crew? Right…?</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>What are you up to, [name]? Something is off…</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>Something is off about [name] today…</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>[name], you traitorous scum. I do not trust you!</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>What shady business have you gotten yourself into, [name]?</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>What nefarious plan is occupying you, [name]?</traitor.blamebutton.dialog>
+<traitor.blamebutton.dialog>[name] is not working toward our mission objective. Do they have some hidden agenda?</traitor.blamebutton.dialog>
+<traitor.blameresult>The crew suspected [name] as a traitor!</traitor.blameresult>
+<traitor.blameresult.correct.objectivesuccessful>The crew's suspicions were correct. Since the traitor was exposed, they will not receive any rewards from whoever assigned them the traitorous task, even though they successfully completed it.</traitor.blameresult.correct.objectivesuccessful>
+<traitor.blameresult.correct.objectivefailed>The crew's suspicions were correct. Luckily, the traitor failed to complete their task.</traitor.blameresult.correct.objectivefailed>
+<traitor.blameresult.failure>The crew's suspicions turned out to be incorrect, and the traitor may still be at large.</traitor.blameresult.failure>
+<traitor.blameresult.failure.penalty>The crew has received a fine of [money] marks for wasting the official's time with the false accusations.</traitor.blameresult.failure.penalty>
+<entityname.safeandsoundsecurity101>Officer Pérez's Safe and Sound Security 101</entityname.safeandsoundsecurity101>
+<entitydescription.safeandsoundsecurity101>An official set of guidelines for dealing with traitorous crewmates.</entitydescription.safeandsoundsecurity101>
+<securityofficer.traitor.guidelines>Officer Pérez's Safe and Sound Security 101\n\nHostile factions and individuals are known to offer submariners bribes or other compensation for committing unlawful acts. This is unfortunately so common that throwing every traitorous submariner out the airlock would be detrimental to the submarine fleets and the Europan labor force as a whole. The Code of Fair Disciplinary Actions provides guidelines for dealing with traitors or other troublesome crewmates in a just manner.\n\nLevel 1 Offenses:\nDescription: mostly harmless misdemeanors, "pranks," neglect of assigned duties. Acts that at most cause minor inconvenience to the rest of the crew.\nSuggested disciplinary actions: Notify the person of their misconduct and command them back to their duties. A baton or some other non-lethal tool may be used to accentuate the verbal commands. More severe disciplinary actions can be considered if the misconduct continues.\n\nLevel 2 Offenses:\nDescription: acts that may endanger the health of the crew or submarine, such as intentional mishandling of devices or substances.\nSuggested disciplinary actions: Similar to level 1 offenses, a simple disciplining can suffice, but depending on the misconduct security can deem it necessary to instead handcuff or detain the individual by other means\n\nLevel 3 Offenses:\nDescription: clearly hostile acts with the intention to cause severe injuries or the death of one or more crewmates.\nSuggested disciplinary actions: Disposing of the traitor as soon as possible is advised. The disposal should preferably be carried out in a humane way, but it is understandable if such means are not available or feasible for one reason or another.</securityofficer.traitor.guidelines>
+<entityname.idcardfakesootman>ID Card</entityname.idcardfakesootman>
+<entitydescription.idcardfakesootman>This belongs to Sootman, the notorious masked vigilante.</entitydescription.idcardfakesootman>
+<serversettingsskilllosspercentageondeath>Skill loss on death</serversettingsskilllosspercentageondeath>
+<serversettingsskilllosspercentageondeathtooltip>How much a character's skills drop toward their job's default skills when they die</serversettingsskilllosspercentageondeathtooltip>
+<hint.assignedastraitor>You have been assigned a traitor objective. If you complete the objective successfully, you'll be given a reward and potentially a more difficult (and dangerous) traitor objective later.</hint.assignedastraitor>
+<hint.assignedastraitor2>Be discreet! Others in the crew can vote on who they suspect to be a traitor, and if the majority of the crew suspects you, the objective will fail and you will receive no rewards.</hint.assignedastraitor2>
+<hint.traitorsonboard>There may be traitors in the crew. If a traitor completes their objective successfully, they might get to steal portions of the mission reward and experience points gained by the rest of the crew.</hint.traitorsonboard>
+<hint.traitorsonboard2>You can suspect someone as the traitor by clicking the traitor icon in the crew list. If most of the crew correctly suspects the traitor, the traitor's objective will fail and they will not receive any rewards. But if the suspicions fall on an innocent player, the crew will need to pay a fine.</hint.traitorsonboard2>
+<hint.repairingsabotageditem>Something's off here. The device seems to keep breaking down despite your attempts to repair it. Could someone have tampered with it in some way?</hint.repairingsabotageditem>
+<TraitorSettings>Traitor settings</TraitorSettings>
+<settings.campaigndisabled>These settings cannot be modified when a campaign is running.</settings.campaigndisabled>
+<traitor.codeword>Addiction</traitor.codeword>
+<traitor.codeword>Affliction</traitor.codeword>
+<traitor.codeword>Amidships</traitor.codeword>
+<traitor.codeword>Armory</traitor.codeword>
+<traitor.codeword>Attack</traitor.codeword>
+<traitor.codeword>Bandit</traitor.codeword>
+<traitor.codeword>Barotrauma</traitor.codeword>
+<traitor.codeword>Battery</traitor.codeword>
+<traitor.codeword>Bilge</traitor.codeword>
+<traitor.codeword>Bloody</traitor.codeword>
+<traitor.codeword>Blue wire</traitor.codeword>
+<traitor.codeword>Brick</traitor.codeword>
+<traitor.codeword>Cargo</traitor.codeword>
+<traitor.codeword>Charybdis</traitor.codeword>
+<traitor.codeword>Circuit</traitor.codeword>
+<traitor.codeword>Citizen</traitor.codeword>
+<traitor.codeword>Codeword</traitor.codeword>
+<traitor.codeword>Coffee</traitor.codeword>
+<traitor.codeword>Coffin</traitor.codeword>
+<traitor.codeword>Comrade</traitor.codeword>
+<traitor.codeword>Crabmen</traitor.codeword>
+<traitor.codeword>Cramped</traitor.codeword>
+<traitor.codeword>Crystal</traitor.codeword>
+<traitor.codeword>Distance</traitor.codeword>
+<traitor.codeword>Docking</traitor.codeword>
+<traitor.codeword>Endworm</traitor.codeword>
+<traitor.codeword>Energy</traitor.codeword>
+<traitor.codeword>Escort</traitor.codeword>
+<traitor.codeword>Excuse</traitor.codeword>
+<traitor.codeword>Family</traitor.codeword>
+<traitor.codeword>Firepower</traitor.codeword>
+<traitor.codeword>Flat</traitor.codeword>
+<traitor.codeword>Follow</traitor.codeword>
+<traitor.codeword>Goblin</traitor.codeword>
+<traitor.codeword>Great</traitor.codeword>
+<traitor.codeword>Grotesque</traitor.codeword>
+<traitor.codeword>Handsome</traitor.codeword>
+<traitor.codeword>Happy</traitor.codeword>
+<traitor.codeword>Hindrance</traitor.codeword>
+<traitor.codeword>Hospital</traitor.codeword>
+<traitor.codeword>Hungry</traitor.codeword>
+<traitor.codeword>Internal</traitor.codeword>
+<traitor.codeword>Jazz</traitor.codeword>
+<traitor.codeword>Joke</traitor.codeword>
+<traitor.codeword>Jupiter</traitor.codeword>
+<traitor.codeword>Kidding</traitor.codeword>
+<traitor.codeword>Labor union</traitor.codeword>
+<traitor.codeword>Latcher</traitor.codeword>
+<traitor.codeword>Manager</traitor.codeword>
+<traitor.codeword>Marine</traitor.codeword>
+<traitor.codeword>Mask</traitor.codeword>
+<traitor.codeword>Moneygrab</traitor.codeword>
+<traitor.codeword>Never</traitor.codeword>
+<traitor.codeword>Nobody</traitor.codeword>
+<traitor.codeword>Nose</traitor.codeword>
+<traitor.codeword>Officer</traitor.codeword>
+<traitor.codeword>Outrageous</traitor.codeword>
+<traitor.codeword>Oxygenite</traitor.codeword>
+<traitor.codeword>Periscope</traitor.codeword>
+<traitor.codeword>Ping</traitor.codeword>
+<traitor.codeword>Plenty of fish</traitor.codeword>
+<traitor.codeword>Powerful</traitor.codeword>
+<traitor.codeword>Quack</traitor.codeword>
+<traitor.codeword>Quality</traitor.codeword>
+<traitor.codeword>Quiet</traitor.codeword>
+<traitor.codeword>Radiation</traitor.codeword>
+<traitor.codeword>Rock</traitor.codeword>
+<traitor.codeword>Rotate</traitor.codeword>
+<traitor.codeword>Round</traitor.codeword>
+<traitor.codeword>Sabotage</traitor.codeword>
+<traitor.codeword>Salty</traitor.codeword>
+<traitor.codeword>Scheme</traitor.codeword>
+<traitor.codeword>Screw</traitor.codeword>
+<traitor.codeword>Seamen</traitor.codeword>
+<traitor.codeword>Shore</traitor.codeword>
+<traitor.codeword>Slipstream</traitor.codeword>
+<traitor.codeword>Spire</traitor.codeword>
+<traitor.codeword>Starboard</traitor.codeword>
+<traitor.codeword>Still</traitor.codeword>
+<traitor.codeword>Supercapacitor</traitor.codeword>
+<traitor.codeword>Tea</traitor.codeword>
+<traitor.codeword>Terminal</traitor.codeword>
+<traitor.codeword>Terrible</traitor.codeword>
+<traitor.codeword>Tides</traitor.codeword>
+<traitor.codeword>Treacherous</traitor.codeword>
+<traitor.codeword>Underwear</traitor.codeword>
+<traitor.codeword>Unlucky</traitor.codeword>
+<traitor.codeword>Uranus</traitor.codeword>
+<traitor.codeword>Visitor</traitor.codeword>
+<traitor.codeword>Vote</traitor.codeword>
+<traitor.codeword>Water</traitor.codeword>
+<traitor.codeword>Whereabouts</traitor.codeword>
+<traitor.codeword>Why</traitor.codeword>
+<traitor.codeword>Xeno</traitor.codeword>
+<traitor.codeword>Yellow</traitor.codeword>
+<traitor.codeword>Yesterday</traitor.codeword>
+<traitor.codeword>Young</traitor.codeword>
+<traitor.codeword>Zigzag</traitor.codeword>
+<traitor.codeword>Zinc</traitor.codeword>
+<traitor.codeword>Zoom</traitor.codeword>
+<traitor.codeword>Hundred</traitor.codeword>
+<radiojammer.transmit>Transmit</radiojammer.transmit>
+<entityname.radiojammer>Radio Jammer</entityname.radiojammer>
+<entitydescription.radiojammer>A portable, battery-powered device that temporarily blocks radio communications.</entitydescription.radiojammer>
+<PlayerHostedServer>Player-hosted server</PlayerHostedServer>
+<CheatsEnabledDescription>Cheat commands have been enabled on this server. You cannot get Achievements during this play session.</CheatsEnabledDescription>
+
+</infotexts>

--- a/Bombscare/FactionEvents.xml
+++ b/Bombscare/FactionEvents.xml
@@ -1,0 +1,2405 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RandomEvents>
+  <EventPrefabs>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                               Coalition                                   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="coalitionspecialhire1">
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="coalitionspecialhire1_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <ConversationAction text="eventtext.coalitionspecialhire1.announcement" eventsprite="NoticeBoard" />
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="ignatiusmay" targettag="ignatiusmay" allowduplicates="false" spawnlocation="Outpost" targetmoduletags="admin,adminmodule" />
+              <Label name="beginning" />
+              <CheckDataAction identifier="coalitionspecialhire1_declinedonce" condition="eq true">
+                <Failure>
+                  <TriggerAction target1tag="ignatiusmay" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="false" radius="300" />
+                  <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="true" />
+                  <!-- we haven't declined the offer before-->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.c1" eventsprite="oldman">
+                    <Option text="eventtext.coalitionspecialhire1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.c1">
+                        <Option text="eventtext.coalitionspecialhire1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.c1">
+                            <Option text="eventtext.coalitionspecialhire1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="ignatiusmay" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="coalitionspecialhire1_hired" value="true" />
+                              <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.separatistspecialhire2.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.o2.c1" />
+                              <SetDataAction identifier="coalitionspecialhire1_declinedonce" value="true" />
+                              <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+                <Success>
+                  <!-- we've declined before, show different dialog this time -->
+                  <TriggerAction target1tag="ignatiusmay" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" radius="300" />
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.repeat" eventsprite="oldman">
+                    <Option text="eventtext.separatistspecialhire2.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.o1.c1" />
+                      <NPCChangeTeamAction npctag="ignatiusmay" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="coalitionspecialhire1_hired" value="true" />
+                      <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                    </Option>
+                    <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                      <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                      <GoTo name="beginning" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="coalitionspecialhire2">
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="coalitionspecialhire2_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="auntdoris" targettag="auntdoris" allowduplicates="false" spawnlocation="Outpost" />
+              <Label name="beginning" />
+              <TriggerAction target1tag="auntdoris" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="true" />
+              <CheckDataAction identifier="coalitionspecialhire2_declinedonce" condition="eq true">
+                <Failure>
+                  <!-- we haven't declined the offer before-->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.c1">
+                    <Option text="eventtext.coalitionspecialhire2.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.c1">
+                        <Option text="eventtext.coalitionspecialhire2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.c1">
+                            <Option text="eventtext.coalitionspecialhire2.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="auntdoris" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="coalitionspecialhire2_hired" value="true" />
+                              <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.separatistspecialhire2.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.o2.c1" />
+                              <SetDataAction identifier="coalitionspecialhire2_declinedonce" value="true" />
+                              <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+                <Success>
+                  <!-- we've declined before, show different dialog this time -->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.repeat">
+                    <Option text="eventtext.separatistspecialhire2.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.o1.c1" />
+                      <NPCChangeTeamAction npctag="auntdoris" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="coalitionspecialhire2_hired" value="true" />
+                      <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                    </Option>
+                    <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                      <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                      <GoTo name="beginning" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <!--Bomb scare-->
+    <ScriptedEvent identifier="bombscare" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="security" spawnlocation="Outpost" />
+      <TriggerAction target1tag="player" target2tag="security" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.bombscare.c1" targettag="triggerer_player" eventsprite="BombScare1">
+        <Option text="EventText.bombscare.o1">
+          <ConversationAction text="EventText.bombscare.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.bombscare.o1.o1">
+              <ConversationAction text="EventText.bombscare.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.bombscare.o1.o1.o1">
+                  <ConversationAction text="EventText.bombscare.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <WaitAction time="13" />
+                  <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.c1" targettag="triggerer_player" eventsprite="BombScare2">
+                    <Option text="EventText.bombscare.o1.o1.o1.c1.o1">
+                      <SkillCheckAction requiredskill="electrical" requiredlevel="45" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="electrical" amount="10" targettag="triggerer_player" />
+                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1" targettag="triggerer_player" />
+                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1.c1" speakertag="security" targettag="triggerer_player" />
+                          <MoneyAction amount="500" />
+                          <ReputationAction targettype="Faction" identifier="coalition" increase="5" />
+                          <ReputationAction targettype="Faction" identifier="separatists" increase="-5" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c2" targettag="triggerer_player">
+                            <Option text="EventText.bombscare.o1.o1.o1.c1.o1.o1">
+                              <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.o1.c1" targettag="triggerer_player" />
+                              <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.o1.c1.c1" speakertag="security" targettag="triggerer_player" />
+                              <ReputationAction targettype="Faction" identifier="coalition" increase="5" />
+                              <ReputationAction targettype="Faction" identifier="separatists" increase="-5" />
+                            </Option>
+                          </ConversationAction>
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                    <Option text="EventText.generic.ignore">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.bombscare.o1.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--Nothing to see here-->
+    <ScriptedEvent identifier="nothingtoseehere" commonness="50">
+      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="oldwoman" targettag="nothingtoseehere_oldwoman" spawnlocation="Outpost" spawnpointtype="Path" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="nothingtoseehere_guard" spawnlocation="Outpost" spawnpointtype="Path" targetmoduletags="securitymodule" />
+      <TagAction criteria="player" tag="player" />
+      <NPCWaitAction npctag="oldwoman" wait="true" />
+      <NPCWaitAction npctag="securitynpc[faction]" wait="true" />
+      <TriggerAction target1tag="nothingtoseehere_oldwoman" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" />
+      <ConversationAction text="EventText.nothingtoseehere.c1" targettag="triggerer_player">
+        <Option text="EventText.nothingtoseehere.o1" endconversation="true">
+          <TagAction criteria="itemidentifier:opdeco_trashcan" tag="potentialtrashcan" submarinetype="outpost" />
+          <TriggerAction target1tag="potentialtrashcan" target2tag="triggerer_player" applytotarget1="selectedtrashcan" radius="100" waitforinteraction="true" />
+          <ConversationAction text="EventText.nothingtoseehere.o1.c1" targettag="triggerer_player" eventsprite="trashcan">
+            <Option text="EventText.nothingtoseehere.o1.o1">
+              <ConversationAction text="EventText.nothingtoseehere.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.generic.continue">
+                  <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <TriggerAction target1tag="nothingtoseehere_guard" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" />
+                  <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.c1" targettag="triggerer_player">
+                    <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1">
+                      <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1">
+                          <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1.c1" targettag="triggerer_player" endconversation="true"/>
+                          <MoneyAction amount="500" />
+                          <ReputationAction targettype="Faction" identifier="coalition" increase="5" />
+                        </Option>
+                        <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2">
+                          <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.c1" targettag="triggerer_player">
+                            <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1">
+                              <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.c1" targettag="triggerer_player">
+                                <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.o1" endconversation="true">
+                                  <MoneyAction amount="500" />
+                                  <ReputationAction targettype="Faction" identifier="coalition" increase="1" />
+                                </Option>
+                                <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.o2" endconversation="true">
+                                  <ReputationAction targettype="Faction" identifier="coalition" increase="-5" />
+                                  <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o2">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.generic.ignore">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 30">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <NPCWaitAction npctag="outpostmanager" wait="true" />
+          <ConversationAction text="EventText.missionevent_jailbreak_coalition.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Coalition">
+            <Option text="EventText.missionevent.pleasecontinue">
+              <!-- "please continue" -->
+              <ConversationAction text="EventText.missionevent_jailbreak_coalition.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Coalition" endconversation="true" />
+              <MissionAction missionidentifier="jailbreak_coalition" locationtype="City,Military" requiredfaction="separatists" minlocationdistance="1" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                          Jovian Separatists                               -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="separatistspecialhire1">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="separatistspecialhire1_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="victoriapetran" targettag="victoria" allowduplicates="false" spawnlocation="Outpost" />
+              <Label name="beginning" />
+              <TriggerAction target1tag="victoria" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="true" />
+              <CheckDataAction identifier="separatistspecialhire1_declinedonce" condition="eq true">
+                <Failure>
+                  <!-- we haven't declined the offer before-->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.c1" eventsprite="HeartOfGold">
+                    <Option text="eventtext.separatistspecialhire1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.c1">
+                        <Option text="eventtext.separatistspecialhire1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.c1">
+                            <Option text="eventtext.separatistspecialhire1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="victoria" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="separatistspecialhire1_hired" value="true" />
+                              <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.separatistspecialhire1.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.o2.c1" />
+                              <SetDataAction identifier="separatistspecialhire1_declinedonce" value="true" />
+                              <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+                <Success>
+                  <!-- we've declined before, show different dialog this time -->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.repeat" eventsprite="HeartOfGold">
+                    <Option text="eventtext.separatistspecialhire1.o1.o1.repeat">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.o1.c1" />
+                      <NPCChangeTeamAction npctag="victoria" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="separatistspecialhire1_hired" value="true" />
+                      <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                    </Option>
+                    <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                      <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                      <GoTo name="beginning" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="separatistspecialhire2">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="separatistspecialhire2_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <CheckDataAction identifier="sootman_freed" condition="eq true">
+                <Failure>
+                  <!-- don't allow hiring until jailbreak mission has been completed -->
+                </Failure>
+                <Success>
+                  <TagAction criteria="player" tag="player" />
+                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="sootman" targettag="sootman" allowduplicates="false" spawnlocation="Outpost" />
+                  <Label name="beginning" />
+                  <TriggerAction target1tag="sootman" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+                  <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="true" />
+                  <CheckDataAction identifier="separatistspecialhire2_declinedonce" condition="eq true">
+                    <Failure>
+                      <!-- we haven't declined the offer before-->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.c1">
+                        <Option text="eventtext.separatistspecialhire2.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.c1">
+                            <Option text="eventtext.separatistspecialhire2.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.c1">
+                                <Option text="eventtext.separatistspecialhire2.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.o1.c1" />
+                                  <NPCChangeTeamAction npctag="sootman" teamid="Team1" addtocrew="true" />
+                                  <SetDataAction identifier="separatistspecialhire2_hired" value="true" />
+                                  <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                                </Option>
+                                <Option text="eventtext.separatistspecialhire2.o1.o1.o2">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.o2.c1" />
+                                  <SetDataAction identifier="separatistspecialhire2_declinedonce" value="true" />
+                                  <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                                  <GoTo name="beginning" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Failure>
+                    <Success>
+                      <!-- we've declined before, show different dialog this time -->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.repeat">
+                        <Option text="eventtext.separatistspecialhire1.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.o1.c1" />
+                          <NPCChangeTeamAction npctag="sootman" teamid="Team1" addtocrew="true" />
+                          <SetDataAction identifier="separatistspecialhire2_hired" value="true" />
+                          <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                        </Option>
+                        <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                          <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                          <GoTo name="beginning" />
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                  </CheckDataAction>                  
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_tormsdalereport" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="tormsdalereport" condition="eq 0">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <NPCWaitAction npctag="outpostmanager" wait="true" />
+              <ConversationAction text="EventText.missionevent_tormsdalereport.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_tormsdalereport.whosthat">
+                  <ConversationAction text="EventText.missionevent_tormsdalereport.whospetran" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                    <Option text="EventText.missionevent_tormsdalereport.o1.o1">
+                      <Goto name="givemission" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.missionevent.pleasecontinue">
+                  <Goto name="givemission" />
+                </Option>
+              </ConversationAction>
+              <Label name="givemission" />
+              <ConversationAction text="EventText.missionevent_tormsdalereport.c1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_tormsdalereport.c1.o1">
+                  <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                    <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1">
+                      <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                        <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1">
+                          <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                            <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                                <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1.o1">
+                                  <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists" endconversation="true" />
+                                  <MissionAction missionidentifier="tormsdalereport" locationtype="City,Outpost,Military,Research,Mine" requiredfaction="coalition" minlocationdistance="2" CreateLocationIfNotFound="true" />
+                                  <NPCWaitAction npctag="outpostmanager" wait="false" />
+                                  <SetDataAction identifier="tormsdalereport" value="1" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="tormsdalereport_outpost">
+      <StatusEffectAction targettag="outpostmanager">
+        <!-- force the outpost manager to be killable (killing outpost NPCs might be disabled in MP) -->
+        <StatusEffect Unkillable="false" />
+      </StatusEffectAction>      
+      <ConversationAction text="EventText.tormsdalereport_outpost.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+        <Option text="EventText.tormsdalereport_outpost.o1">
+          <ConversationAction text="EventText.tormsdalereport_outpost.o1.c1" targettag="triggerer_player" endconversation="true" />
+        </Option>
+        <Option text="EventText.tormsdalereport_outpost.o2">
+          <ConversationAction text="EventText.tormsdalereport_outpost.o2.c1" targettag="triggerer_player" endconversation="true" />
+          <CombatAction combatmode="Offensive" npctag="outpostmanager" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.tormsdalereport_outpost.o3">
+          <ConversationAction text="EventText.tormsdalereport_outpost.o3.c1" targettag="triggerer_player" endconversation="true" />
+          <NPCFollowAction npctag="outpostmanager" targettag="triggerer_player" follow="true" />
+          <WaitAction time="60" />
+          <ConversationAction text="EventText.tormsdalereport_outpost.o3.c1.c1" targettag="triggerer_player" waitforinteraction="false" eventsprite="Separatists" />
+          <NPCFollowAction npctag="outpostmanager" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.tormsdalereport_outpost.o4" endconversation="true" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="tormsdalereport_complete">
+      <CheckDataAction identifier="tormsdalereport" condition="eq 2">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <Label name="beginning" />
+          <ConversationAction text="EventText.tormsdalereport_complete.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+            <Option text="EventText.tormsdalereport_complete.o1">
+              <CheckItemAction targettag="triggerer_player" itemidentifiers="tormsdalereport">
+                <Success>
+                  <ConversationAction text="EventText.tormsdalereport_complete.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <MoneyAction amount="5000" />
+                  <ReputationAction targettype="Faction" identifier="separatists" increase="10" />
+                  <ReputationAction targettype="Faction" identifier="coalition" increase="-10" />
+                  <SetDataAction identifier="tormsdalereport" value="3" />
+                  <RemoveItemAction targettag="triggerer_player" itemidentifier="tormsdalereport" />
+                </Success>
+                <Failure>
+                  <ConversationAction text="EventText.tormsdalereport_complete.o1.c2" targettag="triggerer_player" endconversation="true" />
+                  <GoTo name="beginning" />
+                </Failure>
+              </CheckItemAction>
+            </Option>
+            <Option text="EventText.tormsdalereport_complete.o2" endconversation="true">
+              <GoTo name="beginning" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <NPCWaitAction npctag="outpostmanager" wait="true" />
+          <ConversationAction text="EventText.missionevent_jailbreak_separatists.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+            <Option text="EventText.missionevent.pleasecontinue">
+              <!-- "please continue" -->
+              <ConversationAction text="EventText.missionevent_jailbreak_separatists.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists" endconversation="true" />
+              <MissionAction missionidentifier="jailbreak_separatists" locationtype="City,Military" requiredfaction="coalition" minlocationdistance="1" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_jailbreak_sootman" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 50">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="jailbreak_sootman_unlocked" condition="eq true">
+            <Success>
+              <!-- do nothing -->
+            </Success>
+            <Failure>
+              <NPCWaitAction npctag="outpostmanager" wait="true" />
+              <ConversationAction text="EventText.missionevent_jailbreak_sootman.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_tormsdalereport.whosthat">
+                  <!-- who's that? -->
+                  <ConversationAction text="EventText.missionevent_tormsdalereport.whospetran" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                    <Option text="EventText.missionevent_tormsdalereport.o1.o1">
+                      <!-- ok, what's the mission -->
+                      <Goto name="givemission" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.missionevent.pleasecontinue">
+                  <!-- we're interested -->
+                  <Goto name="givemission" />
+                </Option>
+              </ConversationAction>
+              <Label name="givemission" />
+              <ConversationAction text="EventText.missionevent_jailbreak_sootman.c1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_jailbreak_sootman.c1.o1">
+                  <ConversationAction text="EventText.missionevent_jailbreak_sootman.c1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1" />
+                  <MissionAction missionidentifier="jailbreak_sootman" locationtype="City,Military" requiredfaction="coalition" minlocationdistance="1" CreateLocationIfNotFound="true" />
+                  <SetDataAction identifier="jailbreak_sootman_unlocked" value="true" />
+                </Option>
+              </ConversationAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="jailbreak_sootman">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="humanprefabidentifier:sootman" tag="prisoner" />
+      <NPCWaitAction npctag="sootman" wait="true" />
+      <TriggerAction target1tag="sootman" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="50" waitforinteraction="false" />
+      <NPCFollowAction npctag="sootman" targettag="player" follow="true" />
+      <ConversationAction text="EventText.jailbreak_sootman.c1" targettag="triggerer_player" eventsprite="Separatists">
+        <Option text="EventText.jailbreak_sootman.o1">
+          <ConversationAction text="EventText.jailbreak_sootman.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.jailbreak_sootman.o1.o1">
+              <ConversationAction text="EventText.jailbreak_sootman.o1.o1.c1" targettag="triggerer_player" />
+              <NPCWaitAction npctag="sootman" wait="false" />
+              <NPCFollowAction npctag="sootman" targettag="outpostmanager" follow="true" />
+              <WaitAction time="30" />
+              <TriggerEventAction identifier="jailbreak_alarm" />
+              <GodModeAction targettag="sootman" enabled="true" />
+              <FireAction size="100" targettag="outpostmanager" />
+              <TagAction criteria="itemtag:command" submarinetype="Player" tag="commandroom" />
+              <!-- change team to give Sootman access to the sub -->
+              <NPCChangeTeamAction npctag="sootman" teamid="Team1" addtocrew="false" />
+              <NPCFollowAction npctag="sootman" targettag="commandroom" follow="true" />
+              <WaitAction time="120" />
+              <Label name="forcefollow" />
+              <CheckConditionalAction targettag="sootman" IsInPlayerSub="true">
+                <Failure>
+                  <!-- if not in the player sub within 2 minutes (messed up waypoints, no command room in the sub?) make the NPC follow the player -->
+                  <NPCFollowAction npctag="sootman" targettag="player" follow="true" />
+                  <WaitAction time="10" />
+                  <Goto name="forcefollow" />                  
+                </Failure>
+              </CheckConditionalAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="jailbreak">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="prisoner" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="50" waitforinteraction="false" />
+      <ConversationAction text="EventText.jailbreak.c1" targettag="triggerer_player" eventsprite="BombScare1" />
+      <TriggerEventAction identifier="jailbreak_alarm" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="jailbreak_alarm">
+      <!-- trigger alarm if any of the prisoners are close to security -->
+      <TriggerAction target1tag="prisoner" target2tag="securitynpc" applytotarget1="triggerer_prisoner" applytotarget2="triggerer_securitynpc" disableiftargetincapacitated="false" radius="200" waitforinteraction="false" />
+      <NPCFollowAction npctag="triggerer_prisoner" targettag="triggerer_securitynpc" follow="true" />
+      <WaitAction time="3" />
+      <TagAction criteria="itemtag:securityalarm" submarinetype="Outpost" tag="alarmbutton" />
+      <StatusEffectAction targettag="alarmbutton">
+        <StatusEffect State="true" />
+      </StatusEffectAction>
+      <ConversationAction text="EventText.jailbreak_alarm.c1" eventsprite="NoticeBoard" ContinueAutomatically="true" />
+      <NPCFollowAction npctag="triggerer_prisoner" targettag="triggerer_securitynpc" follow="false" />
+      <NPCChangeTeamAction npctag="securitynpc" teamid="Team2" />
+    </ScriptedEvent>
+    <!--"Separatist relations"
+    TODO:
+    -spawn correct npcs-->
+    <ScriptedEvent identifier="separatistrelations" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="vandal1" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="vandal2" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction itemidentifier="wrench" targetinventory="vandal1" />
+      <SpawnAction itemidentifier="screwdriver" targetinventory="vandal2" />
+      <NPCFollowAction npctag="vandal1" targettag="vandal2" follow="true" />
+      <TriggerAction target1tag="vandal1" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" />
+      <NPCWaitAction npctag="vandal1" wait="true" />
+      <NPCWaitAction npctag="vandal2" wait="true" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.c1" eventsprite="group" />
+          <ReputationAction targettype="Faction" identifier="separatists" increase="1" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.c2" eventsprite="group">
+            <Option text="EventText.separatistrelations.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.o1.c1" />
+              <ReputationAction targettype="Faction" identifier="separatists" increase="-2" />
+              <CombatAction combatmode="offensive" npctag="vandal1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+              <CombatAction combatmode="offensive" npctag="vandal2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+            </Option>
+            <Option text="EventText.separatistrelations.o2">
+              <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.o2.c1" />
+              <ReputationAction targettype="Faction" identifier="separatists" increase="2" />
+            </Option>
+            <Option text="EventText.separatistrelations.o3" />
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+      <NPCWaitAction npctag="vandal1" wait="false" />
+      <NPCWaitAction npctag="vandal2" wait="false" />
+    </ScriptedEvent>
+    <!--Stuck in the middle-->
+    <ScriptedEvent identifier="stuckinthemiddle" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="separatist1" targetmoduletags="airlock" spawnlocation="Outpost" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="separatist2" targetmoduletags="airlock" spawnlocation="Outpost" />
+      <NPCWaitAction npctag="separatist1" wait="true" />
+      <NPCWaitAction npctag="separatist2" wait="true" />
+      <TriggerAction target1tag="player" target2tag="separatist1" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.stuckinthemiddle.c1" targettag="triggerer_player">
+        <Option text="EventText.stuckinthemiddle.o1">
+          <ConversationAction text="EventText.stuckinthemiddle.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.stuckinthemiddle.o1.o1">
+              <ConversationAction text="EventText.stuckinthemiddle.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.stuckinthemiddle.o1.o1.o1">
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1" endconversation="true">
+                              <SetDataAction identifier="stuckinthemiddle_acceptedmission" value="true" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.stuckinthemiddle.o1.o1.o1.o2">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.stuckinthemiddle.o1.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+      <!--Conversation #2-->
+      <CheckDataAction identifier="stuckinthemiddle_acceptedmission" condition="eq true">
+        <Success>
+          <TriggerAction target1tag="triggerer_player" targetmoduletype="adminmodule" radius="100" />
+          <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1">
+              <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1">
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="separatist1" waitforinteraction="true" />
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1" targettag="triggerer_player" />
+                  <ReputationAction targettype="Faction" identifier="separatists" increase="3" />
+                </Option>
+                <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2">
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1" targettag="triggerer_player" endconversation="true" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="separatist1" waitforinteraction="true" />
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1.c1" targettag="triggerer_player" />
+                  <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                  <MoneyAction amount="500" />
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.generic.ignore">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Success>
+        <Failure>
+          <!--Do nothing-->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Terrorism 101-->
+    <ScriptedEvent identifier="terrorism101" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:op_vendingmachine1" tag="selectedvendingmachine" />
+      <TagAction criteria="itemidentifier:op_vendingmachine2" tag="selectedvendingmachine" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="terrorist" spawnpointtag="selectedvendingmachine" spawnlocation="Outpost" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="security" spawnlocation="Outpost" />
+      <NPCWaitAction npctag="terrorist" wait="true" />
+      <TriggerAction target1tag="player" target2tag="terrorist" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.terrorism101.c1" targettag="triggerer_player" eventsprite="Terrorism1">
+        <Option text="EventText.terrorism101.o1">
+          <ConversationAction text="EventText.terrorism101.o1.c1" targettag="triggerer_player" eventsprite="Terrorism2">
+            <Option text="EventText.terrorism101.o1.o1">
+              <ConversationAction text="EventText.terrorism101.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.terrorism101.o1.o1.o1">
+                  <ConversationAction text="EventText.terrorism101.excuse" targettag="triggerer_player">
+                    <Option text="EventText.terrorism101.abomb">
+                      <ConversationAction text="EventText.terrorism101.shh" targettag="triggerer_player">
+                        <Option text="EventText.terrorism101.help">
+                          <ConversationAction text="EventText.terrorism101.novice" targettag="triggerer_player">
+                            <Option text="EventText.terrorism101.armbomb">
+                              <ConversationAction text="EventText.terrorism101.bombarmed" targettag="triggerer_player" />
+                              <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                              <MoneyAction amount="250" />
+                            </Option>
+                            <Option text="EventText.terrorism101.dismantlebomb">
+                              <ConversationAction text="EventText.terrorism101.bombdismantled" targettag="triggerer_player" />
+                              <ReputationAction targettype="Faction" identifier="coalition" increase="3" />
+                              <MoneyAction amount="250" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.terrorism101.o1.o1.o1.o1.o2" endconversation="true">
+                          <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.terrorism101.o1.o1.o1.o2" endconversation="true">
+                      <CombatAction combatmode="arrest" npctag="security" enemytag="terrorist" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.terrorism101.o1.o1.o2">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.terrorism101.o1.o2">
+              <ConversationAction text="EventText.terrorism101.excuse" targettag="triggerer_player">
+                <Option text="EventText.terrorism101.abomb">
+                  <ConversationAction text="EventText.terrorism101.shh" targettag="triggerer_player">
+                    <Option text="EventText.terrorism101.help">
+                      <ConversationAction text="EventText.terrorism101.novice" targettag="triggerer_player">
+                        <Option text="EventText.terrorism101.armbomb">
+                          <ConversationAction text="EventText.terrorism101.bombarmed" targettag="triggerer_player" />
+                          <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                          <MoneyAction amount="250" />
+                        </Option>
+                        <Option text="EventText.terrorism101.dismantlebomb">
+                          <ConversationAction text="EventText.terrorism101.bombdismantled" targettag="triggerer_player" />
+                          <ReputationAction targettype="Faction" identifier="coalition" increase="3" />
+                          <MoneyAction amount="250" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.terrorism101.o1.o2.o1.o2" endconversation="true">
+                      <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.terrorism101.o1.o2.o2" endconversation="true">
+                  <CombatAction combatmode="arrest" npctag="security" enemytag="terrorist" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+      <NPCWaitAction npctag="terrorist" wait="false" />
+    </ScriptedEvent>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                          Church of the Husk                               -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="missionevent_escort1huskcult" commonness="100">
+      <ConversationAction text="EventText.missionevent_escort1huskcult.c1" speakertag="huskcultist" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonershuskcult" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargohuskcult" commonness="100">
+      <ConversationAction text="eventtext.missionevent_cargohuskcult" speakertag="huskcultist" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargohuskcult" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="huskcultspecialhire1">
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot start the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <!-- Can't be hired until rescued in the "Way to Ascension" chain -->
+          <CheckDataAction identifier="waytoascension" condition="gt 7">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <CheckReputationAction targettype="faction" identifier="huskcult" condition="gte 80">
+                <Failure>
+                  <!-- Do nothing -->
+                </Failure>
+                <Success>
+                  <CheckDataAction identifier="huskcultspecialhire1_hired" condition="eq true">
+                    <Success>
+                      <!--Don't repeat event if already hired-->
+                    </Success>
+                    <Failure>
+                      <TagAction criteria="player" tag="player" />
+                      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jacovsubra" targettag="jacovsubra" allowduplicates="false" targetmoduletags="huskmodule" spawnlocation="Outpost" />
+                      <Label name="beginning" />
+                      <TriggerAction target1tag="jacovsubra" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+                      <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="true" />
+                      <CheckDataAction identifier="huskcultspecialhire1_declinedonce" condition="eq true">
+                        <Failure>
+                          <!-- we haven't declined the offer before-->
+                          <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.c1" eventsprite="JacovSubra4">
+                            <Option text="eventtext.huskcultspecialhire1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.c1">
+                                <Option text="eventtext.huskcultspecialhire1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.c1">
+                                    <Option text="eventtext.huskcultspecialhire1.o1.o1.o1" endconversation="true">
+                                      <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.o1.c1" />
+                                      <NPCChangeTeamAction npctag="jacovsubra" teamid="Team1" addtocrew="true" />
+                                      <SetDataAction identifier="huskcultspecialhire1_hired" value="true" />
+                                      <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                                    </Option>
+                                    <Option text="eventtext.huskcultspecialhire1.o1.o1.o2" endconversation="true">
+                                      <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.o2.c1" />
+                                      <SetDataAction identifier="huskcultspecialhire1_declinedonce" value="true" />
+                                      <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                                      <GoTo name="beginning" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Failure>
+                        <Success>
+                          <!-- we've declined before, show different dialog this time -->
+                          <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.repeat" eventsprite="JacovSubra4">
+                            <Option text="eventtext.huskcultspecialhire1.o1.o1.repeat" endconversation="true">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="jacovsubra" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="huskcultspecialhire1_hired" value="true" />
+                              <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.huskcultspecialhire1.o1.o2.repeat" endconversation="true">
+                              <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Success>
+                      </CheckDataAction>
+                    </Failure>
+                  </CheckDataAction>
+                </Success>
+              </CheckReputationAction>
+            </Success>
+          </CheckDataAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--"Husk cult relations" -->
+    <ScriptedEvent identifier="huskcultrelations">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="huskcultist" target2tag="player" applytotarget1="targetcultist" applytotarget2="triggerer_player" radius="250" waitforinteraction="true" />
+      <NPCFollowAction npctag="targetcultist" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.huskcultrelations.c1" eventsprite="huskinvite">
+        <Option text="EventText.huskcultrelations.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.huskcultrelations.o1.c1" fadetoblack="true" eventsprite="dorm">
+            <Option text="EventText.huskcultrelations.o1.o1">
+              <ConversationAction text="EventText.huskcultrelations.o1.o1.c1" targettag="triggerer_player" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+              <SpawnAction itemidentifier="calyxanide" targetinventory="triggerer_player" />
+              <SpawnAction itemidentifier="calyxanide" targetinventory="triggerer_player" />
+              <AfflictionAction targettag="triggerer_player" affliction="huskinfection" strength="40" />
+            </Option>
+            <Option text="EventText.huskcultrelations.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.huskcultrelations.o2" />
+      </ConversationAction>
+      <NPCFollowAction npctag="targetcultist" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Husk cultist"-->
+    <ScriptedEvent identifier="huskcultist">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="huskcultist" target2tag="player" applytotarget1="targetcultist" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.c1" eventsprite="cultist">
+        <Option text="EventText.huskcultist.o1">
+          <CheckItemAction targettag="triggerer_player" itemidentifiers="huskeggsbasic">
+            <Success>
+              <Label name="checkpockets" />
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.c1">
+                <Option text="EventText.huskcultist.o1.o1">
+                  <RemoveItemAction targettag="triggerer_player" itemidentifier="huskeggsbasic" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.o1.c1" />
+                  <MoneyAction amount="1000" />
+                </Option>
+                <Option text="EventText.huskcultist.o1.o2">
+                  <RemoveItemAction targettag="triggerer_player" itemidentifier="huskeggsbasic" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.o2.c1" />
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-3" />
+                </Option>
+                <Option text="EventText.huskcultist.o1.o3" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.c2">
+                <Option text="EventText.huskcultist.o1.o4">
+                  <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.o4.c1" />
+                  <Label name="waitingforeggs" />
+                  <ConversationAction text="EventText.huskcultist_return.c1" eventsprite="cultist" speakertag="huskcultist" dialogtype="Small">
+                    <Option text="EventText.huskcultist_return.o1" endconversation="true">
+                      <CheckItemAction targettag="triggerer_player" itemidentifiers="huskeggsbasic">
+                        <Success>
+                          <GoTo name="checkpockets" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" waitforinteraction="false" text="EventText.huskcultist_return.o1.c2" eventsprite="cultist" dialogtype="Small" />
+                          <GoTo name="waitingforeggs" />
+                        </Failure>
+                      </CheckItemAction>
+                    </Option>
+                    <Option text="EventText.huskcultist_return.o2" endconversation="true">
+                      <GoTo name="waitingforeggs" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.huskcultist.o1.o5" />
+              </ConversationAction>
+            </Failure>
+          </CheckItemAction>
+        </Option>
+        <Option text="EventText.huskcultist.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Husk cult ambush"-->
+    <ScriptedEvent identifier="huskcultambush">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="cultist1" spawnlocation="Outpost" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="cultist2" spawnlocation="Outpost" lootingisstealing="false" />
+      <NPCFollowAction npctag="cultist2" targettag="cultist1" follow="true" />
+      <TriggerAction target1tag="cultist1" target2tag="player" applytotarget2="triggerer_player" radius="300" />
+      <NPCFollowAction npctag="cultist2" targettag="cultist1" follow="false" />
+      <NPCFollowAction npctag="cultist1" targettag="triggerer_player" follow="true" />
+      <NPCFollowAction npctag="cultist2" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.c1" eventsprite="cultist">
+        <Option text="EventText.huskcultambush.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.o1.c1" />
+          <CombatAction combatmode="Offensive" npctag="cultist1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+          <CombatAction combatmode="Offensive" npctag="cultist2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.huskcultambush.o2">
+          <CheckReputationAction targettype="faction" identifier="huskcult" condition="gte 20">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.o2.c1" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.o2.c2" />
+              <!-- give a bit of rep for the nice try -->
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="3" />
+              <CombatAction combatmode="Offensive" npctag="cultist1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+              <CombatAction combatmode="Offensive" npctag="cultist2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+            </Failure>
+          </CheckReputationAction>
+        </Option>
+      </ConversationAction>
+      <NPCFollowAction npctag="cultist1" targettag="triggerer_player" follow="false" />
+      <NPCFollowAction npctag="cultist2" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Young cultists"-->
+    <ScriptedEvent identifier="youngcultists">
+      <CheckDataAction identifier="youngcultists_completed" condition="eq true">
+        <Success>
+          <!--Don't repeat event if already completed -->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="patient" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="cultist2" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <!-- use an existing cultist as the 1st NPC -->
+          <NPCFollowAction npctag="huskcultist" targettag="patient" maxtargets="1" follow="true" />
+          <NPCFollowAction npctag="cultist2" targettag="patient" maxtargets="1" follow="true" />
+          <AfflictionAction targettag="patient" affliction="huskinfection" strength="110" />
+          <GodModeAction targettag="patient" updateafflictions="true" enabled="true" />
+          <TriggerAction target1tag="patient" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="300" waitforinteraction="false" />
+          <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.c1" eventsprite="unconscious">
+            <Option text="EventText.youngcultists.o1">
+              <!-- only mark as completed if the player chooses to interact with the cultists (can occur again if the event is ignored) -->
+              <SetDataAction identifier="youngcultists_completed" value="true" />
+              <GodModeAction targettag="patient" enabled="false" />
+              <AfflictionAction targettag="patient" affliction="huskinfection" strength="-1000" />
+              <NPCFollowAction npctag="patient" targettag="cultist2" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.c1">
+                <Option text="EventText.youngcultists.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.c1">
+                    <Option text="EventText.youngcultists.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o1.c1">
+                        <Option text="EventText.youngcultists.o1.o1.o1.o1">
+                          <Label name="parasite" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o1.o1.c1">
+                            <Option text="EventText.youngcultists.o1.o1.o1.o1.o1">
+                              <Label name="callsecurity" />
+                              <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o1.o1.o1.c1" />
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="-10" />
+                              <CombatAction combatmode="Arrest" npctag="securitynpc" enemytag="cultist2" isinstigator="false" witnessreaction="retreat" />
+                            </Option>
+                            <Option text="EventText.youngcultists.o1.o1.o1.o1.o2"  endconversation="true">
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="-2" />
+                            </Option>
+                            <Option text="EventText.youngcultists.o1.o1.o1.o1.o3">
+                              <GoTo name="info" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.youngcultists.o1.o1.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o2.c1">
+                        <Option text="EventText.youngcultists.o1.o1.o2.o1">
+                          <Label name="info" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o2.o1.c1">
+                            <Option text="EventText.youngcultists.o1.o1.o2.o1.o1" endconversation="true">
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                            </Option>
+                            <Option text="EventText.youngcultists.o1.o1.o2.o1.o2">
+                              <GoTo name="callsecurity" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.youngcultists.o1.o1.o2.o2">
+                          <GoTo name="parasite" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.youngcultists.o2" targettag="triggerer_player" endconversation="true">
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+              <GodModeAction targettag="patient" enabled="false" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- 
+    waytoascension states
+    0: not started
+    1: talked to the ecclesiast, but not been able to answer the question about the second metamorphosis
+    2: answered the question correctly, asked to deliver husk eggs
+    3: delivered husk eggs, offered to join the church
+    4: joined the church, will get a new task when talking to the ecclesiast again
+    5: tasked to assassinate someone who knows too much about the church
+    6: assassination done, will get a reward and a task to pick up Jacov Subra when talking to the ecclesiast
+    7: tasked to rescue Jacov Subra from an abandoned outpost
+    8: rescued Subra
+    -->
+    <!-- Way to Ascension 1 -->
+    <ScriptedEvent identifier="waytoascension1">
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot start the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <CheckReputationAction targettype="faction" identifier="huskcult" condition="gte 0">
+            <Failure>
+              <!-- Do nothing -->
+            </Failure>
+            <Success>              
+              <CheckDataAction identifier="waytoascension" condition="eq 0">
+                <Failure>
+                  <CheckDataAction identifier="waytoascension" condition="eq 1">
+                    <Failure>
+                      <!-- do nothing -->
+                    </Failure>
+                    <Success>
+                      <TagAction criteria="player" tag="player" />
+                      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+                      <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+                      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+                      <ConversationAction text="EventText.waytoascension1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o1">
+                          <Label name="wronganswer" />
+                          <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast" endconversation="true" />
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o2">
+                          <GoTo name="wronganswer" />
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o3">
+                          <GoTo name="givetask" />
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o4">
+                          <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o4.c1" targettag="triggerer_player" eventsprite="Ecclesiast" endconversation="true" />
+                          <SetDataAction identifier="waytoascension" value="1" />
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                  </CheckDataAction>
+                </Failure>
+                <Success>
+                  <TagAction criteria="player" tag="player" />
+                  <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+                  <NPCFollowAction npctag="huskcultist" targettag="ecclesiast" follow="true" />
+                  <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+                  <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+                  <ConversationAction text="EventText.waytoascension1.c2" targettag="triggerer_player" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension1.o5">
+                      <ConversationAction text="EventText.waytoascension1.o5.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension1.o5.o1">
+                          <ConversationAction text="EventText.waytoascension1.o5.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                            <Option text="EventText.waytoascension1.o5.o1.o1">
+                              <ConversationAction text="EventText.waytoascension1.o5.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                <Option text="EventText.waytoascension1.o5.o1.o1.o1">
+                                  <Label name="challenge" />
+                                  <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o1">
+                                      <Label name="wronganswer" />
+                                      <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast" endconversation="true" />
+                                      <SetDataAction identifier="waytoascension" value="1" />
+                                    </Option>
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o2">
+                                      <GoTo name="wronganswer" />
+                                    </Option>
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o3">
+                                      <Label name="givetask" />
+                                      <ReputationAction targettype="Faction" identifier="huskcult" increase="2" />
+                                      <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o3.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o3.o1">
+                                          <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o3.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast" />
+                                          <SetDataAction identifier="waytoascension" value="2" />
+                                        </Option>
+                                      </ConversationAction>
+                                    </Option>
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o4">
+                                      <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o4.c1" eventsprite="Ecclesiast" targettag="triggerer_player" endconversation="true" />
+                                      <SetDataAction identifier="waytoascension" value="1" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                            <Option text="EventText.waytoascension1.o5.o1.o2">
+                              <ConversationAction text="EventText.waytoascension1.o5.o1.o2.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                <Option text="EventText.waytoascension1.o5.o1.o1.o1">
+                                  <GoTo name="challenge" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o2" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.waytoascension1.o6">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension1.o6.c1" />
+                      <ReputationAction targettype="Faction" identifier="huskcult" increase="-10" />
+                      <CombatAction combatmode="Arrest" npctag="securitynpc" enemytag="ecclesiast" isinstigator="false" witnessreaction="retreat" />
+                    </Option>
+                    <Option text="EventText.waytoascension1.o7" endconversation="true" />
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+            </Success>
+          </CheckReputationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension 2 -->
+    <ScriptedEvent identifier="waytoascension2">
+
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot continue the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="waytoascension" condition="eq 2">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+              <Label name="beginning" />
+              <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension2.o1">
+                  <CheckItemAction targettag="triggerer_player" itemidentifiers="huskeggs,huskeggsbasic" amount="12">
+                    <Success>
+                      <RemoveItemAction targettag="triggerer_player" itemidentifier="huskeggs,huskeggsbasic" amount="12" />
+                      <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o1.c1">
+                        <Option text="EventText.waytoascension2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o1.o1.c1">
+                            <Option text="EventText.waytoascension2.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o1.o1.o1.c1" endconversation="true" />
+                              <SetDataAction identifier="waytoascension" value="3" />
+                              <Goto name="answer" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                    <Failure>
+                      <ConversationAction text="EventText.waytoascension2.o1.c2" eventsprite="Ecclesiast" />
+                      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+                      <Goto name="beginning" />
+                    </Failure>
+                  </CheckItemAction>
+                </Option>
+                <Option text="EventText.waytoascension2.o2" endconversation="true">
+                  <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+                  <Goto name="beginning" />
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <CheckDataAction identifier="waytoascension" condition="eq 3">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+              <Label name="answer" />
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+              <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.c2" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension2.o3">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.c1">
+                    <Option text="EventText.waytoascension2.o3.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.c1">
+                        <Option text="EventText.waytoascension2.o3.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.o1.c1">
+                            <Option text="EventText.waytoascension2.o3.o1">
+                              <SetDataAction identifier="waytoascension" value="4" />
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="10" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="-10" />
+                              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.o1.o1.c1">
+                                <Option text="EventText.waytoascension2.o3.o1.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.o1.o1.o1.c1" endconversation="true" />
+                                  <SpawnAction itemidentifier="bookofchalices2" targetinventory="triggerer_player" />
+                                  <SpawnAction itemidentifier="cultistrobes" targetinventory="triggerer_player" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                            <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                              <Goto name="answer" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                          <Goto name="answer" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                      <Goto name="answer" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                  <Goto name="answer" />
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension 3 -->
+    <ScriptedEvent identifier="waytoascension3">
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot continue the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="waytoascension" condition="eq 4">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+              <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension3.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.o1.c1" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension3.o1.o1">
+                      <GoTo name="givemission" />
+                    </Option>
+                    <Option text="EventText.waytoascension3.o1.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.o1.o2.c1" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension3.o1.o2.o1">
+                          <Label name="givemission" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.o1.o2.o1.c1" eventsprite="Ecclesiast" endconversation="true" />
+                          <MissionAction missionidentifier="huskcultspecialassassinate" minlocationdistance="2" requiredfaction="coalition" locationtype="City,Outpost,Military,Research,Mine" CreateLocationIfNotFound="true" />
+                          <SetDataAction identifier="waytoascension" value="5" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension: assassination mission start -->
+    <ScriptedEvent identifier="waytoascension_assassination1">
+      <ConversationAction text="EventText.waytoascension_assassination1.c1" endeventifinterrupted="false" eventsprite="JacovSubra3" />
+      <ConversationAction text="EventText.waytoascension_assassination1.c1.c1" speakertag="coalitionspy" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Infiltration1">
+        <Option text="EventText.waytoascension_assassination1.c1.o1">
+          <ConversationAction text="EventText.waytoascension_assassination1.c1.o1.c1" targettag="triggerer_player" endconversation="true" />
+          <CombatAction combatmode="Offensive" npctag="coalitionspy" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.waytoascension_assassination1.c1.o2">
+          <ConversationAction text="EventText.waytoascension_assassination1.c1.o2.c1" targettag="triggerer_player" endconversation="true" />
+          <NPCFollowAction npctag="coalitionspy" targettag="triggerer_player" follow="true" />
+          <WaitAction time="60" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension_assassination1.c1.o2.c1.c1" waitforinteraction="false" eventsprite="Infiltration1" />
+          <NPCFollowAction npctag="coalitionspy" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.waytoascension_assassination1.c1.o3" endconversation="true" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension 4 -->
+    <ScriptedEvent identifier="waytoascension4">
+      <CheckDataAction identifier="waytoascension" condition="eq 6">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.c1" eventsprite="Ecclesiast">
+            <Option text="EventText.waytoascension4.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.o1.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension4.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.o1.o1.c1" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension4.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.o1.o1.o1.c1" eventsprite="Ecclesiast" endconversation="true" />
+                      <MissionAction missionidentifier="huskcultrescuesubra" locationtype="Abandoned" CreateLocationIfNotFound="true" />
+                      <SetDataAction identifier="waytoascension" value="7" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="waytoascensionfoundsubra" commonness="0">
+      <TagAction criteria="player" tag="player" />
+      <!-- enable godmode to ensure the player can't get locked from completing the rest of the event chain -->
+      <GodModeAction targettag="jacovsubra" />
+      <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" radius="300" waitforinteraction="false" />
+      <NPCWaitAction npctag="jacovsubra" wait="true" />
+      <ConversationAction text="EventText.waytoascensionfoundsubra.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+        <Option text="EventText.waytoascensionfoundsubra.o1">
+          <ConversationAction text="EventText.waytoascensionfoundsubra.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionfoundsubra.o1.o1">
+              <ConversationAction text="EventText.waytoascensionfoundsubra.o1.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra4" />
+              <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="true" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecuritybrute" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecuritybrute" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecuritygunner" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecurityelite" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+      <TriggerEventAction identifier="waytoascensionsubraescort" nextround="true" />
+      <NPCWaitAction npctag="jacovsubra" wait="false" />
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="waytoascensionsubraescort" commonness="0">
+      <CheckDataAction identifier="waytoascension" condition="eq 8">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <SetDataAction identifier="waytoascension" value="9" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jacovsubra" targettag="jacovsubra" allowduplicates="false" spawnlocation="MainSub" />
+          <TagAction criteria="player" tag="player" />
+          <WaitAction time="5" />
+          <!-- enable godmode to ensure the player can't get locked from completing the rest of the event chain -->
+          <GodModeAction targettag="jacovsubra" />
+          <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" radius="300" waitforinteraction="false" />
+          <NPCWaitAction npctag="jacovsubra" wait="true" />
+          <ConversationAction text="EventText.waytoascensionsubraescort.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionsubraescort.o1">
+              <ConversationAction text="EventText.waytoascensionsubraescort.c2" targettag="triggerer_player" eventsprite="JacovSubra4" />
+            </Option>
+          </ConversationAction>
+          <NPCWaitAction npctag="jacovsubra" wait="false" />
+          <WaitAction time="120" />
+          <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" radius="300" waitforinteraction="true" />
+          <NPCWaitAction npctag="jacovsubra" wait="true" />
+          <ConversationAction text="EventText.waytoascensionsubraescort.c3" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionsubraescort.c3.o1">
+              <ConversationAction text="EventText.waytoascensionsubraescort.c4" targettag="triggerer_player" eventsprite="JacovSubra4" />
+            </Option>
+          </ConversationAction>
+          <ConversationAction text="EventText.waytoascensionsubraescort.c5" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionsubraescort.c5.o1" targettag="triggerer_player" eventsprite="JacovSubra4">
+              <ConversationAction text="EventText.waytoascensionsubraescort.c6" targettag="triggerer_player" eventsprite="JacovSubra4" />
+            </Option>
+          </ConversationAction>          
+          <NPCWaitAction npctag="jacovsubra" wait="false" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+
+    <!-- Way to Ascension 4 -->
+    <ScriptedEvent identifier="waytoascension5">
+      <CheckDataAction identifier="waytoascension" condition="eq 9">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnpointtag="ritualchamber" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <NPCFollowAction npctag="huskcultist" targettag="ecclesiast" follow="true" />
+          <NPCWaitAction npctag="ecclesiast" wait="true" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" radius="200" waitforinteraction="false" />
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1" eventsprite="Ecclesiast">
+            <Option text="EventText.waytoascension5.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.o1.c1" eventsprite="Ecclesiast" endconversation="true" />
+              <GoTo name="wait" />
+            </Option>
+          </ConversationAction>
+          <Label name="wait" />
+          <NPCWaitAction npctag="ecclesiast" wait="true" />
+          <NPCFollowAction npctag="huskcultist" targettag="ecclesiast" follow="true" />
+          <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.c1" eventsprite="Ecclesiast">
+            <Option text="EventText.waytoascension5.c1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension5.c1.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.c1" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension5.c1.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.c1" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension5.c1.o1.o1.o1.o1" endconversation="true">
+                          <AfflictionAction targettag="ecclesiast" affliction="husksymbiosis" strength="1000" />
+                          <AfflictionAction targettag="huskcultist" affliction="huskinfection" strength="1000" />
+                          <StatusEffectAction targettag="triggerer_player">
+                            <StatusEffect target="NearbyCharacters" range="800" duration="10">
+                              <Conditional TeamID="Team1" />
+                              <Sound file="Content/Items/Alien/AlienTurret2.ogg" range="1000" />
+                              <Affliction identifier="hallucinating" strength="10" />
+                              <Affliction identifier="husksymbiosis" strength="10" />
+                            </StatusEffect>
+                          </StatusEffectAction>
+                          <WaitAction time="3" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.o1.c1" eventsprite="Ecclesiast">
+                            <Option text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1.c1" eventsprite="Ecclesiast">
+                                <Option text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1.o1.c1" eventsprite="Ecclesiast" />
+                                  <ReputationAction targettype="Faction" identifier="huskcult" increase="10" />
+                                  <ReputationAction targettype="Faction" identifier="clowns" increase="-10" />
+                                  <SetDataAction identifier="waytoascension" value="10" />
+                                  <CombatAction combatmode="arrest" npctag="security" enemytag="ecclesiast" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.waytoascension5.c1.o2" endconversation="true">
+              <GoTo name="wait" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--Husk Extremists-->
+    <ScriptedEvent identifier="huskextremists">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="humanprefabidentifier:huskextremist" tag="cultist" />
+      <TagAction criteria="humanprefabidentifier:huskextremist_leader" tag="cultist" />
+      <NPCChangeTeamAction npctag="cultist" teamid="FriendlyNPC" />
+
+      <Label name="waitforspotting" />
+      <WaitAction time="1" />
+      <CheckVisibilityAction EntityTag="cultist" TargetTag="player" ApplyTagToEntity="talk_cultist" ApplyTagToTarget="triggerer_player">
+        <Failure>
+          <Goto name="waitforspotting" />
+        </Failure>
+      </CheckVisibilityAction>
+      
+      <NPCWaitAction npctag="talk_cultist" wait="true" />
+      <!-- Set cultists to passive until after the conversations -->
+      <ConversationAction text="eventtext.huskextremists1.c1" targettag="triggerer_player">
+        <Option text="eventtext.huskextremists1.o1">
+          <ConversationAction text="eventtext.huskextremists1.o1.c1" targettag="triggerer_player">
+            <Option text="eventtext.huskextremists1.o1.o1">
+              <ConversationAction text="eventtext.huskextremists1.o1.o1.c1" targettag="triggerer_player">
+                <Option text="eventtext.huskextremists1.o1.o1.o1" endconversation="true">
+                  <!-- Combat -->
+                  <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+                  <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-5" />
+                </Option>
+                <Option text="eventtext.huskextremists1.o1.o1.o2" endconversation="true">
+                  <!-- Combat -->
+                  <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+                  <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+                </Option>
+                <Option text="eventtext.huskextremists1.o1.o1.o3" endconversation="true">
+                  <!-- Peace, but no mission reward -->
+                  <SpawnAction itemidentifier="geneticmaterialhusk" targetinventory="triggerer_player"/>
+                  <SpawnAction itemidentifier="geneticmaterialhusk" targetinventory="triggerer_player"/>
+                  <SpawnAction itemidentifier="geneticmaterialhusk" targetinventory="triggerer_player"/>
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-10" />
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="-3" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="eventtext.huskextremists1.o2">
+          <ConversationAction text="eventtext.huskextremists1.o2.c1" targettag="triggerer_player">
+            <Option text="eventtext.givingdirections.o2.o2" endconversation="true"><!-- Uh oh. -->
+              <!-- Combat -->
+              <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+              <NPCWaitAction npctag="talk_cultist" wait="false" />
+              <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="eventtext.huskextremists1.o3" endconversation="true">
+          <!-- Combat -->
+          <Label name="beforecheck2" />
+          <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+          <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+          <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+          <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+        </Option>
+      </ConversationAction>
+      <NPCWaitAction npctag="talk_cultist" wait="false" />
+    </ScriptedEvent>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                                  Clowns                                   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="missionevent_escort1clowns" commonness="100">
+      <ConversationAction text="EventText.missionevent_escort1clowns.c1" speakertag="clown" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonersclowns" />
+    </ScriptedEvent>
+    <!--"Clown relations 1"-->
+    <ScriptedEvent identifier="clownrelations1" commonness="100">
+      <SpawnAction itemidentifier="toolbelt" spawnlocation="outpost" targettag="clowntoolbelt" targetmoduletags="crewmodule" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clowntoolbelt" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clowntoolbelt" />
+      <SpawnAction itemidentifier="clownmask" targetinventory="clowntoolbelt" />
+      <SpawnAction itemidentifier="clowncostume" targetinventory="clowntoolbelt" />
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="clowntoolbelt" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.c1">
+        <Option text="EventText.clownrelations1.o1">
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown1" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown1" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+          <NPCFollowAction npctag="clown1" targettag="clowntoolbelt" follow="true" />
+          <NPCFollowAction npctag="clown2" targettag="triggerer_player" follow="true" />
+          <WaitAction time="2" />
+          <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.o1.c1" eventsprite="clown">
+            <Option text="EventText.clownrelations1.o1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.o1.o1.c1" />
+            </Option>
+            <Option text="EventText.clownrelations1.o1.o2">
+              <SpawnAction itemidentifier="bikehorn" targetinventory="triggerer_player" />
+              <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+              <StatusEffectAction targettag="triggerer_player">
+                <StatusEffect>
+                  <Sound file="Content/Items/Weapons/honk.ogg" range="300" />
+                </StatusEffect>
+              </StatusEffectAction>
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.o1.o2.c1" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.clownrelations1.o2" />
+      </ConversationAction>
+      <NPCFollowAction npctag="clown1" targettag="clowntoolbelt" follow="false" />
+      <NPCFollowAction npctag="clown2" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Clown relations 2"-->
+    <ScriptedEvent identifier="clownrelations2" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown" spawnlocation="Outpost" spawnpointtype="Path" />
+      <TriggerAction target1tag="clown" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <NPCFollowAction npctag="clown" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.clownrelations2.c1" eventsprite="clown">
+        <Option text="EventText.clownrelations2.o1">
+          <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 30">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations2.o1.c1" endconversation="true"/>
+              <SpawnAction itemidentifier="bikehorn" targetinventory="triggerer_player" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations2.o1.c2">
+                <Option text="EventText.clownrelations2.o1.o1" />
+              </ConversationAction>
+              <AfflictionAction targettag="triggerer_player" affliction="blunttrauma" strength="3" limbtype="head" />
+              <CombatAction combatmode="retreat" npctag="clown" enemytag="triggerer_player" />
+            </Failure>
+          </CheckReputationAction>
+          <NPCFollowAction npctag="clown" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.clownrelations2.o2" endconversation="true">
+          <WaitAction time="10" />
+          <NPCFollowAction npctag="clown" targettag="triggerer_player" follow="false" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Clown brutality"-->
+    <ScriptedEvent identifier="clownbrutality" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clownnpc1" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clownnpc2" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="clownvictimnpc" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <SpawnAction itemidentifier="toyhammer" targetinventory="clownnpc1" />
+      <SpawnAction itemidentifier="toyhammer" targetinventory="clownnpc2" />
+      <TriggerAction target1tag="clownvictimnpc" target2tag="player" radius="300" />
+      <CombatAction combatmode="offensive" npctag="clownnpc1" enemytag="clownvictimnpc" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+      <CombatAction combatmode="offensive" npctag="clownnpc2" enemytag="clownvictimnpc" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+    </ScriptedEvent>
+    <!--Infiltration-->
+    <ScriptedEvent identifier="infiltration" commonness="50">
+      <CheckDataAction identifier="infiltration_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <TriggerAction target1tag="player" target2tag="outpostmanager" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <ConversationAction text="EventText.infiltration.c1" targettag="triggerer_player" eventsprite="Infiltration1">
+            <Option text="EventText.infiltration.o1">
+              <ConversationAction text="EventText.infiltration.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.infiltration.o1.o1">
+                  <ConversationAction text="EventText.infiltration.o1.o1.c1" targettag="triggerer_player" eventsprite="Infiltration2">
+                    <Option text="EventText.infiltration.o1.o1.o1">
+                      <ConversationAction text="EventText.infiltration.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.infiltration.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.infiltration.o1.o1.o1.o1.c1" targettag="triggerer_player" />
+                          <GoTo name="gotoclowns" />
+                        </Option>
+                        <Option text="EventText.infiltration.o1.o1.o1.o2" endconversation="true">
+                          <Label name="gotoclowns" />
+                          <TriggerAction target1tag="triggerer_player" target2tag="clowntroublemaker" waitforinteraction="true" allowmultipletargets="true" />
+                          <ConversationAction text="EventText.infiltration.o1.o1.o1.o2.c1" targettag="triggerer_player">
+                            <Option text="EventText.infiltration.o1.o1.o1.o2.o1">
+                              <SkillCheckAction requiredskill="weapons" requiredlevel="30" targettag="triggerer_player">
+                                <Success>
+                                  <GiveSkillEXPAction skill="weapons" amount="5" targettag="triggerer_player" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.c1">
+                                    <Option text="EventText.infiltration.o1.o1.o1.o2.o1.o1">
+                                      <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.o1.c1" />
+                                      <MoneyAction amount="1000" />
+                                      <TagAction criteria="hullname:airlock" tag="airlock" submarinetype="Outpost" />
+                                      <NPCFollowAction npctag="clowntroublemaker" targettag="airlock" follow="true" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Success>
+                                <Failure>
+                                  <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.c2">
+                                    <Option text="EventText.infiltration.o1.o1.o1.o2.o1.o2">
+                                      <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.o2.c1" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Failure>
+                              </SkillCheckAction>
+                            </Option>
+                            <Option text="EventText.infiltration.o1.o1.o1.o2.o2">
+                              <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o2.c1">
+                                <Option text="EventText.infiltration.o1.o1.o1.o2.o1.o2">
+                                  <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.o2.c1" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.infiltration.o1.o1.o2">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.infiltration.o2" endconversation="true">
+              <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="infiltration_complete" value="true" />
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Censorship-->
+    <ScriptedEvent identifier="censorship" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown" targetmoduletags="clownmodule" spawnlocation="Outpost" />
+      <SpawnAction itemidentifier="metalcrate" spawnlocation="outpost" targettag="clownbox" targetmoduletags="adminmodule" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+      <NPCWaitAction npctag="clown" wait="true" />
+      <TriggerAction target1tag="player" target2tag="clown" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.censorship.c1" targettag="triggerer_player" eventsprite="Censorship1">
+        <Option text="EventText.censorship.o1">
+          <ConversationAction text="EventText.censorship.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.generic.continue">
+              <ConversationAction text="EventText.censorship.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.censorship.o1.o1.o1">
+                  <ConversationAction text="EventText.censorship.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <SetDataAction identifier="censorship_acceptedmission" value="true" />
+                </Option>
+                <Option text="EventText.censorship.o1.o1.o2">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+      <!--Trigger at box-->
+      <CheckDataAction identifier="censorship_acceptedmission" condition="eq true">
+        <Success>
+          <TriggerAction target1tag="triggerer_player" target2tag="clownbox" waitforinteraction="true" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="security" spawnpointtag="triggerer_player" />
+          <NPCFollowAction npctag="security" targettag="triggerer_player" follow="true" />
+          <ConversationAction text="EventText.censorship.o1.o1.o1.c1.c1" targettag="triggerer_player" eventsprite="Bombscare1">
+            <Option text="EventText.censorship.o1.o1.o1.c1.o1">
+              <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.censorship.o1.o1.o1.c1.o1.o1">
+                  <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o1.o1.c1" targettag="triggerer_player" />
+                  <RemoveItemAction targettag="clownbox" />
+                </Option>
+                <Option text="EventText.censorship.o1.o1.o1.c1.o1.o2">
+                  <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o1.o2.c1" targettag="triggerer_player" />
+                  <CombatAction combatmode="arrest" npctag="security" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+                  <RemoveItemAction targettag="clownbox" />
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.censorship.o1.o1.o1.c1.o2">
+              <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.c1" targettag="triggerer_player">
+                <Option text="EventText.censorship.o1.o1.o1.c1.o2.o1">
+                  <SkillCheckAction requiredskill="Helm" requiredlevel="30" targettag="triggerer_player">
+                    <Success>
+                      <NPCFollowAction npctag="security" targettag="triggerer_player" follow="false" />
+                      <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c1" targettag="triggerer_player" />
+                      <Label name="censorship_returnbox" />
+                      <TriggerAction target1tag="triggerer_player" target2tag="clown" waitforinteraction="true" />
+                      <CheckItemAction targettag="triggerer_player" itemtags="clownbox">
+                        <Success>
+                          <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c1.c1" targettag="triggerer_player" eventsprite="Censorship1" />
+                          <RemoveItemAction targettag="clownbox" />
+                          <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+                          <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c2.c2" targettag="triggerer_player" eventsprite="Censorship1" />
+                          <GoTo name="censorship_returnbox" />
+                        </Failure>
+                      </CheckItemAction>
+                    </Success>
+                    <Failure>
+                      <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c2" targettag="triggerer_player" />
+                      <RemoveItemAction targettag="clownbox" itemidentifier="metalcrate_event" />
+                      <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c2.c2" speakertag="clown" targettag="triggerer_player" />
+                    </Failure>
+                  </SkillCheckAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          <NPCFollowAction npctag="security" targettag="triggerer_player" follow="false" />
+        </Success>
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="clownspecialhire1">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 7">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 80">
+            <Failure>
+              <!-- Do nothing -->
+            </Failure>
+            <Success>
+              <CheckDataAction identifier="clownspecialhire1_hired" condition="eq true">
+                <Success>
+                  <!--Don't repeat event if already hired-->
+                </Success>
+                <Failure>
+                  <TagAction criteria="player" tag="player" />
+                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" allowduplicates="false" />
+                  <Label name="beginning" />
+                  <TriggerAction target1tag="jestmaster" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+                  <CheckDataAction identifier="clownspecialhire1_declinedonce" condition="eq true">
+                    <Failure>
+                      <!-- we haven't declined the offer before-->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.c1" eventsprite="Jestmaster">
+                        <Option text="eventtext.clownspecialhire1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.c1">
+                            <Option text="eventtext.clownspecialhire1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.c1">
+                                <Option text="eventtext.clownspecialhire1.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.o1.c1" />
+                                  <NPCChangeTeamAction npctag="jestmaster" teamid="Team1" addtocrew="true" />
+                                  <SetDataAction identifier="clownspecialhire1_hired" value="true" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                                </Option>
+                                <Option text="eventtext.clownspecialhire1.o1.o1.o2">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.o2.c1" />
+                                  <SetDataAction identifier="clownspecialhire1_declinedonce" value="true" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                                  <GoTo name="beginning" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Failure>
+                    <Success>
+                      <!-- we've declined before, show different dialog this time -->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.repeat" eventsprite="Jestmaster">
+                        <Option text="eventtext.clownspecialhire1.o1.o1.repeat">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.o1.c1" />
+                          <NPCChangeTeamAction npctag="jestmaster" teamid="Team1" addtocrew="true" />
+                          <SetDataAction identifier="clownspecialhire1_hired" value="true" />
+                          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                        </Option>
+                        <Option text="eventtext.clownspecialhire1.o1.o2.repeat" endconversation="true">
+                          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                          <GoTo name="beginning" />
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                  </CheckDataAction>
+                </Failure>
+              </CheckDataAction>
+            </Success>
+          </CheckReputationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 1-->
+    <ScriptedEvent identifier="pathofthebikehorn1">
+      <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 15">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="pathofthebikehorn" condition="eq 0">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+              <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn1.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn1.o1">
+                  <ConversationAction text="EventText.pathofthebikehorn1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.pathofthebikehorn1.o1.o1">
+                      <ConversationAction text="EventText.pathofthebikehorn1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.pathofthebikehorn1.o1.o1.o1">
+                          <GoTo name="teaching" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.pathofthebikehorn1.o2">
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-2" />
+                  <ConversationAction text="EventText.pathofthebikehorn1.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.pathofthebikehorn1.o2.o1">
+                      <ReputationAction targettype="Faction" identifier="clowns" increase="-2" />
+                    </Option>
+                    <Option text="EventText.pathofthebikehorn1.o2.o2">
+                      <ConversationAction text="EventText.pathofthebikehorn1.o2.o2.c1" targettag="triggerer_player">
+                        <Option text="EventText.pathofthebikehorn1.o2.o2.o1" endconversation="true" />
+                      </ConversationAction>
+                      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                      <Label name="waitforcostume" />
+                      <TriggerAction target1tag="triggerer_player" target2tag="jestmaster" waitforinteraction="true" />
+                      <CheckItemAction targettag="triggerer_player" itemtags="clownmask,clowngear">
+                        <Success>
+                          <GoTo name="teaching" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction text="EventText.pathofthebikehorn1.o2.o2.c1.c1" targettag="triggerer_player" eventsprite="Jestmaster" />
+                          <GoTo name="waitforcostume" />
+                        </Failure>
+                      </CheckItemAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.pathofthebikehorn1.o3">
+                  <ConversationAction text="EventText.pathofthebikehorn1.o3.c1" targettag="triggerer_player">
+                    <Option text="EventText.pathofthebikehorn1.o3.o1">
+                      <Label name="teaching" />
+                      <ConversationAction text="EventText.pathofthebikehorn1.o3.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.pathofthebikehorn1.o3.o1.o1">
+                          <ConversationAction text="EventText.pathofthebikehorn1.o3.o1.o1.c1" targettag="triggerer_player" />
+                          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+                          <SetDataAction identifier="pathofthebikehorn" value="1" />
+                          <SpawnAction itemidentifier="honkmotherianscriptures1" targetinventory="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />              
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 2-->
+    <ScriptedEvent identifier="pathofthebikehorn2">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 1">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <Label name="beginning" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.c1" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn2.o1">
+              <CheckItemAction targettag="triggerer_player" itemidentifiers="clownmaskunique">
+                <Success>
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.c1" eventsprite="Jestmaster">
+                    <Option text="EventText.pathofthebikehorn2.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn2.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.c1">
+                                <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1">
+                                  <Label name="teaching" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.c1">
+                                    <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1">
+                                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.c1">
+                                        <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o1">
+                                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o1.c1"/>
+                                          <SetDataAction identifier="pathofthebikehorn" value="2" />
+                                          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+                                          <SpawnAction itemidentifier="honkmotherianscriptures2" targetinventory="triggerer_player" />
+                                        </Option>
+                                        <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o2">
+                                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o2.c1"/>
+                                          <SetDataAction identifier="pathofthebikehorn" value="2" />
+                                          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+                                          <SpawnAction itemidentifier="honkmotherianscriptures2" targetinventory="triggerer_player" />
+                                        </Option>
+                                      </ConversationAction>
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                                <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o2">
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o2.c1">
+                                    <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o2.o1">
+                                      <GoTo name="teaching" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.c2" eventsprite="Jestmaster" />
+                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                  <Goto name="beginning" />
+                </Failure>
+              </CheckItemAction>
+            </Option>
+            <Option text="EventText.pathofthebikehorn2.o2">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o2.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn2.o2.o1" endconversation="true">
+                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                  <Goto name="beginning" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!-- Hitting an abyss monster with a toy hammer-->
+    <ScriptedEvent identifier="toyhammeronabyssmonster">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 2">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <SetDataAction identifier="pathofthebikehorn" value="3" />
+          <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+          <!-- target tag is set by the status effect that triggers this event (defined in the toy hammer) -->
+          <ConversationAction text="EventText.toyhammeronabyssmonster.c1" targettag="statuseffectuser" eventsprite="Jestmaster" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 3 -->
+    <ScriptedEvent identifier="pathofthebikehorn3">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 3">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.c0" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn3.o0">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn3.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o1.c1">
+                    <Option text="EventText.pathofthebikehorn3.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn3.o1.o1.o1">
+                          <GoTo name="idontgetit" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.pathofthebikehorn3.o1.o2">
+                      <GoTo name="idontgetit" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.pathofthebikehorn3.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.c1">
+                    <Option text="EventText.pathofthebikehorn3.o2.o1">
+                      <Label name="idontgetit" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.c1">
+                        <Option text="EventText.pathofthebikehorn3.o2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn3.o2.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.o1.c1" endconversation="true" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="3" />
+                              <SetDataAction identifier="pathofthebikehorn" value="4" />
+                            </Option>
+                            <Option text="EventText.pathofthebikehorn3.o2.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.o2.c1" endconversation="true" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="6" />
+                              <SetDataAction identifier="pathofthebikehorn" value="4" />
+                            </Option>
+                            <Option text="EventText.pathofthebikehorn3.o2.o1.o1.o3">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.o3.c1" endconversation="true" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="1" />
+                              <SetDataAction identifier="pathofthebikehorn" value="4" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 4 -->
+    <ScriptedEvent identifier="pathofthebikehorn4">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 4">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <Label name="beginning" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.c1" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn4.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.c1">
+                <Option text="EventText.pathofthebikehorn4.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.c1">
+                    <Option text="EventText.pathofthebikehorn4.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.c1">
+                                <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o1">
+                                  <Label name="takemission" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o1.c1" endconversation="true" />
+                                  <ReputationAction targettype="Faction" identifier="clowns" increase="1" />
+                                  <SetDataAction identifier="pathofthebikehorn" value="5" />
+                                  <SpawnAction itemidentifier="clownexosuit" targetinventory="triggerer_player" targettag="clownexosuit" />
+                                  <SpawnAction itemidentifier="fuelrod" targetinventory="clownexosuit" />
+                                  <SpawnAction itemidentifier="oxygentank" targetinventory="clownexosuit" />
+                                  <MissionAction missionidentifier="gotoclownhaven" locationtype="City" requiredfaction="clowns" minlocationdistance="1" CreateLocationIfNotFound="true" />
+                                </Option>
+                                <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2" endconversation="true">
+                                  <Label name="thinkaboutthis" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                                  <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2.c1" eventsprite="Jestmaster">
+                                    <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2.o1">
+                                      <GoTo name="takemission" />
+                                    </Option>
+                                    <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2.o2" endconversation="true">
+                                      <GoTo name="thinkaboutthis" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.pathofthebikehorn4.o2" endconversation="true">
+              <GoTo name="beginning" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="clownhaven1">
+      <SetDataAction identifier="clownhaven_peopleannoyed" operation="Set" value="1" />
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 5">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <Label name="beginning" />
+          <WaitAction time="5" />
+          <CheckItemAction targettag="player" itemidentifiers="clownexosuit" applytagtotarget="funbringer">
+            <Success>
+              <!-- do nothing and allow the event to continue-->
+            </Success>
+            <Failure>
+              <GoTo name="beginning" />
+            </Failure>
+          </CheckItemAction>
+          <WaitAction time="1" />
+          <ConversationAction text="EventText.clownhaven1.c1" eventsprite="Infiltration2" />
+          <Label name="state1" />
+          <WaitAction time="1" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 1">
+            <Failure>
+              <Goto name="state1" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c1" eventsprite="Infiltration2" />
+            </Success>
+          </CheckDataAction>
+          <!-- commoners flee -->
+          <Label name="state2" />
+          <CombatAction combatmode="retreat" npctag="commoner" enemytag="funbringer" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+          <WaitAction time="5" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 10">
+            <Failure>
+              <Goto name="state2" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c2" eventsprite="Infiltration2" />
+            </Success>
+          </CheckDataAction>
+          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+          <!-- clowns in the outpost start following the player -->
+          <Label name="state3" />
+          <NPCFollowAction npctag="clown" targettag="funbringer" maxtargets="1000" follow="true" />
+          <CombatAction combatmode="retreat" npctag="commoner" enemytag="funbringer" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+          <WaitAction time="5" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 20">
+            <Failure>
+              <Goto name="state3" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c3" eventsprite="Infiltration2" />
+            </Success>
+          </CheckDataAction>
+          <!-- security tries to arrest the player -->
+          <Label name="state4" />
+          <CombatAction combatmode="arrest" npctag="securitynpc" enemytag="funbringer" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+          <WaitAction time="5" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 35">
+            <Failure>
+              <Goto name="state4" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c4" eventsprite="NoticeBoard" />
+            </Success>
+          </CheckDataAction>
+          <!-- security tries to kill the player -->
+          <Label name="state5" />
+          <WaitAction time="5" />
+          <CombatAction combatmode="offensive" npctag="securitynpc" enemytag="funbringer" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gte 40">
+            <Failure>
+              <Goto name="state5" />
+            </Failure>
+            <Success />
+          </CheckDataAction>
+          <WaitAction time="10" />
+          <NPCFollowAction npctag="securitynpc" targettag="outpostmanager" follow="true" />
+          <NPCFollowAction npctag="commonner" targettag="outpostmanager" follow="true" />
+          <ConversationAction text="EventText.clownhaven1.c1.c5" eventsprite="NoticeBoard" />
+          <ModifyLocationAction faction="Clowns" name="location.clownhaven" />
+          <SetDataAction identifier="pathofthebikehorn" value="6" />
+          <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+          <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="clownhaven_progress">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 5">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>          
+          <CheckMissionAction MissionIdentifier="gotoclownhaven" Type="Current">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <MissionStateAction missionidentifier="gotoclownhaven" operation="Add" value="1" />
+              <SetDataAction identifier="clownhaven_peopleannoyed" operation="Add" value="1" />
+            </Success>
+          </CheckMissionAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 5 -->
+    <ScriptedEvent identifier="pathofthebikehorn5">
+      <!-- check for state 6: state 5 for the clownhaven event -->
+      <CheckDataAction identifier="pathofthebikehorn" condition="gte 6">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <CheckDataAction identifier="pathofthebikehorn" condition="eq 6">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />              
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn5.o1">
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="-2" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.c1">
+                    <Option text="EventText.pathofthebikehorn5.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn5.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn5.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.o1.o1.o1.c1" endconversation="true" />
+                              <SetDataAction identifier="pathofthebikehorn" value="7" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>              
+            </Success>
+          </CheckDataAction>
+          <Label name="moreadvicepls" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.c1.c1" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn5.c1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.c1.o1.c1">
+                <Option text="EventText.pathofthebikehorn5.c1.o1.o1" endconversation="true">
+                  <Goto name="moreadvicepls" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+  </EventPrefabs>
+</RandomEvents>

--- a/Bombscare/FactionEvents.xml
+++ b/Bombscare/FactionEvents.xml
@@ -132,11 +132,15 @@
         </Success>
       </CheckReputationAction>
     </ScriptedEvent>
+    
     <!--Bomb scare-->
     <ScriptedEvent identifier="bombscare" commonness="50">
       <TagAction criteria="player" tag="player" />
-      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="security" spawnlocation="Outpost" />
-      <TriggerAction target1tag="player" target2tag="security" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <TagAction criteria="itemidentifier:mediumsteelcabinet" tag="bombcabinet" SubmarineType="Outpost" chooserandom="true" ContinueIfNoTargetsFound="false"  />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="bombsecurity" spawnlocation="Outpost" />
+      <!-- talk to security NPC -->
+      <TriggerAction target1tag="player" target2tag="bombsecurity" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="true" />
       <ConversationAction text="EventText.bombscare.c1" targettag="triggerer_player" eventsprite="BombScare1">
         <Option text="EventText.bombscare.o1">
           <ConversationAction text="EventText.bombscare.o1.c1" targettag="triggerer_player">
@@ -144,47 +148,90 @@
               <ConversationAction text="EventText.bombscare.o1.o1.c1" targettag="triggerer_player">
                 <Option text="EventText.bombscare.o1.o1.o1">
                   <ConversationAction text="EventText.bombscare.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
-                  <WaitAction time="13" />
-                  <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.c1" targettag="triggerer_player" eventsprite="BombScare2">
-                    <Option text="EventText.bombscare.o1.o1.o1.c1.o1">
-                      <SkillCheckAction requiredskill="electrical" requiredlevel="45" targettag="triggerer_player">
+                  <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="false" />
+                  <SpawnAction itemidentifier="traitortimebomb" targettag="bombscarebomb" targetinventory="bombcabinet" ignorebyai="true" />
+                  <!-- Find the bomb cabinet -->
+                  <TriggerAction target1tag="player" target2tag="bombcabinet" applytotarget1="noisehearer" waitforinteraction="false" radius="80" />
+                  <StatusEffectAction targettag="bombscarebomb">
+                    <StatusEffect condition="100" IsOn="true" setvalue="true" />
+                  </StatusEffectAction>
+                  <ConversationAction text="eventtext.bombscare.tickingnoise" targettag="noisehearer" endconversation="true" dialogtype="Small"/>
+                  <!-- must pick up bomb to proceed -->
+                  <TriggerAction target1tag="player" target2tag="bombscarebomb" applytotarget1="bombfinder" waitforinteraction="true" />
+                  <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.c1" targettag="bombfinder" eventsprite="BombScare2">
+                    <Option text="eventtext.bombscare.o1.o1.o1.c1.o1">
+                      <SkillCheckAction requiredskill="electrical" requiredlevel="80" targettag="bombfinder">
                         <Success>
-                          <GiveSkillEXPAction skill="electrical" amount="10" targettag="triggerer_player" />
-                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1" targettag="triggerer_player" />
-                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1.c1" speakertag="security" targettag="triggerer_player" />
-                          <MoneyAction amount="500" />
-                          <ReputationAction targettype="Faction" identifier="coalition" increase="5" />
-                          <ReputationAction targettype="Faction" identifier="separatists" increase="-5" />
-                        </Success>
-                        <Failure>
-                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c2" targettag="triggerer_player">
-                            <Option text="EventText.bombscare.o1.o1.o1.c1.o1.o1">
-                              <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.o1.c1" targettag="triggerer_player" />
-                              <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.o1.c1.c1" speakertag="security" targettag="triggerer_player" />
+                          <StatusEffectAction targettag="bombscarebomb">
+                            <StatusEffect IsOn="false" setvalue="true" />
+                          </StatusEffectAction>
+                          <GiveSkillEXPAction skill="electrical" amount="10" targettag="bombfinder" />
+                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1" targettag="bombfinder" eventsprite="BombScare2"/>
+                          <!-- Bomb defused, go to security. -->
+                          <Label name="hasdefusedbomb" />
+                          <TriggerAction target1tag="player" target2tag="bombsecurity" applytotarget1="bombbringer" waitforinteraction="true" />
+                          <CheckItemAction targettag="bombbringer" itemtags="bombscarebomb" >
+                            <Success>
+                              <NPCFollowAction npctag="bombsecurity" targettag="bombbringer" follow="true" />
+                              <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1.c1" targettag="bombbringer" eventsprite="BombScare1"/>
+                              <StatusEffectAction targettag="bombscarebomb">
+                                <StatusEffect>
+                                  <Remove />
+                                </StatusEffect>
+                              </StatusEffectAction>
+                              <MoneyAction amount="500" />
                               <ReputationAction targettype="Faction" identifier="coalition" increase="5" />
                               <ReputationAction targettype="Faction" identifier="separatists" increase="-5" />
+                              <NPCFollowAction npctag="bombsecurity" targettag="bombbringer" follow="false" />
+                            </Success>
+                            <Failure>
+                              <ConversationAction text="EventText.bombscare.nobombtogive" targettag="bombbringer" dialogtype="Small" eventsprite="BombScare1"/>
+                              <ClearTagAction tag="bombbringer" />
+                              <WaitAction time="1" />
+                              <Goto name="hasdefusedbomb" />
+                            </Failure>
+                          </CheckItemAction>
+                        </Success>
+                        <Failure>
+                          <!-- Bomb turns off then turns on again and ticks faster -->
+                          <StatusEffectAction targettag="bombscarebomb">
+                            <StatusEffect IsOn="false" setvalue="true" />
+                          </StatusEffectAction>
+                          <ConversationAction text="eventtext.bombscare.o1.o1.o1.c1.o1.c2" targettag="bombfinder" eventsprite="BombScare2">
+                            <Option text="eventtext.bombscare.o1.o1.o1.c1.o1.o1">
+                              <Waitaction Time="1" />
+                              <StatusEffectAction targettag="bombscarebomb">
+                                <StatusEffect IsOn="True" setvalue="true" />
+                                <StatusEffect type="OnActive" target="This" duration="100" Condition="-2" >
+                                  <sound file="Content/Items/Button/Switch1.ogg" range="200" frequencymultiplier="1" volume="0.75" loop="true" />
+                                </StatusEffect>
+                              </StatusEffectAction>
+                              <ConversationAction text="eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1" targettag="bombfinder" endconversation="true" eventsprite="BombScare2"/>
                             </Option>
                           </ConversationAction>
                         </Failure>
                       </SkillCheckAction>
                     </Option>
-                    <Option text="EventText.generic.ignore">
-                      <!--END-->
+                    <Option text="eventtext.bombscare.leavethebomb" endconversation="true">
+                      <!-- Let the bomb tick -->
                     </Option>
                   </ConversationAction>
                 </Option>
               </ConversationAction>
             </Option>
-            <Option text="EventText.bombscare.o1.o2">
+            <Option text="EventText.bombscare.o1.o2" endconversation="true">
               <!--END-->
+              <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="false" />
             </Option>
           </ConversationAction>
         </Option>
-        <Option text="EventText.generic.ignore">
+        <Option text="EventText.generic.ignore" endconversation="true">
           <!--END-->
+          <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="false" />
         </Option>
       </ConversationAction>
     </ScriptedEvent>
+    
     <!--Nothing to see here-->
     <ScriptedEvent identifier="nothingtoseehere" commonness="50">
       <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="oldwoman" targettag="nothingtoseehere_oldwoman" spawnlocation="Outpost" spawnpointtype="Path" />


### PR DESCRIPTION
The event `bombscare` plays out entirely through text.
Happens ina random location, it mentions a bomb but said bomb doesn't even spawn, and both options defuse the bomb anyway. 

![image](https://github.com/Regalis11/Barotrauma/assets/73229309/6946e8fc-05eb-4044-8756-e3a14e0dd80c)

This changes the event to spawn an actual bomb, with a twist

_video too big for github, note that text isn't the proper one because overriding text isnt possible_

https://cdn.discordapp.com/attachments/668819422919524352/1175591635564900382/Desktop_2023.09.10_-_17.38.09.06_20.mp4?ex=656bca07&is=65595507&hm=2ab3f4a154cbea30d2ea237a58ea0313cf4a137d2d64dd81931690624f099e20&

Changes: 

-After talking with the guard, a random steel cabinet is selected
-Getting near the cabinet prompts a text
-A traitor time bomb spawns inside the cabinet and is set active
-Grab the bomb to continue event
-Trying to defuse the bomb has 2 outcomes
-On success, bomb is defused (same as before), can be given to guard
-On failure, bomb stops ticking for a moment then ticks twice as fast. 
-Added/Changed text to reflect the bomb changes

