### PR TITLE
Change VoipClient to be informed of the message being radio or local by VoipServer instead of by re-running the checks ran server-side..

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipClient.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipClient.cs
@@ -118,16 +118,22 @@ namespace Barotrauma.Networking
                     float rangeMultiplier = spectating ? 2.0f : 1.0f;
                     WifiComponent senderRadio = null;
 
-                    //Checks if the radio noise filter should be applied. CanUseRadio is there because the code after uses senderRadio.
-                    var messageType = ChatMessage.CanUseRadio(client.Character, out senderRadio) && isRadio ? ChatMessageType.Radio : ChatMessageType.Default;
+                    //Checks if the radio noise filter should be applied.
+                    var messageType = isRadio ? ChatMessageType.Radio : ChatMessageType.Default;
+                    
                     client.Character.ShowTextlessSpeechBubble(1.25f, ChatMessage.MessageColor[(int)messageType]);
 
                     client.VoipSound.UseRadioFilter = messageType == ChatMessageType.Radio && !GameSettings.CurrentConfig.Audio.DisableVoiceChatFilters;
                     client.RadioNoise = 0.0f;
                     if (messageType == ChatMessageType.Radio)
                     {
+                        //If the client cannot establish a radio, use a headsets default range as a fallback to calculate the radio noise.
+                        //This cannot happen in an un-modded setting as CanUseRadio is part of the server side check for isRadio to be true.
+                        ChatMessage.CanUseRadio(client.Character, out senderRadio);
+                        float senderRadioRange = (senderRadio == null) ? 35000.0f : senderRadio.Range;
+                    
                         client.VoipSound.UsingRadio = true;
-                        client.VoipSound.SetRange(senderRadio.Range * RangeNear * speechImpedimentMultiplier * rangeMultiplier, senderRadio.Range * speechImpedimentMultiplier * rangeMultiplier);
+                        client.VoipSound.SetRange(senderRadioRange * RangeNear * speechImpedimentMultiplier * rangeMultiplier, senderRadioRange * speechImpedimentMultiplier * rangeMultiplier);
                         if (distanceFactor > RangeNear && !spectating)
                         {
                             //noise starts increasing exponentially after 40% range

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipClient.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipClient.cs
@@ -89,6 +89,7 @@ namespace Barotrauma.Networking
         {
             byte queueId = msg.ReadByte();
             float distanceFactor = msg.ReadRangedSingle(0.0f, 1.0f, 8);
+            bool isRadio = msg.ReadBoolean();
             VoipQueue queue = queues.Find(q => q.QueueID == queueId);
 
             if (queue == null)
@@ -117,11 +118,7 @@ namespace Barotrauma.Networking
                     float rangeMultiplier = spectating ? 2.0f : 1.0f;
                     WifiComponent senderRadio = null;
 
-                    var messageType = 
-                        !client.VoipQueue.ForceLocal && 
-                        ChatMessage.CanUseRadio(client.Character, out senderRadio) && 
-                        (spectating || (ChatMessage.CanUseRadio(Character.Controlled, out var recipientRadio) && senderRadio.CanReceive(recipientRadio)))
-                            ? ChatMessageType.Radio : ChatMessageType.Default;
+                    var messageType = isRadio ? ChatMessageType.Radio : ChatMessageType.Default;
                     client.Character.ShowTextlessSpeechBubble(1.25f, ChatMessage.MessageColor[(int)messageType]);
 
                     client.VoipSound.UseRadioFilter = messageType == ChatMessageType.Radio && !GameSettings.CurrentConfig.Audio.DisableVoiceChatFilters;

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipClient.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Voip/VoipClient.cs
@@ -118,7 +118,8 @@ namespace Barotrauma.Networking
                     float rangeMultiplier = spectating ? 2.0f : 1.0f;
                     WifiComponent senderRadio = null;
 
-                    var messageType = isRadio ? ChatMessageType.Radio : ChatMessageType.Default;
+                    //Checks if the radio noise filter should be applied. CanUseRadio is there because the code after uses senderRadio.
+                    var messageType = ChatMessage.CanUseRadio(client.Character, out senderRadio) && isRadio ? ChatMessageType.Radio : ChatMessageType.Default;
                     client.Character.ShowTextlessSpeechBubble(1.25f, ChatMessage.MessageColor[(int)messageType]);
 
                     client.VoipSound.UseRadioFilter = messageType == ChatMessageType.Radio && !GameSettings.CurrentConfig.Audio.DisableVoiceChatFilters;

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/Voip/VoipServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/Voip/VoipServer.cs
@@ -93,7 +93,7 @@ namespace Barotrauma.Networking
             //sender can't speak
             if (sender.Character != null && sender.Character.SpeechImpediment >= 100.0f) { return false; }
 
-            //check if the message can be sent via radio
+            //check if the message can be sent via radio, and if so, sets isRadio to true so the client knows to apply the appropriate audio effects.
             WifiComponent recipientRadio = null;
             if (!sender.VoipQueue.ForceLocal &&
                 ChatMessage.CanUseRadio(sender.Character, out WifiComponent senderRadio) &&

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/Voip/VoipServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/Voip/VoipServer.cs
@@ -51,13 +51,14 @@ namespace Barotrauma.Networking
                 {
                     if (recipient == sender) { continue; }
 
-                    if (!CanReceive(sender, recipient, out float distanceFactor)) { continue; }
+                    if (!CanReceive(sender, recipient, out float distanceFactor, out bool isRadio)) { continue; }
 
                     IWriteMessage msg = new WriteOnlyMessage();
 
                     msg.WriteByte((byte)ServerPacketHeader.VOICE);
                     msg.WriteByte((byte)queue.QueueID);
                     msg.WriteRangedSingle(distanceFactor, 0.0f, 1.0f, 8);
+                    msg.WriteBoolean(isRadio);
                     queue.Write(msg);
                     
                     netServer.Send(msg, recipient.Connection, DeliveryMethod.Unreliable);
@@ -65,15 +66,17 @@ namespace Barotrauma.Networking
             }
         }
 
-        private static bool CanReceive(Client sender, Client recipient, out float distanceFactor)
+        private static bool CanReceive(Client sender, Client recipient, out float distanceFactor, out bool isRadio)
         {
             if (Screen.Selected != GameMain.GameScreen) 
             {
                 distanceFactor = 0.0f;
+                isRadio = false;
                 return true; 
             }
 
             distanceFactor = 0.0f;
+            isRadio = false;
 
             //no-one can hear muted players
             if (sender.Muted) { return false; }
@@ -98,13 +101,15 @@ namespace Barotrauma.Networking
             {
                 if (recipientSpectating)
                 {
-                    if (recipient.SpectatePos == null) { return true; }
+                    if (recipient.SpectatePos == null) { isRadio = true; return true; }
                     distanceFactor = MathHelper.Clamp(Vector2.Distance(sender.Character.WorldPosition, recipient.SpectatePos.Value) / senderRadio.Range, 0.0f, 1.0f);
+                    isRadio = true;
                     return distanceFactor < 1.0f;
                 }
                 else if (recipientRadio != null && recipientRadio.CanReceive(senderRadio))
                 {
                     distanceFactor = MathHelper.Clamp(Vector2.Distance(sender.Character.WorldPosition, recipient.Character.WorldPosition) / senderRadio.Range, 0.0f, 1.0f);
+                    isRadio = true;
                     return true;
                 }
             }


### PR DESCRIPTION
Change VoipClient to be informed of the message being radio or local by VoipServer instead of by re-running the checks ran server-side.
 
Reasoning why is explained in #16969 (Moved to #16978).

Unlike #16970, which simply removes the check, this PR takes advantage of the fact that that exact check is already ran server-side, and simply includes the result of that check in the packet sent to the client as a boolean value.

NOTE: This WILL require testing with another person (which I am unable to alone), though I see no reason why it would not function.