### PR TITLE
Fixed #15112 - Outpost bots now react to you dragging corpses

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/HumanAIController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/HumanAIController.cs
@@ -454,6 +454,7 @@ namespace Barotrauma
                     }
                     reportProblemsTimer = reportProblemsInterval;
                 }
+                CheckForDraggedCorpses();
                 SpeakAboutIssues();
                 UnequipUnnecessaryItems();
                 reactTimer = GetReactionTime();
@@ -1200,6 +1201,37 @@ namespace Barotrauma
                     string msgId = "DialogPressure";
                     Character.Speak(TextManager.GetWithVariable(msgId, "[roomname]", Character.CurrentHull.DisplayName, FormatCapitals.Yes).Value, delay: Rand.Range(minDelay, maxDelay), identifier: msgId.ToIdentifier(), minDurationBetweenSimilar: 30.0f);
                 }
+            }
+        }
+
+        private void CheckForDraggedCorpses()
+        {
+            if (Character.IsOnPlayerTeam) { return; }
+
+            foreach (Character otherCharacter in Character.CharacterList)
+            {
+                if (otherCharacter.SelectedCharacter == null || !otherCharacter.SelectedCharacter.IsDead || 
+                    otherCharacter.SelectedCharacter.TeamID != Character.TeamID || !Character.CanSeeTarget(otherCharacter))
+                {
+                    continue;
+                }
+
+                // Player is dragging a corpse from our team
+                if (Character.SpeechImpediment < 100)
+                {
+                    Character.Speak(TextManager.Get("dialogstealwarning").Value, null, 
+                        Rand.Range(0.5f, 1.0f), "dialogstealwarning".ToIdentifier(), 10.0f);
+                }
+
+                if (Character.IsSecurity)
+                {
+                    AddCombatObjective(AIObjectiveCombat.CombatMode.Arrest, otherCharacter);
+                }
+                else
+                {
+                    AddCombatObjective(AIObjectiveCombat.CombatMode.Retreat, otherCharacter);
+                }
+                break; // Only react to one at a time
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/FakeFishGames/Barotrauma/issues/15112
Now outpost bots will react when a player drags around a corpse of an outpost dweller

They will:
- Comment (if not mute) using the existing steal warnings, like "Hey! Put that back!" (`dialogstealwarning`)
- Regular NPCs will run away (if not in combat) & Security will try to arrest the player

Changes:
- Added `CheckForDraggedCorpses()` to `HumanAIController`
- Called it in `Update()` alongside other reaction checks