### PR TITLE
[fix] Check SpamServerFilter once on AddToList

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/ServerListScreen/ServerListScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/ServerListScreen/ServerListScreen.cs
@@ -1013,8 +1013,6 @@ namespace Barotrauma
                 return false;
             }
 #endif
-            if (SpamServerFilters.IsFiltered(serverInfo)) { return false; }
-
             if (!string.IsNullOrEmpty(searchBox.Text) && !serverInfo.ServerName.Contains(searchBox.Text, StringComparison.OrdinalIgnoreCase)) { return false; }
 
             if (filterSameVersion.Selected)
@@ -1330,6 +1328,8 @@ namespace Barotrauma
             if (serverInfo.MaxPlayers <= 0) { return; }
             //no way a legit server can have this many players
             if (serverInfo.MaxPlayers > MaxAllowedPlayers) { return; }
+            
+            if (SpamServerFilters.IsFiltered(serverInfo)) { return; }
 
             int similarServerCount = 0;
             string serverInfoStr = getServerInfoStr(serverInfo);


### PR DESCRIPTION
Currently, `SpamServerFilters.IsFiltered` is a small hotspot with the on going api DoS. Every server added to the server list will cause every server to be checked for spam. The spam check can be slow as some spam server desc's are pretty big, causing `String.Contains` to be a hotspot.

This change mostly makes `LevenshteinDistance` the main thing causing lag spikes when loading the browser, #16026 should help with this but does not completely eliminate it. 