### PR TITLE
Double-clicking mods in the mod settings menu now moves them to the top of the opposite list instead of to the bottom

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Steam/WorkshopMenu/Mutable/InstalledTab.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Steam/WorkshopMenu/Mutable/InstalledTab.cs
@@ -142,6 +142,7 @@ namespace Barotrauma.Steam
                 {
                     frame.Parent.RemoveChild(frame);
                     frame.RectTransform.Parent = to.Content.RectTransform;
+                    frame.RectTransform.SetAsFirstChild();
                 }
                 from.RecalculateChildren();
                 from.RectTransform.RecalculateScale(true);


### PR DESCRIPTION
This seems more logical, since top mods take precedence over bottom ones, and if you move one to the very bottom, it will be instantly overridden - an action that makes no sense

+It'll be easier to find them if you move them to the top


https://github.com/Regalis11/Barotrauma/assets/122838333/0f95d73a-7621-4403-a405-6e43e541eb4b


https://github.com/Regalis11/Barotrauma/assets/122838333/1aced107-5bf5-47c2-8256-5aca9e47a420

Here's pack of mods with colored wrenches if you need them for testing
[3 mods with wrenches.zip](https://github.com/Regalis11/Barotrauma/files/13433852/3.mods.with.wrenches.zip)

and proof that top mods have priority

https://github.com/Regalis11/Barotrauma/assets/122838333/bb53fd0b-d333-4bc6-a179-5f79da33f706