### PR TITLE
Don't force Outpost spawn inside a hull (Allow custom starter outpost)

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/GameSession/CrewManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSession/CrewManager.cs
@@ -399,7 +399,6 @@ namespace Barotrauma
             return WayPoint.WayPointList.FindAll(wp =>
                     wp.SpawnType == SpawnType.Human &&
                     wp.Submarine == Level.Loaded.StartOutpost &&
-                    wp.CurrentHull != null &&
                     wp.CurrentHull.OutpostModuleTags.Contains("airlock".ToIdentifier()));
         }
 


### PR DESCRIPTION
When determining where to spawn the crew in outposts, the game checks for a valid spawnpoint **INSIDE A HULL**

This check is useless, as you will always put spawnpoints inside hulls anyway. 

https://github.com/FakeFishGames/Barotrauma/blob/783499f152669a89745e4f9fa46167b6f2bf5195/Barotrauma/BarotraumaShared/SharedSource/GameSession/CrewManager.cs#L393-L405

Removing this check will finally allow me to add a cool cinematic starter outpost intro to the campaign by spawning players in the descending shuttle.
I'm even willing to give you the whole thing for vanilla if you make it work

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f6c6d433-0498-4f18-8944-c6aac24f468f" />

<img width="1118" height="630" alt="image" src="https://github.com/user-attachments/assets/f9425294-7e7b-4381-81b0-4b276f0c2513" />

https://cdn.discordapp.com/attachments/668819422919524352/1372243853498912838/StarterTeleport.mp4?ex=69909dad&is=698f4c2d&hm=8c11d69a11df110f9b3908b3b457e5cc0be234db4fb127d79a9b5bdbae6d89ff&