### PR TITLE
Add beds as wandering targets depending on health

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveIdle.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveIdle.cs
@@ -71,7 +71,7 @@ namespace Barotrauma
 
         private Character tooCloseCharacter;
 
-        const float chairCheckInterval = 5.0f;
+        const float chairCheckInterval = 4.0f;
         private float chairCheckTimer;
 
         private float autonomousObjectiveRetryTimer = 10;
@@ -382,12 +382,18 @@ namespace Barotrauma
                     {
                         foreach (Item item in Item.ItemList)
                         {
-                            if (item.CurrentHull != currentHull || !item.HasTag(Tags.ChairItem)) { continue; }
-                            //not possible in vanilla game, but a mod might have holdable/attachable chairs
+                            
+                            if (item.CurrentHull != currentHull) { continue; }
+                            //not possible in vanilla game, but a mod might have holdable/attachable ones
                             if (item.ParentInventory != null || item.body is { Enabled: true }) { continue; } 
                             var controller = item.GetComponent<Controller>();
                             if (controller == null || controller.User != null) { continue; }
-                            item.TryInteract(character, forceSelectKey: true);
+                            //make it more likely to seek a bed when hurt, (68% chance after 10 checks at 80% health, 40% at 90%H 10th try, 5% at 90%H first try, 56% at 20%H first try...)
+                            if(item.HasTag(Tags.BedItem) && Rand.Value() > Math.Sqrt(character.HealthPercentage/100)){
+                                item.TryInteract(character, forceSelectKey: true);
+                            } else if (item.HasTag(Tags.ChairItem) && Rand.Value() > 0.4){
+                                item.TryInteract(character, forceSelectKey: true);
+                            }
                         }
                         chairCheckTimer = chairCheckInterval;
                     }

--- a/Barotrauma/BarotraumaShared/SharedSource/Tags.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Tags.cs
@@ -48,6 +48,7 @@ public static class Tags
     public static readonly Identifier IdCardTag = "identitycard".ToIdentifier();
     public static readonly Identifier WireItem = "wire".ToIdentifier();
     public static readonly Identifier ChairItem = "chair".ToIdentifier();
+    public static readonly Identifier BedItem = "bed".ToIdentifier();
     public static readonly Identifier ArtifactHolder = "artifactholder".ToIdentifier();
     public static readonly Identifier Thalamus = "thalamus".ToIdentifier();
 


### PR DESCRIPTION
I've given the AI the ability to seek beds when idling, allowing them to heal during downtimes without being a constant drain on supplies for minor wounds, with the chance of choosing a bed increasing the more wounded they are every time a check passes.

To make it work, you'll need to add `tags="bed"` to the respective bunks and hospital beds in their XML files.
It essentially allows you to slowly heal NPCs at the cost of having to dissmiss them of any active duties like maintenance or operating machinery, which is a worthy tradeoff in my opinion as you trade away threat readiness for some weak, cost-free healing.