### PR TITLE
Small visual tweak: decimal accuracy for speed on the navigation terminal

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Steering.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Steering.cs
@@ -321,7 +321,7 @@ namespace Barotrauma.Items.Components
                         {
                             Vector2 vel = controlledSub == null ? Vector2.Zero : controlledSub.Velocity;
                             var realWorldVel = ConvertUnits.ToDisplayUnits(vel.Y * Physics.DisplayToRealWorldRatio) * 3.6f;
-                            return MathF.Round(-realWorldVel,2).ToString("0.00");
+                            return (-realWorldVel).ToString("0.0");
                         };
                         break;
                     case 1:
@@ -332,7 +332,7 @@ namespace Barotrauma.Items.Components
                             Vector2 vel = controlledSub == null ? Vector2.Zero : controlledSub.Velocity;
                             var realWorldVel = ConvertUnits.ToDisplayUnits(vel.X * Physics.DisplayToRealWorldRatio) * 3.6f;
                             if (controlledSub != null && controlledSub.FlippedX) { realWorldVel *= -1; }
-                            return MathF.Round(realWorldVel,1).ToString("0.0");
+                            return realWorldVel.ToString("0.0");
                         };
                         break;
                     case 2:

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Steering.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Steering.cs
@@ -321,7 +321,7 @@ namespace Barotrauma.Items.Components
                         {
                             Vector2 vel = controlledSub == null ? Vector2.Zero : controlledSub.Velocity;
                             var realWorldVel = ConvertUnits.ToDisplayUnits(vel.Y * Physics.DisplayToRealWorldRatio) * 3.6f;
-                            return ((int)(-realWorldVel)).ToString();
+                            return MathF.Round(-realWorldVel,2).ToString("0.00");
                         };
                         break;
                     case 1:
@@ -332,7 +332,7 @@ namespace Barotrauma.Items.Components
                             Vector2 vel = controlledSub == null ? Vector2.Zero : controlledSub.Velocity;
                             var realWorldVel = ConvertUnits.ToDisplayUnits(vel.X * Physics.DisplayToRealWorldRatio) * 3.6f;
                             if (controlledSub != null && controlledSub.FlippedX) { realWorldVel *= -1; }
-                            return ((int)realWorldVel).ToString();
+                            return MathF.Round(realWorldVel,1).ToString("0.0");
                         };
                         break;
                     case 2:


### PR DESCRIPTION
Quick tweak, I wanted to see in real time how fast the sub was moving, without having to hook up another text terminal.

Result:

![decimal](https://github.com/Regalis11/Barotrauma/assets/68995233/12fe994d-4c2c-4f5e-9c12-84524d8bab70)

You will also need a font with a narrower decimal point, I edited yours with FontForge to get the look that's in the screenshot.
[Segment7Standard.otf.gz](https://github.com/Regalis11/Barotrauma/files/13546080/Segment7Standard.otf.gz)
