### PR TITLE
Kill characters before removing them with status effects

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
@@ -550,7 +550,7 @@ namespace Barotrauma
             }
         }
 
-        partial void KillProjSpecific(CauseOfDeathType causeOfDeath, Affliction causeOfDeathAffliction, bool log)
+        partial void KillProjSpecific(CauseOfDeathType causeOfDeath, Affliction causeOfDeathAffliction, bool log, bool triggerDeathEffects)
         {
             HintManager.OnCharacterKilled(this);
 
@@ -564,7 +564,10 @@ namespace Barotrauma
 
                 RespawnManager.ShowDeathPromptIfNeeded();
 
-                GameMain.NetworkMember.AddChatMessage(chatMessage.Value, ChatMessageType.Dead);
+                if (triggerDeathEffects)
+                {
+                    GameMain.NetworkMember.AddChatMessage(chatMessage.Value, ChatMessageType.Dead);
+                }
                 GameMain.LightManager.LosEnabled = false;
                 controlled = null;
                 if (Screen.Selected?.Cam is Camera cam)
@@ -577,7 +580,10 @@ namespace Barotrauma
                 }
             }
 
-            PlaySound(CharacterSound.SoundType.Die);
+            if (triggerDeathEffects)
+            {
+                PlaySound(CharacterSound.SoundType.Die);
+            }
         }
 
         partial void DisposeProjSpecific()

--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterNetworking.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterNetworking.cs
@@ -800,6 +800,7 @@ namespace Barotrauma
 
         private void ReadStatus(IReadMessage msg)
         {
+            TriggerDeathEffects = msg.ReadBoolean();
             bool isDead = msg.ReadBoolean();
             if (isDead)
             {

--- a/Barotrauma/BarotraumaServer/ServerSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Characters/Character.cs
@@ -13,7 +13,7 @@ namespace Barotrauma
             GameMain.Server.KarmaManager.OnCharacterHealthChanged(this, attacker, attackResult.Damage, stun, attackResult.Afflictions);
         }
 
-        partial void KillProjSpecific(CauseOfDeathType causeOfDeath, Affliction causeOfDeathAffliction, bool log)
+        partial void KillProjSpecific(CauseOfDeathType causeOfDeath, Affliction causeOfDeathAffliction, bool log, bool triggerDeathEffects)
         {
             if (log)
             {

--- a/Barotrauma/BarotraumaServer/ServerSource/Characters/CharacterNetworking.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Characters/CharacterNetworking.cs
@@ -649,6 +649,7 @@ namespace Barotrauma
         /// <param name="forceAfflictionData">Normally full affliction data is not written for dead characters, this can be used to force them to be written</param>
         private void WriteStatus(IWriteMessage msg, bool forceAfflictionData = false)
         {
+            msg.WriteBoolean(TriggerDeathEffects);
             msg.WriteBoolean(IsDead);
             if (IsDead)
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -1157,6 +1157,9 @@ namespace Barotrauma
             }
         }
 
+        // If set to false, the character won't trigger death status effects, death sounds or have death notifications show up in their chat when they die.
+        public bool TriggerDeathEffects { get; set; } = true;
+
         public bool EnableDespawn { get; set; } = true;
 
         public CauseOfDeath CauseOfDeath
@@ -5027,7 +5030,10 @@ namespace Barotrauma
             //it's important that we set isDead before executing the status effects,
             //otherwise a statuseffect might kill the character "again" and trigger a loop that crashes the game
             isDead = true;
-            ApplyStatusEffects(ActionType.OnDeath, 1.0f);
+            if (TriggerDeathEffects)
+            {
+                ApplyStatusEffects(ActionType.OnDeath, 1.0f);
+            }
 
 #if CLIENT
             // Keep permadeath status in sync (to show it correctly in the UI, the server takes care of the actual logic)
@@ -5095,7 +5101,7 @@ namespace Barotrauma
                 AchievementManager.OnCharacterKilled(this, CauseOfDeath);
             }
 
-            KillProjSpecific(causeOfDeath, causeOfDeathAffliction, log);
+            KillProjSpecific(causeOfDeath, causeOfDeathAffliction, log, TriggerDeathEffects);
 
             if (info != null)
             {
@@ -5132,7 +5138,7 @@ namespace Barotrauma
             }
             GameMain.GameSession?.KillCharacter(this);
         }
-        partial void KillProjSpecific(CauseOfDeathType causeOfDeath, Affliction causeOfDeathAffliction, bool log);
+        partial void KillProjSpecific(CauseOfDeathType causeOfDeath, Affliction causeOfDeathAffliction, bool log, bool triggerDeathEffects);
 
         public void Revive(bool removeAfflictions = true, bool createNetworkEvent = false)
         {

--- a/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
@@ -2173,7 +2173,7 @@ namespace Barotrauma
                                             }
 #endif
                                             }
-                                            if (characterSpawnInfo.RemovePreviousCharacter) { Entity.Spawner?.AddEntityToRemoveQueue(character); }
+                                            if (characterSpawnInfo.RemovePreviousCharacter) { character.TriggerDeathEffects = false; character.Kill(CauseOfDeathType.Unknown, null); Entity.Spawner?.AddEntityToRemoveQueue(character); }
                                         }
                                     }
                                     if (characterSpawnInfo.InheritEventTags)
@@ -2305,6 +2305,8 @@ namespace Barotrauma
                     }
                 }
             }
+            character.TriggerDeathEffects = false;
+            character.Kill(CauseOfDeathType.Unknown, null);
             Entity.Spawner?.AddEntityToRemoveQueue(character);
         }
 


### PR DESCRIPTION
Fixes https://github.com/FakeFishGames/Barotrauma/discussions/15279

Adds a new character boolean property called TriggerDeathEffects (set to true by default) which prevents the character from triggering "OnDeath" type status effects as well as death sounds and the multiplayer chat notification when they die, if set to false, essentially resulting in a silent death. This is synced between the server and the clients in order to fully work in multiplayer as it does in singleplayer.

When characters are removed through status effects, we now set this new property to false, as well as kill them before removing them, making removing characters work just like it did before, with the added benefit of counting them as dead, fixing various issues.