### PR TITLE
Fix negative-amount wallet transfer exploit

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/GameSession/GameModes/MultiPlayerCampaign.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/GameSession/GameModes/MultiPlayerCampaign.cs
@@ -1179,6 +1179,7 @@ namespace Barotrauma
             NetWalletTransfer transfer = INetSerializableStruct.Read<NetWalletTransfer>(msg);
 
             if (GameMain.Server is null) { return; }
+            if (transfer.Amount <= 0) { return; }
 
             if (transfer.Sender.TryUnwrap(out var id))
             {


### PR DESCRIPTION
Wallet transfers accept an Amount field sent by client with no lower bound check. Sending a NetWalletTransfer packet with a negative value causes TryDeduct to behave incorrectly: the balance check passes (any non-negative balance satisfies Balance >= negative), and the subsequent subtraction inverts sign - effectively adding money to the sender's wallet and draining the target or adding money if target wallet does not have enough. The exploit is trivially reproducible by crafting a single TRANSFER_MONEY packet and currently is being used in the wild on public servers by malicious actors to ruin campaigns alongside with crash exploits and mass buying items using it.

The fix adds a one-line guard in ServerReadMoney that rejects any transfer with Amount <= 0 before any wallet logic runs. No changes to the shared network struct or wire format are needed - the existing UI already prevents sending non-positive values, so this only blocks crafted packets.