### PR TITLE
Add regex-based spam server filters

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/SpamServerFilter.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/SpamServerFilter.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Cache;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -20,8 +21,10 @@ namespace Barotrauma
         Invalid,
         NameEquals,
         NameContains,
+        NameMatches,
         MessageEquals,
         MessageContains,
+        MessageMatches,
         PlayerCountLarger,
         PlayerCountExact,
         MaxPlayersLarger,
@@ -66,9 +69,11 @@ namespace Barotrauma
             {
                 SpamServerFilterType.NameEquals => CompareEquals(name, value),
                 SpamServerFilterType.NameContains => CompareContains(name, value),
+                SpamServerFilterType.NameMatches => CompareRegex(name, value),
 
                 SpamServerFilterType.MessageEquals => CompareEquals(desc, value),
                 SpamServerFilterType.MessageContains => CompareContains(desc, value),
+                SpamServerFilterType.MessageMatches => CompareRegex(desc, value),
 
                 SpamServerFilterType.Endpoint =>
                     info.Endpoints != null &&
@@ -104,6 +109,15 @@ namespace Barotrauma
                     return a == b;
                 }
                 return a.Contains(b, StringComparison.OrdinalIgnoreCase);
+            }
+
+            static bool CompareRegex(string a, string b)
+            {
+                if (a == null || b == null)
+                {
+                    return a == b;
+                }
+                return Regex.IsMatch(a, b);
             }
         }
 
@@ -215,8 +229,10 @@ The filters are saved in this file, which you can edit manually if you want to.
 The available filter types are:
 - NameEquals: The server name must equal the specified value. Homoglyphs are also checked.
 - NameContains: The server name must contain the specified value.
+- NameMatches: The server name must match the specified regular expression pattern. Use inline options like (?i) for case-insensitive matching.
 - MessageEquals: The server description must equal the specified value. Homoglyphs are also checked.
 - MessageContains: The server description must contain the specified value.
+- MessageMatches: The server description must match the specified regular expression pattern. Use inline options like (?i) for case-insensitive matching.
 - PlayerCountLarger: The player count must be larger than the specified value.
 - PlayerCountExact: The player count must match the specified value exactly.
 - MaxPlayersLarger: The max player count must be larger than the specified value.
@@ -234,8 +250,10 @@ Examples:
   <Filter namecontains=""discord.gg"" />
   <Filter messagecontains=""discord.gg"" />
   <Filter nameequals=""get good get lmaobox"" maxplayersexact=""999"" />
+  <Filter namematches=""(?i)(buy|sell|trade).*cheap"" />
+  <Filter messagematches=""(?i)join.*discord\.(gg|com)"" />
 </Filters>
-These will hide all servers that have a discord.gg link in their name or description and servers with the name ""get good get lmaobox"" that have 999 max players.
+These will hide all servers that have a discord.gg link in their name or description, servers with the name ""get good get lmaobox"" that have 999 max players, servers with names matching the pattern for buying/selling/trading (case-insensitive), and servers with messages containing discord links (case-insensitive).
 ";
         static SpamServerFilters()
         {


### PR DESCRIPTION
Adds two new `SpamServerFilterType` options for filtering servers using regular expressions:

- `NameMatches` - Match server names against regex patterns
- `MessageMatches` - Match server descriptions against regex patterns

This enables more powerful spam filtering compared to simple string matching, allowing users to create sophisticated patterns to hide unwanted servers from the server list.

## Implementation

- Added `NameMatches` and `MessageMatches` to `SpamServerFilterType` enum
- Implemented `CompareRegex` helper using `System.Text.RegularExpressions.Regex.IsMatch`
- Supports inline regex options (e.g., `(?i)` for case-insensitive matching) giving users full control over pattern behavior
- Updated `LocalFilterComment` documentation with new filter types and examples

## Example Usage

Inside of `Data/serverblacklist.xml`'s `<Filters>` element, the following `<Filter>` elements can be used:

```xml
<Filter namematches="^.{150,}$" />
```

Match any server name 150 characters or longer.

```xml
<Filter namematches="(_.*){8,}" />
```

Match any server name that contains 8 or more underscores.

```xml
<Filter namematches="(?i)(buy|sell|trade).*cheap" />
```

Match any server name that contains the phrases "buy", "sell", or "trade", followed by any number of characters before the word "cheap" in a case-insensitive match.

```xml
<Filter messagematches="(?i)join.*discord\.(gg|com)" />
```

Match any server description that contains the words "join" followed by any number of characters before either the string "discord.gg" or "discord.com" in a case-insensitive match.

---

Relates to #16538 as a possible short-term workaround for the issue.  Discussion in #16536.
